### PR TITLE
Add scripts to build and release GD2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ vendor/
 _builds/
 _steps/
 _projects/
+# Ignore build and release directories
+build/
+releases/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-VERSION := $(shell bash ./scripts/pkg-version --full)
-LDFLAGS := '-X github.com/gluster/glusterd2/gdctx.GlusterdVersion=$(VERSION)'
+GOPATH := $(shell go env GOPATH)
+GOBIN := '$(GOPATH)/bin'
 
-.PHONY: all build check check-go check-reqs install vendor-update verify
+.PHONY: all build check check-go check-reqs install vendor-update verify glusterd2 release check-protoc
 
 all: build
 
@@ -22,15 +22,13 @@ check-reqs:
 	@echo
 
 glusterd2:
-	@echo Building GlusterD-2.0
-	@GO15VENDOREXPERIMENT=1 go build -ldflags $(LDFLAGS)
+	@./scripts/build.sh
 	@echo
 
-install: check vendor-update
-	@echo Building and installing GlusterD-2.0
-	@GO15VENDOREXPERIMENT=1 go install -ldflags $(LDFLAGS)
+install: check-go check-reqs vendor-update
+	@./scripts/build.sh $(GOBIN)
 	@echo Setting CAP_SYS_ADMIN for glusterd2 \(requires sudo\)
-	sudo setcap cap_sys_admin+ep $$GOPATH/bin/glusterd2
+	sudo setcap cap_sys_admin+ep $(GOBIN)/glusterd2
 	@echo
 
 vendor-update:
@@ -43,3 +41,6 @@ verify: check-reqs
 
 test:
 	@GO15VENDOREXPERIMENT=1 go test $$(GO15VENDOREXPERIMENT=1 glide nv)
+
+release: check-go check-reqs vendor-update
+	@./scripts/release.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+## This scripts builds a GD2 binary and places it in the given path
+## Should be called from the root of the GD2 repo as
+## ./scripts/build.sh [<path-to-output-directory>]
+## If no path is given, defaults to build
+
+OUTDIR=build
+if [ "x$1" != "x" ]; then
+  OUTDIR=$1
+fi
+
+VERSION=$($(dirname $0)/pkg-version --full)
+LDFLAGS="-X github.com/gluster/glusterd2/gdctx.GlusterdVersion=$VERSION"
+BIN=$(basename $(go list -f '{{.ImportPath}}'))
+
+echo "Building $BIN $VERSION"
+go build -ldflags "${LDFLAGS}" -o $OUTDIR/$BIN || exit 1
+echo "Built $BIN $VERSION at $OUTDIR/$BIN"
+
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+## This script builds a GlusterD-2.0 binary and creates an archive, and then signs it.
+## Should be called from the root of the GD2 repo
+
+VERSION=$($(dirname $0)/pkg-version --full)
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+BIN=$(basename $(go list -f '{{.ImportPath}}'))
+
+RELEASEDIR=releases/$VERSION
+TAR=$RELEASEDIR/$BIN-$VERSION-$OS-$ARCH.tar
+ARCHIVE=$TAR.xz
+
+if [ -e $ARCHIVE ]; then
+  echo "Release archive $ARCHIVE exists."
+  echo "Do you want to clean and start again?(y/N)"
+  read answer
+  case "$answer" in
+    y|Y)
+      echo "Cleaning previously built release"
+      rm -rf $RELEASEDIR
+      echo
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+
+mkdir -p $RELEASEDIR
+
+echo "Making GlusterD-2.0 release $VERSION"
+echo
+
+# Build GD2 into the release directory
+$(dirname $0)/build.sh $RELEASEDIR || exit 1
+echo
+
+# Create release archive
+echo "Creating release archive"
+tar -cf $TAR -C $RELEASEDIR $BIN || exit 1
+xz $TAR || exit 1
+echo "Created release archive $RELEASEDIR/$ARCHIVE"
+echo
+
+# Sign the tarball
+# Requires that a default gpg key be set up
+echo "Signing archive"
+SIGNFILE=$ARCHIVE.asc
+gpg --armor --output $SIGNFILE --detach-sign $ARCHIVE || exit 1
+echo "Signed archive, signature in $SIGNFILE"


### PR DESCRIPTION
- The Makefile has been updated to use these scripts to build, install
  and release
- Run `make release` to create build, create and sign a release archive,
  useful for releasing on Github.