### PR TITLE
Implement volume status as example of transaction result aggregation

### DIFF
--- a/brick/brick.go
+++ b/brick/brick.go
@@ -28,6 +28,17 @@ type Brickinfo struct {
 	ID       uuid.UUID
 }
 
+// Brickstatus represents real-time status of the brick
+// TODO: Consolidate fields of Brickinfo, Brickstatus and Brick structs
+type Brickstatus struct {
+	Hostname string
+	Path     string
+	ID       uuid.UUID
+	Online   bool
+	Pid      int
+	// TODO: Add other fields like filesystem type, statvfs output etc.
+}
+
 // Brick type represents information about the brick daemon
 type Brick struct {
 	// Externally consumable using methods of Daemon interface

--- a/commands/volumes/commands.go
+++ b/commands/volumes/commands.go
@@ -31,6 +31,12 @@ func (c *Command) Routes() rest.Routes {
 			Version:     1,
 			HandlerFunc: volumeInfoHandler},
 		rest.Route{
+			Name:        "VolumeStatus",
+			Method:      "GET",
+			Pattern:     "/volumes/{volname}/status",
+			Version:     1,
+			HandlerFunc: volumeStatusHandler},
+		rest.Route{
 			Name:        "VolumeList",
 			Method:      "GET",
 			Pattern:     "/volumes",
@@ -57,4 +63,5 @@ func (c *Command) RegisterStepFuncs() {
 	registerVolDeleteStepFuncs()
 	registerVolStartStepFuncs()
 	registerVolStopStepFuncs()
+	registerVolStatusStepFuncs()
 }

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -60,8 +60,8 @@ func checkStatus(ctx transaction.TxnCtx) error {
 		brickStatuses = append(brickStatuses, fakeStatus)
 	}
 
-	// Store the results in transaction context. This will consumed by the
-	// node that initiated the transaction.
+	// Store the results in transaction context. This will be consumed by
+	// the node that initiated the transaction.
 	ctx.SetNodeResult(gdctx.MyUUID, brickStatusTxnKey, brickStatuses)
 
 	return nil

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -16,6 +16,10 @@ import (
 	"github.com/pborman/uuid"
 )
 
+const (
+	brickStatusTxnKey string = "brickstatuses"
+)
+
 func checkStatus(ctx transaction.TxnCtx) error {
 	var volname string
 
@@ -58,8 +62,7 @@ func checkStatus(ctx transaction.TxnCtx) error {
 
 	// Store the results in transaction context. This will consumed by the
 	// node that initiated the transaction.
-	key := gdctx.MyUUID.String() + "/" + "brickstatuses"
-	ctx.Set(key, brickStatuses)
+	ctx.SetNodeResult(gdctx.MyUUID, brickStatusTxnKey, brickStatuses)
 
 	return nil
 }
@@ -75,8 +78,7 @@ func aggregateVolumeStatus(ctx transaction.TxnCtx, nodes []uuid.UUID) (*volume.V
 	// Fetch brick statuses stored by each node in transaction context.
 	for _, node := range nodes {
 		var tmp []brick.Brickstatus
-		key := node.String() + "/" + "brickstatuses"
-		err := ctx.Get(key, &tmp)
+		err := ctx.GetNodeResult(node, brickStatusTxnKey, &tmp)
 		if err != nil {
 			return nil, goerrors.New("aggregateVolumeStatus: Could not fetch results from transaction context.")
 		}

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -1,0 +1,142 @@
+package volumecommands
+
+import (
+	goerrors "errors"
+	"net/http"
+
+	"github.com/gluster/glusterd2/brick"
+	"github.com/gluster/glusterd2/errors"
+	"github.com/gluster/glusterd2/gdctx"
+	"github.com/gluster/glusterd2/rest"
+	"github.com/gluster/glusterd2/transaction"
+	"github.com/gluster/glusterd2/volume"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
+)
+
+func checkStatus(ctx transaction.TxnCtx) error {
+	var volname string
+
+	if err := ctx.Get("volname", &volname); err != nil {
+		ctx.Logger().WithFields(log.Fields{
+			"error": err,
+			"key":   "volname",
+		}).Error("checkStatus: Failed to get key from transaction context.")
+		return err
+	}
+
+	vol, err := volume.GetVolume(volname)
+	if err != nil {
+		ctx.Logger().WithFields(log.Fields{
+			"error": err,
+			"key":   "volname",
+		}).Error("checkStatus: Failed to get volume information from store.")
+		return err
+	}
+
+	var brickStatuses []*brick.Brickstatus
+
+	for _, binfo := range vol.Bricks {
+		// Skip bricks that aren't on this node.
+		// TODO: Rename Brickinfo field 'ID' to 'NodeUUID'
+		if uuid.Equal(binfo.ID, gdctx.MyUUID) == false {
+			continue
+		}
+
+		// TODO: Check actual brick status when we get them running.
+		fakeStatus := &brick.Brickstatus{
+			Hostname: binfo.Hostname,
+			Path:     binfo.Path,
+			ID:       binfo.ID,
+			Online:   false,
+			Pid:      1234,
+		}
+		brickStatuses = append(brickStatuses, fakeStatus)
+	}
+
+	// Store the results in transaction context. This will consumed by the
+	// node that initiated the transaction.
+	key := gdctx.MyUUID.String() + "/" + "brickstatuses"
+	ctx.Set(key, brickStatuses)
+
+	return nil
+}
+
+func registerVolStatusStepFuncs() {
+	transaction.RegisterStepFunc(checkStatus, "vol-status.Check")
+}
+
+func aggregateVolumeStatus(ctx transaction.TxnCtx, nodes []uuid.UUID) (*volume.VolStatus, error) {
+	var brickStatuses []brick.Brickstatus
+
+	// Loop over each node on which txn was run.
+	// Fetch brick statuses stored by each node in transaction context.
+	for _, node := range nodes {
+		var tmp []brick.Brickstatus
+		key := node.String() + "/" + "brickstatuses"
+		err := ctx.Get(key, &tmp)
+		if err != nil {
+			return nil, goerrors.New("aggregateVolumeStatus: Could not fetch results from transaction context.")
+		}
+		brickStatuses = append(brickStatuses, tmp...)
+	}
+	v := &volume.VolStatus{Brickstatuses: brickStatuses}
+	return v, nil
+}
+
+func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	volname := p["volname"]
+
+	// Ensure that the volume exists.
+	vol, err := volume.GetVolume(volname)
+	if err != nil {
+		rest.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+	}
+
+	// A very simple free-form transaction to query each node for brick
+	// status. Fetching volume status does not modify state/data on the
+	// remote node. So there's no need for locks.
+	txn := transaction.NewTxn()
+	defer txn.Cleanup()
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		&transaction.Step{
+			DoFunc: "vol-status.Check",
+			Nodes:  txn.Nodes,
+		},
+	}
+
+	// The remote nodes get args it needs from the transaction context.
+	txn.Ctx.Set("volname", volname)
+
+	// As all key-value pairs stored in transaction context ends up in etcd
+	// store, using either the old txn context reference or the one
+	// returned by txn.Do() is one and the same. The transaction context is
+	// a way for the nodes store the results of the step runs.
+	rtxn, err := txn.Do()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":  err.Error(),
+			"volume": volname,
+		}).Error("volumeStatusHandler: Failed to get volume status.")
+		rest.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Example of how an aggregate function will make sense from results of
+	// run of a step on multiple nodes. The transaction context will have
+	// results from each node, seggregated by the node's UUID.
+	result, err := aggregateVolumeStatus(rtxn, txn.Nodes)
+	if err != nil {
+		errMsg := "Failed to aggregate brick status results from multiple nodes."
+		log.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)
+		rest.SendHTTPError(w, http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	// Send aggregated result back to the client.
+	rest.SendHTTPResponse(w, http.StatusOK, result)
+}

--- a/transaction/context.go
+++ b/transaction/context.go
@@ -6,14 +6,19 @@ import (
 	"github.com/gluster/glusterd2/gdctx"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pborman/uuid"
 )
 
 // TxnCtx is used to carry contextual information across the lifetime of a transaction
 type TxnCtx interface {
 	// Set attaches the given key with value to the context. It updates value if key exists already.
 	Set(key string, value interface{}) error
+	// SetNodeResult is similar to Set but prefixes the key with node UUID specified.
+	SetNodeResult(nodeID uuid.UUID, key string, value interface{}) error
 	// Get gets the value for the given key. Returns an error if the key is not present
 	Get(key string, value interface{}) error
+	// GetNodeResult is similar to Get but prefixes the key with node UUID specified.
+	GetNodeResult(nodeID uuid.UUID, key string, value interface{}) error
 	// Delete deletes the key and value
 	Delete(key string) error
 	// Logger returns the Logrus logger associated with the context
@@ -105,6 +110,14 @@ func (c *txnCtx) Set(key string, value interface{}) error {
 	return e
 }
 
+// SetNodeResult is similar to Set but prefixes the key with the node UUID
+// specified. This function can be used by nodes to store results of
+// transaction steps.
+func (c *txnCtx) SetNodeResult(nodeID uuid.UUID, key string, value interface{}) error {
+	storeKey := nodeID.String() + "/" + key
+	return c.Set(storeKey, value)
+}
+
 // Get gets the value for the given key if available.
 // Returns error if not found.
 func (c *txnCtx) Get(key string, value interface{}) error {
@@ -125,6 +138,14 @@ func (c *txnCtx) Get(key string, value interface{}) error {
 		}).Error("failed to unmarshal value")
 	}
 	return e
+}
+
+// GetNodeResult is similar to Get but prefixes the key with node UUID
+// specified. This function can be used by the transaction initiator node to
+// fetch results of transaction step run on remote nodes.
+func (c *txnCtx) GetNodeResult(nodeID uuid.UUID, key string, value interface{}) error {
+	storeKey := nodeID.String() + "/" + key
+	return c.Get(storeKey, value)
 }
 
 // Delete deletes the key and attached value

--- a/transaction/context_mock.go
+++ b/transaction/context_mock.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"errors"
 	log "github.com/Sirupsen/logrus"
+	"github.com/pborman/uuid"
 )
 
 // MockCtx implements a dummy context type that can be used in tests
