### PR TITLE
makefile: Reduce gometalinter parallel jobs to 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ vendor-update:
 	@echo
 
 verify: check-reqs
-	@GO15VENDOREXPERIMENT=1 gometalinter -D gotype -E gofmt --errors --deadline=5m $$(GO15VENDOREXPERIMENT=1 glide nv)
+	@GO15VENDOREXPERIMENT=1 gometalinter -D gotype -E gofmt --errors --deadline=5m -j 4 $$(GO15VENDOREXPERIMENT=1 glide nv)
 
 test:
 	@GO15VENDOREXPERIMENT=1 go test $$(GO15VENDOREXPERIMENT=1 glide nv)


### PR DESCRIPTION
The default of 12 is too much and can hang your system.