### PR TITLE
Changes for auto building test-env docker images

### DIFF
--- a/extras/test-env/Dockerfile
+++ b/extras/test-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM kshlm/glusterd2-dev:centos-latest
+FROM gluster/glusterd2-dev:latest
 
 MAINTAINER Kaushal M <kshlmster@gmail.com>
 

--- a/extras/test-env/Dockerfile
+++ b/extras/test-env/Dockerfile
@@ -2,6 +2,9 @@ FROM gluster/glusterd2-dev:latest
 
 MAINTAINER Kaushal M <kshlmster@gmail.com>
 
+ARG GD2_VERSION
+ENV GD2_VERSION $GD2_VERSION
+
 ADD setup.sh /setup.sh
 RUN chmod +x /setup.sh
 RUN /setup.sh

--- a/extras/test-env/README.md
+++ b/extras/test-env/README.md
@@ -7,9 +7,9 @@ A 'Vagrantfile' is provided which makes use of this docker image to setup a test
 
 A trusted build 'gluster/glusterd2-test' is available from the Docker hub.
 
-To build the image on your own, run the following from this directory
+To build the image on your own, run the build script from this directory
 ```
-$ docker build -t gluster/glusterd2-test:latest .
+$ ./build.sh
 ```
 
 The image has GD2 installed at `/usr/sbin/glusterd2`.

--- a/extras/test-env/Vagrantfile
+++ b/extras/test-env/Vagrantfile
@@ -5,6 +5,10 @@ Vagrant.configure("2") do |config|
     config.vm.define "gd2test-#{i}" do |arch|
       arch.vm.hostname = "gd2test-#{i}"
       arch.vm.provider "docker" do |d|
+        # By default uses the latest image.
+        # Change latest to whatever version you want.
+        # Make sure to `docker pull gluster/glusterd2-test` after every release
+        # to get the latest release
         d.image = 'gluster/glusterd2-test:latest'
         d.name = "gd2test-#{i}"
         d.has_ssh = true

--- a/extras/test-env/build.sh
+++ b/extras/test-env/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+# This script builds the glusterd2-test docker image.
+# It is mainly designed to run on the Docker Hub via the hooks mechanism just
+# so we can pass the build arg GD2_VERSION onto setup.sh.
+# It can run locally as well.
+
+# When run in Docker Hub DOCKER_TAG and IMAGE_NAME are set based on GD2 version
+# for which the image is being built.
+# Hub needs to have build with trigger settings as follows,
+#  Type: Tag
+#  Name: /^v4\.0dev\-[0-9.]+$/
+#  Docker tag name: {sourceref}
+# This should trigger builds for new tags.
+
+# If not running in the hub environment set up the hub variables to use
+if [ "x${IMAGE_NAME}" = "x" -o "x${DOCKER_TAG}" ]; then
+  pkg_version="$(dirname $0)/../../scripts/pkg-version"
+  # Doing it this way because pkg-version returns a dirty version when there
+  # are commits beyond the latest tag
+  GD2_VERSION="v$($pkg_version --version)-$($pkg_version --release | cut -d. -f1)"
+
+  IMAGE_NAME="gluster/glusterd2-test:${GD2_VERSION}"
+else
+  GD2_VERSION=${DOCKER_TAG}
+fi
+
+docker build --build-arg=GD2_VERSION=$GD2_VERSION -t $IMAGE_NAME .
+
+

--- a/extras/test-env/hooks/build
+++ b/extras/test-env/hooks/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+## Used to give a custom build command for Docker Hub.
+## Refer https://github.com/docker/hub-feedback/issues/508 for more information
+
+echo Running build hook script
+./build.sh

--- a/extras/test-env/setup.sh
+++ b/extras/test-env/setup.sh
@@ -1,17 +1,19 @@
 #! /bin/bash
 set -x -e
-TMP=$(mktemp -d)
+TMPDIR=$(mktemp -d)
 
 # GD2_VERSION will be set as an ENV variable form the Dockerfile
 ARCHIVE=glusterd2-${GD2_VERSION}-linux-amd64.tar.xz
 URL=https://github.com/gluster/glusterd2/releases/download/${GD2_VERSION}/${ARCHIVE}
 
-curl -o ${TMP}/${ARCHIVE} -L $URL
-tar -C /usr/sbin --xz -xf ${TMP}/${ARCHIVE}
+curl -o ${TMPDIR}/${ARCHIVE} -L $URL
+tar -C /usr/sbin --xz -xf ${TMPDIR}/${ARCHIVE}
 setcap cap_sys_admin+ep /usr/sbin/glusterd2
 
 yum install -y etcd
+
 yum clean all
+rm -rf $TMPDIR
 
 
 

--- a/extras/test-env/setup.sh
+++ b/extras/test-env/setup.sh
@@ -2,9 +2,9 @@
 set -x -e
 TMP=$(mktemp -d)
 
-VERSION=v4.0dev-2
-ARCHIVE=glusterd2-${VERSION}-linux-amd64.tar.xz
-URL=https://github.com/gluster/glusterd2/releases/download/${VERSION}/${ARCHIVE}
+# GD2_VERSION will be set as an ENV variable form the Dockerfile
+ARCHIVE=glusterd2-${GD2_VERSION}-linux-amd64.tar.xz
+URL=https://github.com/gluster/glusterd2/releases/download/${GD2_VERSION}/${ARCHIVE}
 
 curl -o ${TMP}/${ARCHIVE} -L $URL
 tar -C /usr/sbin --xz -xf ${TMP}/${ARCHIVE}


### PR DESCRIPTION
This required to setup auto-triggering builds of images whenever a new
tag/release is done. Without this the build script has to be manually updated
and builds manually triggered on Docker hub.