### PR TITLE
Don't let child process become zombie

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -77,10 +77,8 @@ func Start(d Daemon, wait bool) error {
 	} else {
 		// If the process exits at some point later, do read it's
 		// exit status. This should not let it be a zombie.
-		done := make(chan error, 1)
 		go func() {
-			done <- cmd.Wait()
-			err := <-done
+			err := cmd.Wait()
 			log.WithFields(log.Fields{
 				"name":   d.Name(),
 				"pid":    cmd.Process.Pid,
@@ -92,7 +90,7 @@ func Start(d Daemon, wait bool) error {
 	// Check if the daemon is running
 	// TODO: Need some form of waiting period or timeout here before
 	// returning success. The process may die shortly after spawn.
-	_, err = GetProcess(pid)
+	_, err = GetProcess(cmd.Process.Pid)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -54,18 +54,6 @@ func Start(d Daemon, wait bool) error {
 		"args": d.Args(),
 	}).Debug("Starting daemon.")
 
-	cmd := exec.Command(d.Path(), d.Args())
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	if wait == true {
-		// Wait for the process to exit
-		err = cmd.Wait()
-		return err
-	}
-
 	// Check if pidfile exists
 	pid, err := ReadPidFromFile(d.PidFile())
 	if err == nil {
@@ -74,6 +62,39 @@ func Start(d Daemon, wait bool) error {
 		if err == nil {
 			return errors.ErrProcessAlreadyRunning
 		}
+	}
+
+	cmd := exec.Command(d.Path(), d.Args())
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	if wait == true {
+		// Wait for the process to exit
+		err = cmd.Wait()
+		return err
+	} else {
+		// If the process exits at some point later, do read it's
+		// exit status. This should not let it be a zombie.
+		done := make(chan error, 1)
+		go func() {
+			done <- cmd.Wait()
+			err := <-done
+			log.WithFields(log.Fields{
+				"name":   d.Name(),
+				"pid":    cmd.Process.Pid,
+				"status": err,
+			}).Debug("Daemon died.")
+		}()
+	}
+
+	// Check if the daemon is running
+	// TODO: Need some form of waiting period or timeout here before
+	// returning success. The process may die shortly after spawn.
+	_, err = GetProcess(pid)
+	if err != nil {
+		return err
 	}
 
 	log.WithFields(log.Fields{


### PR DESCRIPTION
glusterfsd, when spawned will exit because:
* Directories in logfile path and pidfile path don't exist
* It tries to use portmap and communicate with glusterd to get volfile.
  This isn't implemented yet.

When glusterfsd dies immediately after spawn, it'll become zombie if
exit status of the process isn't read by parent.

This change also moves the code that reads pid file to place where it
really should be. Also checks if process is really running before it
returns success to the caller.

Signed-off-by: Prashanth Pai <ppai@redhat.com>