### PR TITLE
Name configurable addresses to be more meaningful

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	defaultLogLevel          = "debug"
-	defaultRestAddress       = ":24007"
-	defaultRPCAddress        = ":24008"
+	defaultClientAddress     = ":24007"
+	defaultPeerAddress       = ":24008"
 	defaultEtcdClientAddress = ":2379"
 	defaultEtcdPeerAddress   = ":2380"
 
@@ -39,8 +39,8 @@ func parseFlags() {
 	flag.String("config", "", "Configuration file for GlusterD. By default looks for glusterd.(yaml|toml|json) in /etc/glusterd and current working directory.")
 	flag.String("loglevel", defaultLogLevel, "Severity of messages to be logged.")
 
-	flag.String("restaddress", defaultRestAddress, "Address to bind the REST service.")
-	flag.String("rpcaddress", defaultRPCAddress, "Address to bind the RPC service.")
+	flag.String("clientaddress", defaultClientAddress, "Address to bind the REST service.")
+	flag.String("peeraddress", defaultPeerAddress, "Address to bind the inter glusterd2 RPC service.")
 	flag.String("etcdclientaddress", defaultEtcdClientAddress, "Address which etcd server will use for peer to peer communication.")
 	flag.String("etcdpeeraddress", defaultEtcdPeerAddress, "Address which etcd server will use to receive etcd client requests.")
 
@@ -75,21 +75,21 @@ func setDefaults() {
 		config.SetDefault("logdir", path.Join(wd, "log"))
 	}
 
-	// Set default rpc port. This shouldn't be configurable.
-	config.SetDefault("defaultrpcport", defaultRPCAddress[1:])
+	// Set default peer port. This shouldn't be configurable.
+	config.SetDefault("defaultpeerport", defaultPeerAddress[1:])
 
-	// Set rpc address.
-	host, port, err := net.SplitHostPort(config.GetString("rpcaddress"))
+	// Set peer address.
+	host, port, err := net.SplitHostPort(config.GetString("peeraddress"))
 	if err != nil {
-		log.Fatal("Invalid rpc address specified.")
+		log.Fatal("Invalid peer address specified.")
 	} else {
 		if host == "" {
 			host = gdctx.HostIP
 		}
 		if port == "" {
-			port = config.GetString("defaultrpcport")
+			port = config.GetString("defaultpeerport")
 		}
-		config.SetDefault("rpcaddress", host+":"+port)
+		config.SetDefault("peeraddress", host+":"+port)
 	}
 
 	// If no IP is specified for etcd config options (defaults), set those.

--- a/glusterd.json.example
+++ b/glusterd.json.example
@@ -1,5 +1,5 @@
 {
   "localstatedir": "/var/lib/glusterd",
-  "rpcaddress": ":24008",
-  "restaddress":":24007"
+  "peeraddress": ":24008",
+  "clientaddress":":24007"
 }

--- a/glusterd.toml.example
+++ b/glusterd.toml.example
@@ -1,3 +1,3 @@
 localstatedir = "/var/lib/glusterd"
-rpcaddress = ":24008"
-restaddress = ":24007"
+peeraddress = ":24008"
+clientaddress = ":24007"

--- a/glusterd.yaml.example
+++ b/glusterd.yaml.example
@@ -1,3 +1,3 @@
 localstatedir: "/var/lib/glusterd"
-rpcaddress: ":24008"
-restaddress: ":24007"
+peeraddress: ":24008"
+clientaddress: ":24007"

--- a/peer/self.go
+++ b/peer/self.go
@@ -26,7 +26,7 @@ func AddSelfDetails() {
 	p := &Peer{
 		ID:        gdctx.MyUUID,
 		Name:      gdctx.HostName,
-		Addresses: []string{config.GetString("rpcaddress")},
+		Addresses: []string{config.GetString("peeraddress")},
 		MemberID:  memberID,
 	}
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -24,7 +24,7 @@ type GDRest struct {
 func New() *GDRest {
 	rest := &GDRest{}
 
-	rest.addr = config.GetString("restaddress")
+	rest.addr = config.GetString("clientaddress")
 
 	rest.Routes = mux.NewRouter()
 

--- a/rpc/server/listener.go
+++ b/rpc/server/listener.go
@@ -24,7 +24,7 @@ func StartListener() error {
 	server = grpc.NewServer()
 	registerServices(server)
 
-	listenAddr := config.GetString("rpcaddress")
+	listenAddr := config.GetString("peeraddress")
 
 	l, e := net.Listen("tcp", listenAddr)
 	if e != nil {

--- a/utils/peerutils.go
+++ b/utils/peerutils.go
@@ -17,7 +17,7 @@ func FormRemotePeerAddress(peeraddress string) (string, error) {
 		// net.SplitHostPort() returns an error if port is missing.
 		if strings.HasPrefix(err.Error(), "missing port in address") {
 			host = peeraddress
-			port = config.GetString("defaultrpcport")
+			port = config.GetString("defaultpeerport")
 		} else {
 			return "", err
 		}


### PR DESCRIPTION
The name of the configurable options should represent the services
provided or consumer of the port and not the protocol used.

* Renamed 'rpcaddress' to 'peeraddress': Denotes the address used
  for peer to peer communication.
* Renamed 'restaddress' to 'clientaddress': Denotes the address
  used by clients to communicate with glusterd2.

Coincidentally, these are analogous to those provided by etcd.

Signed-off-by: Prashanth Pai <ppai@redhat.com>