### PR TITLE
Use uuid.NewRandom() to maintain uniformity in uuid generation

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gluster/glusterd2/errors"
+	"github.com/pborman/uuid"
 )
 
 const testXattr = "trusted.glusterfs.test"
@@ -195,7 +196,7 @@ func ValidateBrickPathStats(brickPath string, host string, force bool) error {
 //ValidateXattrSupport checks whether the underlying file system has extended
 //attribute support and it also sets some internal xattrs to mark the brick in
 //use
-func ValidateXattrSupport(brickPath string, host string, uuid string, force bool) error {
+func ValidateXattrSupport(brickPath string, host string, uuid uuid.UUID, force bool) error {
 	var err error
 	err = unix.Setxattr(brickPath, "trusted.glusterfs.test", []byte("working"), 0)
 	if err != nil {

--- a/volume/struct.go
+++ b/volume/struct.go
@@ -50,7 +50,7 @@ const (
 
 // Volinfo repesents a volume
 type Volinfo struct {
-	ID   string
+	ID   uuid.UUID
 	Name string
 	Type VolType
 
@@ -88,7 +88,7 @@ type VolCreateRequest struct {
 type Brickinfo struct {
 	Hostname string
 	Path     string
-	ID       string
+	ID       uuid.UUID
 }
 
 // NewVolinfo returns an empty Volinfo
@@ -103,7 +103,7 @@ func NewVolinfo() *Volinfo {
 func NewVolumeEntry(req *VolCreateRequest) *Volinfo {
 	v := NewVolinfo()
 
-	v.ID = uuid.NewUUID().String()
+	v.ID = uuid.NewRandom()
 	v.Name = req.Name
 	if len(req.Transport) > 0 {
 		v.Transport = req.Transport
@@ -129,7 +129,7 @@ func NewVolumeEntry(req *VolCreateRequest) *Volinfo {
 
 // newBrickEntries returns list of initialized Brickinfo objects using list of
 // bricks
-func newBrickEntries(bricks []string, volId string, force bool) []Brickinfo {
+func newBrickEntries(bricks []string, volId uuid.UUID, force bool) []Brickinfo {
 	var b []Brickinfo
 	var b1 Brickinfo
 	for _, brick := range bricks {

--- a/volume/utils_misc.go
+++ b/volume/utils_misc.go
@@ -13,7 +13,7 @@ var volCount uint64
 func getRandVolume() *Volinfo {
 	v := NewVolinfo()
 
-	v.ID = uuid.NewUUID().String()
+	v.ID = uuid.NewRandom()
 	v.Name = fmt.Sprintf("volume-%d", atomic.AddUint64(&volCount, 1))
 	v.Type = DistReplicate
 	brickCount := uint64(rand.Intn(256) + 1)


### PR DESCRIPTION
This also makes the type of ID field of volume object from string to uuid.

Closes #32

Signed-off-by: Atin Mukherjee <amukherj@redhat.com>