### PR TITLE
Minor fixups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,19 @@ import (
 var (
 	LogLevel    = flag.String("loglevel", "debug", "Log messages upto this level")
 	RestAddress = flag.String("restaddress", ":24007", "Address to bind REST endpoint to")
+	RpcAddress  = flag.String("rpcaddress", ":9876", "Address to bind for RPC")
+
+	// Example to start glusterd2 with REST server listening on port 8080:
+	// glusterd2 --restaddress=:8080
+	// TODO: Parse and remove ':' appropriately
+
+	/*
+		A non-root user can start glusterd2 by setting appropriate
+		permissions to the following paths:
+		ETCDConfDir: /var/lib/glusterd
+		etcdPidDir: /var/run/gluster
+		etcdLogDir: /var/log/glusterfs
+	*/
 
 	LocalStateDir string
 )

--- a/etcdmgmt/etcd-mgmt.go
+++ b/etcdmgmt/etcd-mgmt.go
@@ -103,7 +103,6 @@ func StartETCD(args []string) (*os.Process, error) {
 	etcdCmd.Stdout = outFile
 	etcdCmd.Stderr = outFile
 
-	// TODO: use unix.Setpgid instead of using syscall
 	// Don't kill chlid process (etcd) upon ^C (SIGINT) of main glusterd process
 	etcdCmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	log.Info("GlusterD starting")
+	log.WithField("pid", os.Getpid()).Info("GlusterD starting")
 
 	utils.InitDir(config.LocalStateDir)
 	context.MyUUID = context.InitMyUUID()
@@ -40,11 +40,10 @@ func main() {
 		peer.AddSelfDetails()
 	}
 
+	// Start listening for incoming RPC requests
 	err = server.StartListener()
 	if err != nil {
-		log.Fatal("Could not register the listener. Aborting")
-	} else {
-		log.Debug("Registered RPC listener")
+		log.Fatal("Could not register RPC listener. Aborting")
 	}
 
 	sigCh := make(chan os.Signal)
@@ -65,6 +64,7 @@ func main() {
 		}
 	}()
 
+	// Start GlusterD REST server
 	err = context.Rest.Listen()
 	if err != nil {
 		log.Fatal("Could not start GlusterD Rest Server. Aborting.")

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -42,7 +42,7 @@ func New() *GDRest {
 
 // Listen begins the GlusterD Rest server
 func (r *GDRest) Listen() error {
-	log.Debug("Beginning the GlusterD Rest server")
+	log.WithField("port", *config.RestAddress).Info("Starting GlusterD REST server")
 	err := r.srv.ListenAndServe()
 	if err != nil {
 		log.WithField("error", err).Error("Failed to start the Rest Server")

--- a/rpc/client/peer-rpc-clnt.go
+++ b/rpc/client/peer-rpc-clnt.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/rpc"
 
+	"github.com/gluster/glusterd2/config"
 	"github.com/gluster/glusterd2/peer"
 	"github.com/gluster/glusterd2/rpc/services"
 
@@ -24,8 +25,7 @@ func ValidateAddPeer(p *peer.PeerAddRequest) (*services.RPCPeerAddResp, error) {
 	*args.Name = p.Name
 
 	rsp := new(services.RPCPeerAddResp)
-	//TODO : port 9876 is hardcoded for now, can be made configurable
-	remoteAddress := fmt.Sprintf("%s:%s", p.Name, "9876")
+	remoteAddress := fmt.Sprintf("%s:%s", p.Name, *config.RpcAddress)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")
@@ -57,8 +57,7 @@ func ValidateDeletePeer(id string, name string) (*services.RPCPeerGenericResp, e
 	*args.ID = id
 
 	rsp := new(services.RPCPeerGenericResp)
-	//TODO : port 9876 is hardcoded for now, can be made configurable
-	remoteAddress := fmt.Sprintf("%s:%s", name, "9876")
+	remoteAddress := fmt.Sprintf("%s:%s", name, *config.RpcAddress)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")
@@ -95,7 +94,7 @@ func ConfigureRemoteETCD(p *peer.ETCDConfig) (*services.RPCPeerGenericResp, erro
 
 	rsp := new(services.RPCPeerGenericResp)
 
-	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, "9876")
+	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, *config.RpcAddress)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")

--- a/rpc/server/listener.go
+++ b/rpc/server/listener.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/rpc"
 
+	"github.com/gluster/glusterd2/config"
 	"github.com/gluster/glusterd2/rpc/services"
 
 	log "github.com/Sirupsen/logrus"
@@ -14,13 +15,12 @@ import (
 func StartListener() error {
 	server := rpc.NewServer()
 	services.RegisterServices(server)
-	//TODO : port 9876 is hardcoded now, can be made configurable
-	l, e := net.Listen("tcp", ":9876")
+	l, e := net.Listen("tcp", *config.RpcAddress)
 	if e != nil {
-		log.WithField("error", e).Fatal("listener error")
+		log.WithField("error", e).Error("net.Listen() error")
 		return e
 	} else {
-		log.Debug("listening on port 9876")
+		log.WithField("port", *config.RpcAddress).Info("Registered RPC Listener")
 	}
 
 	go func() {

--- a/volgen/core.go
+++ b/volgen/core.go
@@ -67,7 +67,6 @@ func getServerFilePath(vinfo *volume.Volinfo, path *string, brickinfo volume.Bri
 	var vdir string
 	getVolumeDir(vinfo, &vdir)
 
-	//TODO : take the hostname from brickinfo
 	hname := brickinfo.Hostname
 	// Create volume directory (/var/lib/glusterd/vols/<VOLNAME>)
 	err := os.MkdirAll(vdir, os.ModeDir|os.ModePerm)


### PR DESCRIPTION
* Remove hard-coded RPC port 9876
* Log pid of glusterd2 process on start
* Log ports that glusterd2 listens on

Remove a TODO about using unix.Setpgid because:
A process can set PGID of only itself and its children. And it can't
change the PGID of its children after that child has called one of the
functions of exec family. execve() is invoked internally in Cmd.Start()

Signed-off-by: Prashanth Pai <ppai@redhat.com>