### PR TITLE
Migrate to etcd client v3

### DIFF
--- a/commands/peers/addpeer.go
+++ b/commands/peers/addpeer.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gluster/glusterd2/utils"
 
 	log "github.com/Sirupsen/logrus"
-	etcdcontext "golang.org/x/net/context"
-
 	"github.com/pborman/uuid"
 )
 
@@ -62,13 +60,12 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 		ID:        uuid.Parse(rsp.UUID),
 		Name:      req.Name,
 		Addresses: req.Addresses,
-		MemberID:  "",
+		MemberID:  0,
 	}
 
 	if req.Client == false {
 		// Add member to etcd server
-		mAPI := etcdmgmt.GetEtcdMembersAPI()
-		member, e := mAPI.Add(etcdcontext.Background(), "http://"+req.Name+":2380")
+		member, e := etcdmgmt.EtcdMemberAdd("http://" + req.Name + ":2380")
 		if e != nil {
 			log.WithFields(log.Fields{
 				"error":  e,
@@ -86,7 +83,7 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 			"member Id ":  member.ID,
 		}).Info("New member added to the cluster")
 
-		mlist, e := mAPI.List(etcdcontext.Background())
+		mlist, e := etcdmgmt.EtcdMemberList()
 		if e != nil {
 			log.WithField("err", e).Error("Failed to list member in etcd cluster")
 			rest.SendHTTPError(w, http.StatusInternalServerError, e.Error())

--- a/commands/peers/deletepeer.go
+++ b/commands/peers/deletepeer.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gluster/glusterd2/rest"
 
 	log "github.com/Sirupsen/logrus"
-	etcdcontext "golang.org/x/net/context"
-
 	"github.com/gorilla/mux"
 )
 
@@ -39,8 +37,7 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Delete member from etcd cluster
-	mAPI := etcdmgmt.GetEtcdMembersAPI()
-	e = mAPI.Remove(etcdcontext.Background(), p.MemberID)
+	e = etcdmgmt.EtcdMemberRemove(p.MemberID)
 	if e != nil {
 		log.WithFields(log.Fields{
 			"er":   e,

--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -183,7 +183,10 @@ func (p *PeerService) ExportAndStoreETCDConfig(nc netctx.Context, c *EtcdConfigR
 			}
 		}
 
-		etcdmgmt.CloseEtcdClient()
+		err := etcdmgmt.CloseEtcdClient()
+		if err != nil {
+			log.WithField("error", err.Error()).Error("Could not stop etcd client.")
+		}
 
 		// Restarting etcd daemon
 		etcdCtx, err := etcdmgmt.ReStartETCD()
@@ -200,10 +203,13 @@ func (p *PeerService) ExportAndStoreETCDConfig(nc netctx.Context, c *EtcdConfigR
 	} else {
 		// This is a request to reconfigure etcd as part of delete peer
 
-		etcdmgmt.CloseEtcdClient()
+		err := etcdmgmt.CloseEtcdClient()
+		if err != nil {
+			log.WithField("error", err.Error()).Error("Could not stop etcd client.")
+		}
 
 		etcdCtx := gdctx.EtcdProcessCtx
-		err := etcdmgmt.StopETCD(etcdCtx)
+		err = etcdmgmt.StopETCD(etcdCtx)
 		if err != nil {
 			log.WithField("error", err.Error()).Error("Could not stop etcd daemon.")
 			return nil, err

--- a/etcdmgmt/client.go
+++ b/etcdmgmt/client.go
@@ -1,35 +1,115 @@
 package etcdmgmt
 
 import (
+	"errors"
+	"sync"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	etcd "github.com/coreos/etcd/client"
+	etcd "github.com/coreos/etcd/clientv3"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	etcdcontext "golang.org/x/net/context"
 )
 
-var (
-	etcdClient etcd.Client
-)
+var etcdClient struct {
+	client *etcd.Client
+	sync.Mutex
+}
 
 // InitEtcdClient will initialize etcd client. This instance of the client
 // should only be used to maintain/modify cluster membership. For storing
 // key-values in etcd store, one should use libkv instead.
-func InitEtcdClient(endpoints string) error {
+func InitEtcdClient(endpoint string) error {
 	cfg := etcd.Config{
-		Endpoints:               []string{endpoints},
-		Transport:               etcd.DefaultTransport,
-		HeaderTimeoutPerRequest: 3 * time.Second,
+		Endpoints:   []string{endpoint},
+		DialTimeout: 5 * time.Second,
 	}
+
+	etcdClient.Lock()
+	defer etcdClient.Unlock()
+
+	if etcdClient.client != nil {
+		return errors.New("An instance of etcd client is already active.")
+	}
+
 	c, err := etcd.New(cfg)
 	if err != nil {
-		log.WithField("error", err).Error("Failed to initialize etcd client(v2).")
 		return err
 	}
-	etcdClient = c
+
+	etcdClient.client = c
 	return nil
 }
 
-// GetEtcdMemberAPI returns the etcd MemberAPI
-func GetEtcdMembersAPI() etcd.MembersAPI {
-	return etcd.NewMembersAPI(etcdClient)
+// CloseEtcdClient shuts down the client's etcd connections. If the client is
+// not closed, the connection will have leaky goroutines.
+func CloseEtcdClient() error {
+	etcdClient.Lock()
+	defer etcdClient.Unlock()
+
+	if etcdClient.client == nil {
+		return errors.New("Etcd client is not initialized.")
+	}
+
+	err := etcdClient.client.Close()
+	if err != nil {
+		return err
+	}
+	etcdClient.client = nil
+
+	return nil
+}
+
+// EtcdMemberList returns a list of members in etcd cluster.
+func EtcdMemberList() ([]*pb.Member, error) {
+
+	resp, err := etcdClient.client.MemberList(etcdcontext.Background())
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":               err,
+			"ClusterId(Response)": resp.Header.ClusterId,
+			"MemberId(Response)":  resp.Header.MemberId,
+			"Revision":            resp.Header.Revision,
+			"RaftTerm":            resp.Header.RaftTerm,
+		}).Debug("EtcdMemberList: Failed to list etcd members.")
+		return nil, err
+	}
+
+	return resp.Members, nil
+}
+
+// EtcdMemberAdd will add a new member to the etcd cluster.
+func EtcdMemberAdd(peerURL string) (*pb.Member, error) {
+
+	resp, err := etcdClient.client.MemberAdd(etcdcontext.Background(), []string{peerURL})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":               err,
+			"ClusterId(Response)": resp.Header.ClusterId,
+			"MemberId(Response)":  resp.Header.MemberId,
+			"Revision":            resp.Header.Revision,
+			"RaftTerm":            resp.Header.RaftTerm,
+		}).Debug("EtcdMemberAdd: Failed to add etcd member.")
+		return nil, err
+	}
+
+	return resp.Member, nil
+}
+
+// EtcdMemberRemove will remove a member from the etcd cluster.
+func EtcdMemberRemove(memberID uint64) error {
+
+	resp, err := etcdClient.client.MemberRemove(etcdcontext.Background(), memberID)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":               err,
+			"ClusterId(Response)": resp.Header.ClusterId,
+			"MemberId(Response)":  resp.Header.MemberId,
+			"Revision":            resp.Header.Revision,
+			"RaftTerm":            resp.Header.RaftTerm,
+		}).Debug("EtcdMemberRemove: Failed to remove etcd member.")
+		return err
+	}
+
+	return nil
 }

