### PR TITLE
config,etcdmgmt: Remove hardcoded paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -26,9 +27,7 @@ var (
 
 // parseFlags sets up the flags and parses them, this needs to be called before any other operation
 func parseFlags() {
-	cwd, _ := os.Getwd()
-
-	flag.String("localstatedir", cwd, "Directory to store local state information. Defaults to current working directory.")
+	flag.String("localstatedir", "", "Directory to store local state information. Defaults to current working directory.")
 	flag.String("config", "", "Configuration file for GlusterD. By default looks for glusterd.(yaml|toml|json) in /etc/glusterd and current working directory.")
 	flag.String("loglevel", defaultLogLevel, "Severity of messages to be logged.")
 	flag.String("restaddress", defaultRestAddress, "Address to bind the REST service.")
@@ -40,6 +39,12 @@ func parseFlags() {
 // setDefaults sets defaults values for config options not available as a flag,
 // and flags which don't have default values
 func setDefaults() {
+	cwd, _ := os.Getwd()
+
+	config.SetDefault("localstatedir", cwd)
+	//RunDir and LogDir default to being under localstatedir
+	config.SetDefault("rundir", path.Join(cwd, "run"))
+	config.SetDefault("logdir", path.Join(cwd, "log"))
 }
 
 func dumpConfigToLog() {

--- a/etcdmgmt/etcd-mgmt.go
+++ b/etcdmgmt/etcd-mgmt.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -16,6 +17,7 @@ import (
 	"github.com/gluster/glusterd2/utils"
 
 	log "github.com/Sirupsen/logrus"
+	config "github.com/spf13/viper"
 )
 
 // ExecName is to indicate the executable name, useful for mocking in tests
@@ -32,16 +34,13 @@ var (
 	// ETCD executable path
 	ExecName = "etcd"
 	// Configuration directory for storing etcd configuration
-	ETCDConfDir = "/var/lib/glusterd"
-	ETCDEnvFile = ETCDConfDir + "/etcdenv.conf"
+	ETCDConfDir string
+	ETCDEnvFile string
 	// If this file is touched on ETCDConfDir that indicates that etcd
 	// instance need to come with proxy mode
-	ETCDProxyFile = ETCDConfDir + "/proxy"
+	ETCDProxyFile string
 
-	etcdPidDir  = "/var/run/gluster/"
-	etcdPidFile = etcdPidDir + "etcd.pid"
-	etcdLogDir  = "/var/log/glusterfs"
-	etcdLogFile = etcdLogDir + "/etcd.log"
+	etcdPidDir, etcdPidFile, etcdLogDir, etcdLogFile string
 )
 
 // checkETCDHealth() is to ensure that etcd process have come up properlly or not
@@ -192,8 +191,18 @@ func isETCDStartNeeded() (bool, int) {
 	return start, pid
 }
 
-// initETCDArgVar() will initialize etcd argument which will be used at various places
+// initETCDArgVar() will initialize etcd arguments and variables which will be used at various places
 func initETCDArgVar() {
+	// Set the paths required for etcd
+	ETCDConfDir = path.Join(config.GetString("localstatedir"), "etcd")
+	ETCDEnvFile = path.Join(ETCDConfDir, "etcdenv.conf")
+	ETCDProxyFile = path.Join(ETCDConfDir, "proxy")
+
+	etcdPidDir = path.Join(config.GetString("rundir"), "etcd")
+	etcdPidFile = path.Join(etcdPidDir, "etcd.pid")
+	etcdLogDir = path.Join(config.GetString("logdir"), "etcd")
+	etcdLogFile = path.Join(etcdLogDir, "etcd.log")
+
 	context.SetLocalHostIP()
 
 	listenClientUrls = "http://" + context.HostIP + ":2379"

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main() {
 	initConfig(confFile)
 
 	utils.InitDir(config.GetString("localstatedir"))
+	utils.InitDir(config.GetString("rundir"))
+	utils.InitDir(config.GetString("logdir"))
 	context.MyUUID = context.InitMyUUID()
 
 	// Starting etcd daemon upon starting of GlusterD


### PR DESCRIPTION
Remove the hardcoded paths for etcd and make RunDir and LogDir
configurable.