### PR TITLE
migrate to etcd client api

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,47 +1,68 @@
 parent: null
 package: github.com/gluster/glusterd2
 import:
+- package: github.com/coreos/etcd
+- package: github.com/shurcooL/sanitized_anchor_name
+  version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:
   - go
-- package: github.com/hashicorp/consul
-  version: v0.5.2
-- package: github.com/cheggaaa/pb
-  version: da1f27ad1d9509b16f65f52fd9d8138b0f2dc7b2
 - package: github.com/codegangsta/cli
   version: f7ebb761e83e21225d1d8954fde853bf8edd46c4
-- package: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
-  subpackages:
-  - expfmt
-  - model
-- package: github.com/coreos/pkg
-  version: 2c77715c4df99b5420ffcae14ead08f52104065d
-  subpackages:
-  - capnslog
 - package: github.com/golang/protobuf
   version: 5677a0e3d5e89854c9974e1256839ee23f8233ca
   subpackages:
   - proto
+- package: github.com/russross/blackfriday
+  version: 300106c228d52c8941d4b3de6054a6062a86dda3
+- package: github.com/bgentry/speakeasy
+  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
+- package: golang.org/x/net
+  version: b4e17d61b15679caf2335da776c614169a1b4643
 - package: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- package: github.com/spf13/pflag
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+- package: github.com/pborman/uuid
+  version: cccd189d45f7ac3368a0d127efb7f4d08ae0b655
+- package: github.com/gogo/protobuf
+  version: 64f27bf06efee53589314a6e5a4af34cdd85adf6
+  subpackages:
+  - proto
 - package: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
 - package: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-- package: github.com/russross/blackfriday
-  version: 300106c228d52c8941d4b3de6054a6062a86dda3
-- package: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+- package: gopkg.in/tylerb/graceful.v1
+  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
+- package: github.com/prometheus/client_golang
+  version: e51041b3fa41cece0dca035740ba6411905be473
   subpackages:
-  - pbutil
-- package: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
-- package: github.com/xiang90/probing
-  version: 6a0cc1ae81b4cc11db5e491e030e4b98fba79c19
+  - prometheus
+- package: github.com/coreos/go-systemd
+  version: cea488b4e6855fee89b6c22a811e3c5baca861b6
+  subpackages:
+  - daemon
+  - journal
+  - util
+- package: github.com/cpuguy83/go-md2man
+  version: 71acacd42f85e5e82f70a55327789582a5200a90
+  subpackages:
+  - md2man
+- package: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- package: github.com/hashicorp/consul
+  version: v0.5.2
+- package: github.com/cheggaaa/pb
+  version: da1f27ad1d9509b16f65f52fd9d8138b0f2dc7b2
+- package: github.com/prometheus/common
+  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  subpackages:
+  - expfmt
+  - model
 - package: github.com/coreos/go-semver
   version: 568e959cd89871e61434c1143528d9162da89ef2
   subpackages:
@@ -51,83 +72,62 @@ import:
   subpackages:
   - bcrypt
   - blowfish
-- package: gopkg.in/tylerb/graceful.v1
-  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
+- package: github.com/codegangsta/negroni
+  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
+- package: github.com/coreos/pkg
+  version: 2c77715c4df99b5420ffcae14ead08f52104065d
+  subpackages:
+  - capnslog
 - package: google.golang.org/grpc
   version: f5ebd86be717593ab029545492c93ddf8914832b
-- package: golang.org/x/oauth2
-  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
+- package: github.com/google/btree
+  version: cc6329d4279e3f025a53a83c397d2339b5705c45
+- package: github.com/spf13/cobra
+  version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
+- package: github.com/spacejam/loghisto
+  version: 323309774dec8b7430187e46cd0793974ccca04a
 - package: github.com/Sirupsen/logrus
   version: v0.8.7
-- package: github.com/stretchr/testify
-  version: 9cc77fa25329013ce07362c7742952ff887361f2
-  subpackages:
-  - assert
-- package: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
-  subpackages:
-  - prometheus
-- package: github.com/docker/libkv
-  version: 93099f38de7421e6979983652730a81e2bafd578
-- package: github.com/bgentry/speakeasy
-  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
-- package: github.com/boltdb/bolt
-  version: 0b00effdd7a8270ebd91c24297e51643e370dd52
 - package: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
-- package: github.com/pborman/uuid
-  version: cccd189d45f7ac3368a0d127efb7f4d08ae0b655
 - package: google.golang.org/cloud
   version: f20d6dcccb44ed49de45ae3703312cb46e627db1
   subpackages:
   - compute/metadata
   - internal
