### PR TITLE
Fix deleting peer from remote node

### DIFF
--- a/commands/peers/deletepeer.go
+++ b/commands/peers/deletepeer.go
@@ -36,6 +36,18 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 		rest.SendHTTPError(w, http.StatusInternalServerError, rsp.OpError)
 		return
 	}
+
+	// Remove the peer from the store
+	if e := peer.DeletePeer(id); e != nil {
+		log.WithFields(log.Fields{
+			"er":   e,
+			"peer": id,
+		}).Error("Failed to remove peer from the store")
+		rest.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+	} else {
+		rest.SendHTTPResponse(w, http.StatusNoContent, nil)
+	}
+
 	// Delete member from etcd cluster
 	e = etcdmgmt.EtcdMemberRemove(p.MemberID)
 	if e != nil {
@@ -60,16 +72,4 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 		rest.SendHTTPError(w, http.StatusInternalServerError, etcdrsp.OpError)
 		return
 	}
-
-	// Remove the peer from the store
-	if e := peer.DeletePeer(id); e != nil {
-		log.WithFields(log.Fields{
-			"er":   e,
-			"peer": id,
-		}).Error("Failed to remove peer from the store")
-		rest.SendHTTPError(w, http.StatusInternalServerError, e.Error())
-	} else {
-		rest.SendHTTPResponse(w, http.StatusNoContent, nil)
-	}
-
 }


### PR DESCRIPTION
Problem
*******
Bring up two glusterd2 nodes - A and B. Add B as peer from node A.
Now removing peer A from node B does not work. Why ? Because in
delete peer, we first remove the member from cluster and then
remove the entry from the store. This isn't right as there is a
loss of quorum (no leader) for a brief period of time. Hence, removing
peer entry from store fails.

Fix
***
Change the order. First remove peer entry from store and then remove
the node from etcd cluster.

Closes #171

Signed-off-by: Prashanth Pai <ppai@redhat.com>