### PR TITLE
Allow binding to specific network interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,13 +12,21 @@ import (
 // Any configuration that doesn't require custom default values can have their flags initialised right here.
 // Any configuration that require custom default values should be initalized manually.
 var (
-	LogLevel    = flag.String("loglevel", "debug", "Log messages upto this level")
-	RestAddress = flag.String("restaddress", ":24007", "Address to bind REST endpoint to")
-	RpcAddress  = flag.String("rpcaddress", ":9876", "Address to bind for RPC")
+	LogLevel = flag.String("loglevel", "debug", "Log messages upto this level")
 
-	// Example to start glusterd2 with REST server listening on port 8080:
-	// glusterd2 --restaddress=:8080
-	// TODO: Parse and remove ':' appropriately
+	// A machine can have multiple network interfaces, each with it's own
+	// IP address. If -rest-ip is not specified, the REST service listens
+	// on all available interfaces. If -rest-ip is specified, the REST
+	// service binds only to that specific interface.
+	RestIp   = flag.String("rest-ip", "", "IP address of interface to bind REST endpoint to")
+	RestPort = flag.String("rest-port", "24007", "Port to bind REST endpoint to")
+
+	RpcIp   = flag.String("rpc-ip", "", "IP address of interface to bind RPC service to")
+	RpcPort = flag.String("rpc-port", "9876", "Port to bind for RPC service to")
+
+	// Example to start glusterd2 with REST server listening on port 8080
+	// and on local ip.
+	// glusterd2 -rest-port=8080 -rest-ip=127.0.0.1
 
 	/*
 		A non-root user can start glusterd2 by setting appropriate

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"flag"
+	"strings"
 )
 
 // All configuration values which should be available for use by other packages need to be defined here as global variables.
@@ -15,18 +16,16 @@ var (
 	LogLevel = flag.String("loglevel", "debug", "Log messages upto this level")
 
 	// A machine can have multiple network interfaces, each with it's own
-	// IP address. If -rest-ip is not specified, the REST service listens
-	// on all available interfaces. If -rest-ip is specified, the REST
-	// service binds only to that specific interface.
-	RestIp   = flag.String("rest-ip", "", "IP address of interface to bind REST endpoint to")
-	RestPort = flag.String("rest-port", "24007", "Port to bind REST endpoint to")
-
-	RpcIp   = flag.String("rpc-ip", "", "IP address of interface to bind RPC service to")
-	RpcPort = flag.String("rpc-port", "9876", "Port to bind for RPC service to")
+	// IP address. If IP is not specified, the REST service listens on all
+	// available interfaces. If IP is specified, the REST service binds
+	// only to that specific interface.
+	RestAddress = flag.String("rest-address", ":24007", "IP address of interface and port to bind REST endpoint to")
+	RpcAddress  = flag.String("rpc-address", ":9876", "IP address of interface and port to bind RPC service to")
+	RpcPort     = strings.Split(*RpcAddress, ":")[1]
 
 	// Example to start glusterd2 with REST server listening on port 8080
-	// and on local ip.
-	// glusterd2 -rest-port=8080 -rest-ip=127.0.0.1
+	// and only on local ip.
+	// glusterd2 -rest-address=127.0.0.1:8080
 
 	/*
 		A non-root user can start glusterd2 by setting appropriate

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -32,7 +32,7 @@ func New() *GDRest {
 	rest.srv = &graceful.Server{
 		Timeout: 10 * time.Second,
 		Server: &http.Server{
-			Addr:    *config.RestIp + ":" + *config.RestPort,
+			Addr:    *config.RestAddress,
 			Handler: n,
 		},
 	}
@@ -43,8 +43,7 @@ func New() *GDRest {
 // Listen begins the GlusterD Rest server
 func (r *GDRest) Listen() error {
 	log.WithFields(log.Fields{
-		"ip":   *config.RestIp,
-		"port": *config.RestPort,
+		"ip:port": *config.RestAddress,
 	}).Info("Starting GlusterD REST server")
 	err := r.srv.ListenAndServe()
 	if err != nil {

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -32,7 +32,7 @@ func New() *GDRest {
 	rest.srv = &graceful.Server{
 		Timeout: 10 * time.Second,
 		Server: &http.Server{
-			Addr:    *config.RestAddress,
+			Addr:    *config.RestIp + ":" + *config.RestPort,
 			Handler: n,
 		},
 	}
@@ -42,7 +42,10 @@ func New() *GDRest {
 
 // Listen begins the GlusterD Rest server
 func (r *GDRest) Listen() error {
-	log.WithField("port", *config.RestAddress).Info("Starting GlusterD REST server")
+	log.WithFields(log.Fields{
+		"ip":   *config.RestIp,
+		"port": *config.RestPort,
+	}).Info("Starting GlusterD REST server")
 	err := r.srv.ListenAndServe()
 	if err != nil {
 		log.WithField("error", err).Error("Failed to start the Rest Server")

--- a/rpc/client/peer-rpc-clnt.go
+++ b/rpc/client/peer-rpc-clnt.go
@@ -25,7 +25,7 @@ func ValidateAddPeer(p *peer.PeerAddRequest) (*services.RPCPeerAddResp, error) {
 	*args.Name = p.Name
 
 	rsp := new(services.RPCPeerAddResp)
-	remoteAddress := fmt.Sprintf("%s:%s", p.Name, *config.RpcPort)
+	remoteAddress := fmt.Sprintf("%s:%s", p.Name, config.RpcPort)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")
@@ -94,7 +94,7 @@ func ConfigureRemoteETCD(p *peer.ETCDConfig) (*services.RPCPeerGenericResp, erro
 
 	rsp := new(services.RPCPeerGenericResp)
 
-	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, *config.RpcPort)
+	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, config.RpcPort)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")

--- a/rpc/client/peer-rpc-clnt.go
+++ b/rpc/client/peer-rpc-clnt.go
@@ -25,7 +25,7 @@ func ValidateAddPeer(p *peer.PeerAddRequest) (*services.RPCPeerAddResp, error) {
 	*args.Name = p.Name
 
 	rsp := new(services.RPCPeerAddResp)
-	remoteAddress := fmt.Sprintf("%s:%s", p.Name, *config.RpcAddress)
+	remoteAddress := fmt.Sprintf("%s:%s", p.Name, *config.RpcPort)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")
@@ -57,7 +57,7 @@ func ValidateDeletePeer(id string, name string) (*services.RPCPeerGenericResp, e
 	*args.ID = id
 
 	rsp := new(services.RPCPeerGenericResp)
-	remoteAddress := fmt.Sprintf("%s:%s", name, *config.RpcAddress)
+	remoteAddress := fmt.Sprintf("%s:%s", name, config.RpcPort)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")
@@ -94,7 +94,7 @@ func ConfigureRemoteETCD(p *peer.ETCDConfig) (*services.RPCPeerGenericResp, erro
 
 	rsp := new(services.RPCPeerGenericResp)
 
-	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, *config.RpcAddress)
+	remoteAddress := fmt.Sprintf("%s:%s", p.PeerName, *config.RpcPort)
 	rpcConn, e := net.Dial("tcp", remoteAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Dial() call failed")

--- a/rpc/server/listener.go
+++ b/rpc/server/listener.go
@@ -15,14 +15,13 @@ import (
 func StartListener() error {
 	server := rpc.NewServer()
 	services.RegisterServices(server)
-	l, e := net.Listen("tcp", *config.RpcIp+":"+*config.RpcPort)
+	l, e := net.Listen("tcp", *config.RpcAddress)
 	if e != nil {
 		log.WithField("error", e).Error("net.Listen() error")
 		return e
 	} else {
 		log.WithFields(log.Fields{
-			"ip":   *config.RpcIp,
-			"port": *config.RpcPort,
+			"ip:port": *config.RpcAddress,
 		}).Info("Registered RPC Listener")
 	}
 

--- a/rpc/server/listener.go
+++ b/rpc/server/listener.go
@@ -15,12 +15,15 @@ import (
 func StartListener() error {
 	server := rpc.NewServer()
 	services.RegisterServices(server)
-	l, e := net.Listen("tcp", *config.RpcAddress)
+	l, e := net.Listen("tcp", *config.RpcIp+":"+*config.RpcPort)
 	if e != nil {
 		log.WithField("error", e).Error("net.Listen() error")
 		return e
 	} else {
-		log.WithField("port", *config.RpcAddress).Info("Registered RPC Listener")
+		log.WithFields(log.Fields{
+			"ip":   *config.RpcIp,
+			"port": *config.RpcPort,
+		}).Info("Registered RPC Listener")
 	}
 
 	go func() {


### PR DESCRIPTION
Currently, both the RPC and REST services bind to their respective
ports on all network interfaces. This may not always be desirable.
For example, when a machine is part of multiple networks, the
admin may want to make the REST service available only on one
network interface for external consumption.

This change adds command line options to specify both IP and port
these services should bind to. The default behaviour is not changed
i.e bind on all available interfaces.

Signed-off-by: Prashanth Pai <ppai@redhat.com>