-- package: github.com/codegangsta/negroni
-  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
-- package: github.com/google/btree
-  version: cc6329d4279e3f025a53a83c397d2339b5705c45
-- package: golang.org/x/net
-  version: b4e17d61b15679caf2335da776c614169a1b4643
-- package: github.com/meatballhat/negroni-logrus
-  version: dd89490b0057cca7fe3fa3885f82935dfd430c2e
-- package: github.com/coreos/go-systemd
-  version: cea488b4e6855fee89b6c22a811e3c5baca861b6
-  subpackages:
-  - daemon
-  - journal
-  - util
-- package: github.com/gorilla/mux
-  version: ad4d7a5882b961e07e2626045eb995c022ac6664
-- package: github.com/coreos/etcd
-- package: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
-  subpackages:
-  - /unix
-- package: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
-  subpackages:
-  - quantile
-- package: github.com/spf13/cobra
-  version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
-- package: github.com/inconshreveable/mousetrap
-  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- package: github.com/bradfitz/http2
-  version: 3e36af6d3af0e56fa3da71099f864933dea3d9fb
 - package: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - package: github.com/gorilla/context
   version: 1c83b3eabd45b6d76072b66b746c20815fb2872d
-- package: github.com/gogo/protobuf
-  version: 64f27bf06efee53589314a6e5a4af34cdd85adf6
-  subpackages:
-  - proto
-- package: github.com/spacejam/loghisto
-  version: 323309774dec8b7430187e46cd0793974ccca04a
-- package: github.com/shurcooL/sanitized_anchor_name
-  version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - package: github.com/akrennmair/gopcap
   version: 00e11033259acb75598ba416495bb708d864a010
-- package: github.com/cpuguy83/go-md2man
-  version: 71acacd42f85e5e82f70a55327789582a5200a90
+- package: github.com/bradfitz/http2
+  version: 3e36af6d3af0e56fa3da71099f864933dea3d9fb
+- package: github.com/xiang90/probing
+  version: 6a0cc1ae81b4cc11db5e491e030e4b98fba79c19
+- package: golang.org/x/oauth2
+  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
+- package: github.com/docker/libkv
+  version: 93099f38de7421e6979983652730a81e2bafd578
+- package: github.com/meatballhat/negroni-logrus
+  version: dd89490b0057cca7fe3fa3885f82935dfd430c2e
+- package: github.com/gorilla/mux
+  version: ad4d7a5882b961e07e2626045eb995c022ac6664
+- package: github.com/beorn7/perks
+  version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
-  - md2man
+  - quantile
+- package: github.com/matttproud/golang_protobuf_extensions
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  subpackages:
+  - pbutil
+- package: github.com/stretchr/testify
+  version: 9cc77fa25329013ce07362c7742952ff887361f2
+  subpackages:
+  - assert
+- package: github.com/boltdb/bolt
+  version: 0b00effdd7a8270ebd91c24297e51643e370dd52
+- package: golang.org/x/sys
+  version: 9c60d1c508f5134d1ca726b4641db998f2523357
+  subpackages:
+  - /unix

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,26 +1,133 @@
 parent: null
 package: github.com/gluster/glusterd2
 import:
-- package: github.com/gorilla/context
-  version: 1c83b3eabd45b6d76072b66b746c20815fb2872d
-- package: gopkg.in/tylerb/graceful.v1
-  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
-- package: github.com/pborman/uuid
-  version: cccd189d45f7ac3368a0d127efb7f4d08ae0b655
-- package: github.com/gorilla/mux
-  version: ad4d7a5882b961e07e2626045eb995c022ac6664
-- package: golang.org/x/net
-  version: b4e17d61b15679caf2335da776c614169a1b4643
-- package: github.com/docker/libkv
-  version: 93099f38de7421e6979983652730a81e2bafd578
-- package: github.com/codegangsta/negroni
-  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
-- package: golang.org/x/sys
+- package: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:
-  - /unix
-- package: github.com/meatballhat/negroni-logrus
-  version: dd89490b0057cca7fe3fa3885f82935dfd430c2e
-- package: github.com/Sirupsen/logrus
-  version: v0.8.7
+  - go
 - package: github.com/hashicorp/consul
   version: v0.5.2
