### PR TITLE
Make etcd client connections non-persistent

### DIFF
--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -101,15 +101,6 @@ func (p *PeerService) ExportAndStoreETCDConfig(nc netctx.Context, c *EtcdConfigR
 		}
 	}
 
-	// Gracefully shutdown the etcd client
-	err = etcdmgmt.CloseEtcdClient()
-	if err != nil {
-		opRet = -1
-		opError = fmt.Sprintf("Error stopping etcd client.")
-		log.WithField("error", err.Error()).Error("Error stopping etcd client.")
-		goto Out
-	}
-
 	// Gracefully stop embedded etcd server
 	err = etcdmgmt.DestroyEmbeddedEtcd()
 	if err != nil {
@@ -125,15 +116,6 @@ func (p *PeerService) ExportAndStoreETCDConfig(nc netctx.Context, c *EtcdConfigR
 		opRet = -1
 		opError = fmt.Sprintf("Could not start embedded etcd server.")
 		log.WithField("Error", err).Error("Could not start embedded etcd server.")
-		goto Out
-	}
-
-	// Re-initialize etcd client to talk to the restarted etcd server.
-	err = etcdmgmt.InitEtcdClient("http://" + gdctx.HostIP + ":2379")
-	if err != nil {
-		opRet = -1
-		opError = fmt.Sprintf("Error starting etcd client.")
-		log.WithField("error", err.Error()).Error("Error starting etcd client.")
 		goto Out
 	}
 

--- a/main.go
+++ b/main.go
@@ -58,12 +58,6 @@ func main() {
 		log.WithField("Error", err).Fatal("Could not start embedded etcd server.")
 	}
 
-	// Initialize etcd client (used only for member add/remove)
-	err = etcdmgmt.InitEtcdClient("http://" + gdctx.HostIP + ":2379")
-	if err != nil {
-		log.WithField("err", err).Fatal("Failed to initialize etcd client")
-	}
-
 	gdctx.Init()
 
 	for _, c := range commands.Commands {


### PR DESCRIPTION
glusterd2 uses internal etcd client only during member add, list, delete.
All access for storing information in etcd cluster is done through libkv.
So there is no good reason for the internal etcd client to always remain
connected to etcd server throughout the lifecycle of the process.

This also removes the need to restart/reconfigure etcd client whenever
the glusterd2 instance joins/leaves an etcd cluster.

Signed-off-by: Prashanth Pai <ppai@redhat.com>