### PR TITLE
Install etcd as a package requirement for GlusterD 2.0

### DIFF
--- a/scripts/check-reqs.sh
+++ b/scripts/check-reqs.sh
@@ -2,7 +2,7 @@
 
 # Checks if the tools required for properly building, verifying and testing GlusterD are installed.
 
-TOOLS=(glide gometalinter)
+TOOLS=(glide gometalinter etcd)
 
 MISSING=0
 

--- a/scripts/check-reqs.sh
+++ b/scripts/check-reqs.sh
@@ -9,10 +9,10 @@ MISSING=0
 for tool in ${TOOLS[@]}; do
   type $tool >/dev/null 2>&1
   if [ $? -ne 0 ]; then
-    echo "$tool is missing on the system"
+    echo "$tool package is missing on the system"
     MISSING=1
   else
-    echo "$tool is available"
+    echo "$tool package is available"
   fi
 done
 

--- a/scripts/install-reqs.sh
+++ b/scripts/install-reqs.sh
@@ -45,7 +45,7 @@ install_gometalinter() {
 }
 
 install_etcd() {
-        ETCDVERSION="v2.2.0"
+        ETCDVERSION="v2.2.4"
         ETCDURL="https://github.com/coreos/etcd/releases/download/${ETCDVERSION}/etcd-${ETCDVERSION}-linux-amd64.tar.gz"
         type etcd >/dev/null 2>&1
         if [ $? -eq 0 ]; then

--- a/scripts/install-reqs.sh
+++ b/scripts/install-reqs.sh
@@ -44,5 +44,29 @@ install_gometalinter() {
   gometalinter --install --update || failed_install linters
 }
 
+install_etcd() {
+        ETCDVERSION="v2.2.0"
+        ETCDURL="https://github.com/coreos/etcd/releases/download/${ETCDVERSION}/etcd-${ETCDVERSION}-linux-amd64.tar.gz"
+        type etcd >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+                echo "etcd already installed"
+                return
+        fi
+
+        echo "Installing ETCD version ${ETCDVERSION}"
+        TMPD=$(mktemp -d)
+        pushd $TMPD
+        echo ${TMPD}
+        curl -L $ETCDURL -o etcd-${VERSION}-linux-amd64.tar.gz
+
+        tar xzvf etcd-${VERSION}-linux-amd64.tar.gz
+
+        cp etcd-${ETCDVERSION}-linux-amd64/etcd     $GOPATH/bin
+        cp etcd-${ETCDVERSION}-linux-amd64/etcdctl  $GOPATH/bin
+        popd
+        rm -rf $TMPD
+}
+
 install_glide
 install_gometalinter
+install_etcd


### PR DESCRIPTION
Install etcd while executing install-reqs.sh (all necessary package for
GlusterD 2.0).

Issue #70

Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>