### PR TITLE
Avoid race in brick port allocation and use

### DIFF
--- a/brick/brick.go
+++ b/brick/brick.go
@@ -65,9 +65,6 @@ func (b *Brick) Path() string {
 
 // Args returns arguments to be passed to brick process during spawn.
 func (b *Brick) Args() string {
-	if b.args != "" {
-		return b.args
-	}
 
 	brickPathWithoutSlashes := strings.Trim(strings.Replace(b.brickinfo.Path, "/", "-", -1), "-")
 	logFile := path.Join(config.GetString("logdir"), "glusterfs", "bricks", fmt.Sprintf("%s.log", brickPathWithoutSlashes))

--- a/commands/volumes/volume-start.go
+++ b/commands/volumes/volume-start.go
@@ -41,14 +41,14 @@ func startBricks(c transaction.TxnCtx) error {
 			c.Logger().WithFields(log.Fields{
 				"volume": volname,
 				"brick":  b.Hostname + ":" + b.Path,
-			}).Info("would start brick")
+			}).Info("Starting brick")
 
 			brickDaemon, err := brick.NewDaemon(vol.Name, b)
 			if err != nil {
 				return err
 			}
 
-			err = daemon.Start(brickDaemon, false)
+			err = daemon.Start(brickDaemon, true)
 			if err != nil {
 				return err
 			}

--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -41,7 +41,7 @@ func stopBricks(c transaction.TxnCtx) error {
 			c.Logger().WithFields(log.Fields{
 				"volume": volname,
 				"brick":  b.Hostname + ":" + b.Path,
-			}).Info("would stop brick")
+			}).Info("Stopping brick")
 
 			brickDaemon, err := brick.NewDaemon(vol.Name, b)
 			if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/gluster/glusterd2/errors"
 
@@ -82,18 +81,19 @@ func Start(d Daemon, wait bool) error {
 		}).Debug("Child exited")
 
 		if errStatus != nil {
-			// Immediate child exited with error
-			_ = os.Remove(d.PidFile())
+			// Child exited with error
 			return errStatus
 		}
 
-		// Wait for daemon to be up. It is assumed that the daemon will
-		// write it's pid to pidfile.
+		// It is assumed that the daemon will write it's pid to pidfile.
 		// FIXME: When RPC infra is available, use that and make the
 		// daemon tell glusterd2 that it's up and ready.
-		time.Sleep(1 * time.Second)
 		pid, err = ReadPidFromFile(d.PidFile())
 		if err != nil {
+			log.WithFields(log.Fields{
+				"pidfile": d.PidFile(),
+				"error":   err.Error(),
+			}).Error("Could not read pidfile")
 			return err
 		}
 


### PR DESCRIPTION
This fixes the TOCTOU race for brick port by:

* Starting bricks sequentially (per instance).
* Detect when glusterfsd process exits with EADDRINUSE

Closes #193 

Signed-off-by: Prashanth Pai <ppai@redhat.com>