+- package: github.com/cheggaaa/pb
+  version: da1f27ad1d9509b16f65f52fd9d8138b0f2dc7b2
+- package: github.com/codegangsta/cli
+  version: f7ebb761e83e21225d1d8954fde853bf8edd46c4
+- package: github.com/prometheus/common
+  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  subpackages:
+  - expfmt
+  - model
+- package: github.com/coreos/pkg
+  version: 2c77715c4df99b5420ffcae14ead08f52104065d
+  subpackages:
+  - capnslog
+- package: github.com/golang/protobuf
+  version: 5677a0e3d5e89854c9974e1256839ee23f8233ca
+  subpackages:
+  - proto
+- package: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- package: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
+- package: github.com/prometheus/procfs
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+- package: github.com/russross/blackfriday
+  version: 300106c228d52c8941d4b3de6054a6062a86dda3
+- package: github.com/matttproud/golang_protobuf_extensions
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  subpackages:
+  - pbutil
+- package: github.com/spf13/pflag
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+- package: github.com/xiang90/probing
+  version: 6a0cc1ae81b4cc11db5e491e030e4b98fba79c19
+- package: github.com/coreos/go-semver
+  version: 568e959cd89871e61434c1143528d9162da89ef2
+  subpackages:
+  - semver
+- package: golang.org/x/crypto
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  subpackages:
+  - bcrypt
+  - blowfish
+- package: gopkg.in/tylerb/graceful.v1
+  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
+- package: google.golang.org/grpc
+  version: f5ebd86be717593ab029545492c93ddf8914832b
+- package: golang.org/x/oauth2
+  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
+- package: github.com/Sirupsen/logrus
+  version: v0.8.7
+- package: github.com/stretchr/testify
+  version: 9cc77fa25329013ce07362c7742952ff887361f2
+  subpackages:
+  - assert
+- package: github.com/prometheus/client_golang
+  version: e51041b3fa41cece0dca035740ba6411905be473
+  subpackages:
+  - prometheus
+- package: github.com/docker/libkv
+  version: 93099f38de7421e6979983652730a81e2bafd578
+- package: github.com/bgentry/speakeasy
+  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
+- package: github.com/boltdb/bolt
+  version: 0b00effdd7a8270ebd91c24297e51643e370dd52
+- package: bitbucket.org/ww/goautoneg
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
+- package: github.com/pborman/uuid
+  version: cccd189d45f7ac3368a0d127efb7f4d08ae0b655
+- package: google.golang.org/cloud
+  version: f20d6dcccb44ed49de45ae3703312cb46e627db1
+  subpackages:
+  - compute/metadata
+  - internal
+- package: github.com/codegangsta/negroni
+  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
+- package: github.com/google/btree
+  version: cc6329d4279e3f025a53a83c397d2339b5705c45
+- package: golang.org/x/net
+  version: b4e17d61b15679caf2335da776c614169a1b4643
+- package: github.com/meatballhat/negroni-logrus
+  version: dd89490b0057cca7fe3fa3885f82935dfd430c2e
+- package: github.com/coreos/go-systemd
+  version: cea488b4e6855fee89b6c22a811e3c5baca861b6
+  subpackages:
+  - daemon
+  - journal
+  - util
+- package: github.com/gorilla/mux
+  version: ad4d7a5882b961e07e2626045eb995c022ac6664
+- package: github.com/coreos/etcd
+- package: golang.org/x/sys
+  version: 9c60d1c508f5134d1ca726b4641db998f2523357
+  subpackages:
+  - /unix
+- package: github.com/beorn7/perks
+  version: b965b613227fddccbfffe13eae360ed3fa822f8d
+  subpackages:
+  - quantile
+- package: github.com/spf13/cobra
+  version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
+- package: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- package: github.com/bradfitz/http2
+  version: 3e36af6d3af0e56fa3da71099f864933dea3d9fb
+- package: github.com/jonboulle/clockwork
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+- package: github.com/gorilla/context
+  version: 1c83b3eabd45b6d76072b66b746c20815fb2872d
+- package: github.com/gogo/protobuf
+  version: 64f27bf06efee53589314a6e5a4af34cdd85adf6
+  subpackages:
+  - proto
+- package: github.com/spacejam/loghisto
+  version: 323309774dec8b7430187e46cd0793974ccca04a
+- package: github.com/shurcooL/sanitized_anchor_name
+  version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
+- package: github.com/akrennmair/gopcap
+  version: 00e11033259acb75598ba416495bb708d864a010
+- package: github.com/cpuguy83/go-md2man
+  version: 71acacd42f85e5e82f70a55327789582a5200a90
+  subpackages:
+  - md2man