@@ -22,6 +23,12 @@ func (m *mockTxnCtx) Set(key string, value interface{}) error {
 	return nil
 }
 
+// SetNodeResult is similar to Set but prefixes the key with the node UUID specified.
+func (c *mockTxnCtx) SetNodeResult(nodeID uuid.UUID, key string, value interface{}) error {
+	storeKey := nodeID.String() + "/" + key
+	return c.Set(storeKey, value)
+}
+
 // Get gets the value for the given key. Returns an error if the key is not present
 func (m *mockTxnCtx) Get(key string, value interface{}) error {
 	v, ok := m.data[key]
@@ -30,6 +37,12 @@ func (m *mockTxnCtx) Get(key string, value interface{}) error {
 	}
 	value = v
 	return nil
+}
+
+// GetNodeResult is similar to Get but prefixes the key with node UUID specified.
+func (m *mockTxnCtx) GetNodeResult(nodeID uuid.UUID, key string, value interface{}) error {
+	storeKey := nodeID.String() + "/" + key
+	return m.Get(storeKey, value)
 }
 
 // Delete deletes the key and value

--- a/volume/struct.go
+++ b/volume/struct.go
@@ -17,12 +17,12 @@ import (
 	"github.com/pborman/uuid"
 )
 
-// VolStatus is the current status of a volume
-type VolStatus uint16
+// VolState is the current status of a volume
+type VolState uint16
 
 const (
 	// VolCreated should be set only for a volume that has been just created
-	VolCreated VolStatus = iota
+	VolCreated VolState = iota
 	// VolStarted should be set only for volumes that are running
 	VolStarted
 	// VolStopped should be set only for volumes that are not running, excluding newly created volumes
@@ -79,7 +79,7 @@ type Volinfo struct {
 
 	Options map[string]string
 
-	Status VolStatus
+	Status VolState
 
 	Checksum uint64
 	Version  uint64

--- a/volume/struct.go
+++ b/volume/struct.go
@@ -86,6 +86,13 @@ type Volinfo struct {
 	Bricks   []brick.Brickinfo
 }
 
+// VolStatus represents collective status of the bricks that make up the volume
+type VolStatus struct {
+	Brickstatuses []brick.Brickstatus
+	// TODO: Add further fields like memory usage, brick filesystem, fd consumed,
+	// clients connected etc.
+}
+
 // VolCreateRequest defines the parameters for creating a volume in the volume-create command
 // TODO: This should probably be moved out of here.
 type VolCreateRequest struct {


### PR DESCRIPTION
**Implement volume status endpoint:**

Querying for the status of volume will result in network calls to only
those nodes that contain bricks that make up the volume.
The transaction initiator node aggregates the results from various
nodes and sends it back to client.

This also serves as an example that the transaction framework need
not do the result aggregation part. The nodes can use transaction
context to store results. The initiator node then can do it's own
implementation (this is largely op-specific) to collate results stored
in transaction context and send the aggregated result to client.