### PR TITLE
Remove execute bit for file that stores UUID

### DIFF
--- a/context/myuuid.go
+++ b/context/myuuid.go
@@ -50,7 +50,7 @@ func genMyUUID() uuid.UUID {
 }
 
 func writeMyUUIDFile(u uuid.UUID) {
-	if err := ioutil.WriteFile(myUUIDFile, []byte(u.String()), os.ModePerm); err != nil {
+	if err := ioutil.WriteFile(myUUIDFile, []byte(u.String()), 0644); err != nil {
 		log.WithFields(log.Fields{
 			"err":  err,
 			"path": myUUIDFile,


### PR DESCRIPTION
The value of os.ModePerm which is passed as argument to method
ioutil.WriteFile() is 0777 by default.

Signed-off-by: Prashanth Pai <ppai@redhat.com>