### PR TITLE
Get volume request should show only list of volume name and respectiv…

### DIFF
--- a/commands/volumes/volume-list.go
+++ b/commands/volumes/volume-list.go
@@ -13,7 +13,7 @@ func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Info("In Volume list API")
 
-	volumes, e := volume.GetVolumes()
+	volumes, e := volume.GetVolumesList()
 
 	if e != nil {
 		rest.SendHTTPError(w, http.StatusNotFound, e.Error())


### PR DESCRIPTION
…e uuid

Currently, when you make a volume Get request then it will display list
of whole volume info (volinfo) object.

With this patch it will  show list of volume name and associated volume uuid
when user make get volume request.

Issue #44

Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>