--- a/etcdmgmt/client.go
+++ b/etcdmgmt/client.go
@@ -38,6 +38,8 @@ func InitEtcdClient(endpoint string) error {
 	}
 
 	etcdClient.client = c
+	log.Info("InitEtcdClient: Successfully initialized etcd client.")
+
 	return nil
 }
 
@@ -56,6 +58,7 @@ func CloseEtcdClient() error {
 		return err
 	}
 	etcdClient.client = nil
+	log.Info("CloseEtcdClient: Successfully shutdown etcd client.")
 
 	return nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,13 +1,19 @@
 hash: a74c863150928fd0122b7ca617109dbde07e93cba7fad09aa76efe13d950bbf7
-updated: 2016-11-02T14:55:05.491022998+05:30
+updated: 2016-11-03T16:42:51.418698527+05:30
 imports:
 - name: github.com/codegangsta/negroni
   version: 3f7ce7b928e14ff890b067e5bbbc80af73690a9c
 - name: github.com/coreos/etcd
   version: 83347907774bf36cbb261c594a32fd7b0f5dd9f6
   subpackages:
+  - auth/authpb
   - client
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
   - pkg/pathutil
+  - pkg/tlsutil
   - pkg/types
 - name: github.com/docker/libkv
   version: 3fce6a0f26e07da3eac45796a8e255547a47a750
@@ -16,15 +22,24 @@ imports:
   - store/etcd
 - name: github.com/fsnotify/fsnotify
   version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/golang/protobuf
-  version: 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
+  - jsonpb
   - proto
   - protoc-gen-go
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 0a192a193177452756c362c20087ddafcf6829c4
+- name: github.com/grpc-ecosystem/grpc-gateway
+  version: f52d055dc48aec25854ed7d31862f78913cf17d1
+  subpackages:
+  - runtime
+  - runtime/internal
+  - utilities
 - name: github.com/hashicorp/hcl
   version: 99df0eb941dd8ddbc83d3f3605a34f6a686ac85e
   subpackages:

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -11,7 +11,7 @@ type Peer struct {
 	Name      string    `json:"name"`
 	Addresses []string  `json:"addresses"`
 	Client    bool      `json:"client"`
-	MemberID  string    `json:"memberID"`
+	MemberID  uint64    `json:"memberID"`
 }
 
 // ETCDConfig represents the structure which holds the ETCD env variables &

--- a/peer/self.go
+++ b/peer/self.go
@@ -5,25 +5,21 @@ import (
 	"github.com/gluster/glusterd2/gdctx"
 
 	log "github.com/Sirupsen/logrus"
-	etcdcontext "golang.org/x/net/context"
 )
 
 // AddSelfDetails function adds its own details into the central store
 func AddSelfDetails() {
-	var memberID string
-	mAPI := etcdmgmt.GetEtcdMembersAPI()
+	var memberID uint64
 
-	mlist, e := mAPI.List(etcdcontext.Background())
+	mlist, e := etcdmgmt.EtcdMemberList()
 	if e != nil {
 		log.WithField("err", e).Fatal("Failed to list member in etcd cluster")
 	}
 
 	for _, memb := range mlist {
-		for _ = range memb.PeerURLs {
-			if memb.Name == "default" {
-				memberID = memb.ID
-				break
-			}
+		if memb.Name == "default" {
+			memberID = memb.ID
+			break
 		}
 	}
 	p := &Peer{


### PR DESCRIPTION
- Implements etcd client v3
- Implements wrapper functions for etcd member operations i.e
   (add, remove, list) etcd members
- The etcd member id was of type string in v2.
   In v3, the member id is of type uint64.
- The client connections are  now cleanly shutdown before
   etcd server is restarted.

This PR closes issue #162 