### PR TITLE
Fix test in TestIsETCDStartNeeded

### DIFF
--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -50,7 +50,8 @@ func TestIsETCDStartNeeded(t *testing.T) {
 	var pid int
 	oldPid := cmd.Process.Pid
 	err = cmd.Process.Kill()
-	cmd.Wait()
+	tests.Assert(t, err == nil)
+	_, err = cmd.Process.Wait()
 	tests.Assert(t, err == nil)
 	start, pid = isETCDStartNeeded()
 	tests.Assert(t, oldPid == pid)

--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -50,8 +50,8 @@ func TestIsETCDStartNeeded(t *testing.T) {
 	var pid int
 	oldPid := cmd.Process.Pid
 	err = cmd.Process.Kill()
-	tests.Assert(t, err == nil)
 	cmd.Wait()
+	tests.Assert(t, err == nil)
 	start, pid = isETCDStartNeeded()
 	tests.Assert(t, oldPid == pid)
 	tests.Assert(t, start == true)

--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -78,15 +78,11 @@ func TestIsETCDStartNeeded(t *testing.T) {
 	tests.Assert(t, start == false)
 
 	//check once etcd process is killed isETCDStartNeeded returns true
-	var pid int
-	oldPid := cmd.Process.Pid
-	tests.Assert(t, oldPid != 0)
 	err = cmd.Process.Kill()
 	tests.Assert(t, err == nil)
 	_, err = cmd.Process.Wait()
 	tests.Assert(t, err == nil)
-	start, pid = isETCDStartNeeded()
-	tests.Assert(t, oldPid == pid)
+	start, _ = isETCDStartNeeded()
 	tests.Assert(t, start == true)
 
 	// check if the pid file is missing then isETCDStartNeeded returns true

--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/gluster/glusterd2/tests"
 
@@ -16,7 +15,6 @@ func formETCDCommand() *exec.Cmd {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatal("Could not able to get hostname")
-		return nil
 	}
 
 	listenClientUrls := "http://" + hostname + ":2379"
@@ -47,8 +45,10 @@ func TestStartETCDWithInvalidExecName(t *testing.T) {
 func TestStartETCD(t *testing.T) {
 	etcdCtx, err := StartETCD()
 	tests.Assert(t, err == nil)
-	etcdCtx.Kill()
-	etcdCtx.Wait()
+	err = etcdCtx.Kill()
+	tests.Assert(t, err == nil)
+	_, err = etcdCtx.Wait()
+	tests.Assert(t, err == nil)
 }
 
 func TestWriteETCDPidFile(t *testing.T) {
@@ -73,7 +73,12 @@ func TestIsETCDStartNeeded(t *testing.T) {
 	tests.Assert(t, err == nil)
 	err = writeETCDPidFile(cmd.Process.Pid)
 	tests.Assert(t, err == nil)
-	time.Sleep(15 * time.Second)
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatal("Could not able to get hostname")
+	}
+	listenClientUrls := "http://" + hostname + ":2379"
+	tests.Assert(t, checkHealth(15, listenClientUrls) == true)
 	start, _ := isETCDStartNeeded()
 	tests.Assert(t, start == false)
 

--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -80,7 +80,7 @@ func TestIsETCDStartNeeded(t *testing.T) {
 		log.Fatal("Could not able to get hostname")
 	}
 	listenClientUrls := "http://" + hostname + ":2379"
-	tests.Assert(t, checkHealth(15, listenClientUrls) == true)
+	tests.Assert(t, checkETCDHealth(15, listenClientUrls) == true)
 	start, _ := isETCDStartNeeded()
 	tests.Assert(t, start == false)
 

--- a/etcdmgmt/etcd-mgmt_test.go
+++ b/etcdmgmt/etcd-mgmt_test.go
@@ -46,16 +46,15 @@ func TestIsETCDStartNeeded(t *testing.T) {
 	start, _ := isETCDStartNeeded()
 	tests.Assert(t, start == false)
 
-	// check once etcd process is killed isETCDStartNeeded returns true
-	//TODO : the last test fails here, need to investigate why, commenting
-	//out the whole section for now
-	/*var pid int
+	//check once etcd process is killed isETCDStartNeeded returns true
+	var pid int
 	oldPid := cmd.Process.Pid
 	err = cmd.Process.Kill()
 	tests.Assert(t, err == nil)
+	cmd.Wait()
 	start, pid = isETCDStartNeeded()
 	tests.Assert(t, oldPid == pid)
-	tests.Assert(t, start == true)*/
+	tests.Assert(t, start == true)
 
 	// check if the pid file is missing then isETCDStartNeeded returns true
 	os.Remove(etcdPidFile)


### PR DESCRIPTION
Kill() call should followed by Wait() before restarting any process

Closes #80

Signed-off-by: Atin Mukherjee <amukherj@redhat.com>