### PR TITLE
Fix volume ID mismatch

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -236,7 +236,7 @@ func ValidateBrickPathStats(brickPath string, host string, force bool) error {
 //ValidateXattrSupport checks whether the underlying file system has extended
 //attribute support and it also sets some internal xattrs to mark the brick in
 //use
-func ValidateXattrSupport(brickPath string, host string, uuid uuid.UUID, force bool) error {
+func ValidateXattrSupport(brickPath string, host string, volid uuid.UUID, force bool) error {
 	var err error
 	err = Setxattr(brickPath, "trusted.glusterfs.test", []byte("working"), 0)
 	if err != nil {
@@ -262,7 +262,7 @@ func ValidateXattrSupport(brickPath string, host string, uuid uuid.UUID, force b
 			return errors.ErrBrickPathAlreadyInUse
 		}
 	}
-	err = Setxattr(brickPath, "trusted.glusterfs.volume-id", []byte(uuid), 0)
+	err = Setxattr(brickPath, volumeIDXattr, []byte(volid), 0)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error(),
 			"brickPath": brickPath,


### PR DESCRIPTION
Problem:
The volume ID was being generated multiple times, once each on the node
or instance which make up the volume. This is because the method
'validateVolumeCreate' was run on all nodes that are part of transaction
and this method was generating a new volume ID. As a result the volume
ID in xattr set on each brick would be different.

Fix:
Only the initiator node should generate the volume id once, set it in the
transaction context, so that every other node/instance can make use of
that.

Closes #191 

Signed-off-by: Prashanth Pai <ppai@redhat.com>