--- a/peer/store-utils.go
+++ b/peer/store-utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gluster/glusterd2/store"
 
 	log "github.com/Sirupsen/logrus"
-	etcdctx "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 const (
@@ -29,7 +28,7 @@ func AddOrUpdatePeer(p *Peer) error {
 	}
 	idStr := p.ID.String()
 
-	if _, err := context.Store.Set(etcdctx.Background(), peerPrefix+idStr, string(json), nil); err != nil {
+	if _, err := context.Store.Set(store.EtcdCtx, peerPrefix+idStr, string(json), nil); err != nil {
 		return err
 	}
 
@@ -38,7 +37,7 @@ func AddOrUpdatePeer(p *Peer) error {
 
 // GetPeer returns specified peer from the store
 func GetPeer(id string) (*Peer, error) {
-	rsp, err := context.Store.Get(etcdctx.Background(), peerPrefix+id, nil)
+	rsp, err := context.Store.Get(store.EtcdCtx, peerPrefix+id, nil)
 	if err != nil || rsp == nil {
 		return nil, err
 	}
@@ -52,7 +51,7 @@ func GetPeer(id string) (*Peer, error) {
 
 // GetPeers returns all available peers in the store
 func GetPeers() ([]Peer, error) {
-	pairs, err := context.Store.Get(etcdctx.Background(), peerPrefix, nil)
+	pairs, err := context.Store.Get(store.EtcdCtx, peerPrefix, nil)
 	if err != nil || pairs == nil {
 		return nil, err
 	}
@@ -77,13 +76,13 @@ func GetPeers() ([]Peer, error) {
 
 // DeletePeer deletes given peer from the store
 func DeletePeer(id string) error {
-	_, err := context.Store.Delete(etcdctx.Background(), peerPrefix+id, nil)
+	_, err := context.Store.Delete(store.EtcdCtx, peerPrefix+id, nil)
 	return err
 }
 
 // Exists checks if given peer is present in the store
 func Exists(id string) bool {
-	_, e := context.Store.Get(etcdctx.Background(), peerPrefix+id, nil)
+	_, e := context.Store.Get(store.EtcdCtx, peerPrefix+id, nil)
 	if e != nil {
 		return false
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	etcdctx "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -20,11 +20,16 @@ const (
 
 var (
 	prefixes []string
+	EtcdCtx  etcdctx.Context
 )
 
 // GDStore is the GlusterD centralized store
 type GDStore struct {
 	client.KeysAPI
+}
+
+func init() {
+	EtcdCtx = etcdctx.Background()
 }
 
 // New creates a new GDStore
@@ -73,13 +78,13 @@ func (s *GDStore) InitPrefix(p string) error {
 	// Create the prefix if the prefix is not found. If any other error occurs
 	// return it. Don't do anything if prefix is found
 
-	if _, e := s.Get(context.Background(), p, nil); e != nil {
+	if _, e := s.Get(etcdctx.Background(), p, nil); e != nil {
 		switch e.(client.Error).Code {
 		case client.ErrorCodeKeyNotFound:
 			log.WithField("prefix", p).Debug("prefix not found, initing")
 			opts := new(client.SetOptions)
 			opts.Dir = true
-			if _, e := s.Set(context.Background(), p, "", opts); e != nil {
+			if _, e := s.Set(EtcdCtx, p, "", opts); e != nil {
 				log.WithFields(log.Fields{
 					"preifx": p,
 					"error":  e,

--- a/store/store.go
+++ b/store/store.go
@@ -9,9 +9,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/libkv"
-	"github.com/docker/libkv/store"
-	"github.com/docker/libkv/store/consul"
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
 )
 
 const (
@@ -25,26 +24,26 @@ var (
 
 // GDStore is the GlusterD centralized store
 type GDStore struct {
-	store.Store
-}
-
-func init() {
-	consul.Register()
+	client.KeysAPI
 }
 
 // New creates a new GDStore
 func New() *GDStore {
-	//TODO: Make this configurable
-	address := "localhost:8500"
-	consul.Register()
-
-	log.WithFields(log.Fields{"type": "consul", "consul.config": address}).Debug("Creating new store")
-	s, err := libkv.NewStore(store.CONSUL, []string{address}, &store.Config{ConnectionTimeout: 10 * time.Second})
+	cfg := client.Config{
+		//TODO: Make this configurable
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	c, err := client.New(cfg)
 	if err != nil {
+		log.Fatal(err)
 		log.WithField("error", err).Fatal("Failed to create store")
 	}
+	s := client.NewKeysAPI(c)
 
-	log.Info("Created new store using Consul")
+	log.Info("Created new store using etcd")
 
 	gds := &GDStore{s}
 
@@ -70,14 +69,17 @@ func (s *GDStore) initPrefixes() bool {
 // InitPrefix initializes the given prefix `p` in the store so that GETs on empty prefixes don't fail
 // Returns error on failure, nil on success
 func (s *GDStore) InitPrefix(p string) error {
+
 	// Create the prefix if the prefix is not found. If any other error occurs
 	// return it. Don't do anything if prefix is found
-	if _, e := s.Get(p); e != nil {
-		switch e {
-		case store.ErrKeyNotFound:
-			log.WithField("prefix", p).Debug("prefix not found, initing")
 
-			if e := s.Put(p, nil, nil); e != nil {
+	if _, e := s.Get(context.Background(), p, nil); e != nil {
+		switch e.(client.Error).Code {
+		case client.ErrorCodeKeyNotFound:
+			log.WithField("prefix", p).Debug("prefix not found, initing")
+			opts := new(client.SetOptions)
+			opts.Dir = true
+			if _, e := s.Set(context.Background(), p, "", opts); e != nil {
 				log.WithFields(log.Fields{
 					"preifx": p,
 					"error":  e,

--- a/volume/store-utils.go
+++ b/volume/store-utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pborman/uuid"
 
 	log "github.com/Sirupsen/logrus"
-	etcdctx "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 const (
@@ -26,7 +25,7 @@ func AddOrUpdateVolume(v *Volinfo) error {
 		log.WithField("error", e).Error("Failed to marshal the volinfo object")
 		return e
 	}
-	if _, e := context.Store.Set(etcdctx.Background(), volumePrefix+v.Name, string(json), nil); e != nil {
+	if _, e := context.Store.Set(store.EtcdCtx, volumePrefix+v.Name, string(json), nil); e != nil {
 		log.WithField("error", e).Error("Couldn't add volume to store")
 		return e
 	}
@@ -37,7 +36,7 @@ func AddOrUpdateVolume(v *Volinfo) error {
 // volinfo object
 func GetVolume(name string) (*Volinfo, error) {
 	var v Volinfo
-	rsp, e := context.Store.Get(etcdctx.Background(), volumePrefix+name, nil)
+	rsp, e := context.Store.Get(store.EtcdCtx, volumePrefix+name, nil)
 	if e != nil {
 		log.WithField("error", e).Error("Couldn't retrive volume from store")
 		return nil, e
@@ -51,12 +50,12 @@ func GetVolume(name string) (*Volinfo, error) {
 
 //DeleteVolume passes the volname to store to delete the volume object
 func DeleteVolume(name string) error {
-	_, err := context.Store.Delete(etcdctx.Background(), volumePrefix+name, nil)
+	_, err := context.Store.Delete(store.EtcdCtx, volumePrefix+name, nil)
 	return err
 }
 
 func GetVolumesList() (map[string]uuid.UUID, error) {
-	pairs, e := context.Store.Get(etcdctx.Background(), volumePrefix, nil)
+	pairs, e := context.Store.Get(store.EtcdCtx, volumePrefix, nil)
 	if e != nil || pairs == nil {
 		return nil, e
 	}
@@ -83,7 +82,7 @@ func GetVolumesList() (map[string]uuid.UUID, error) {
 //GetVolumes retrives the json objects from the store and converts them into
 //respective volinfo objects
 func GetVolumes() ([]Volinfo, error) {
-	pairs, e := context.Store.Get(etcdctx.Background(), volumePrefix, nil)
+	pairs, e := context.Store.Get(store.EtcdCtx, volumePrefix, nil)
 	if e != nil || pairs == nil {
 		return nil, e
 	}
@@ -109,7 +108,7 @@ func GetVolumes() ([]Volinfo, error) {
 
 //Exists check whether a given volume exist or not
 func Exists(name string) bool {
-	_, e := context.Store.Get(etcdctx.Background(), volumePrefix+name, nil)
+	_, e := context.Store.Get(store.EtcdCtx, volumePrefix+name, nil)
 	if e != nil {
 		return false
 	}


### PR DESCRIPTION
We initially started with using libkv as an interface to the central stores like
consul/etcd. But later on we realized it brings in lot of dependencies and since
we've already choosen to use etcd its better to use etcd client APIs.

Closes #17

Signed-off-by: Atin Mukherjee <amukherj@redhat.com>