### PR TITLE
Introduce Sun RPC server

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: eac6c6f490bf391f9499c6ed9def32c0cbee9d07bc01ba7252394b6af9f6dc9d
-updated: 2017-01-20T14:41:12.05669937+05:30
+hash: a51607528ea804e610964a7488894bc01fec018763a5917e9d5bea7e0d83b1b4
+updated: 2017-01-20T18:04:12.05669937+05:30
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -150,6 +150,8 @@ imports:
   subpackages:
   - store
   - store/etcd
+- name: github.com/prashanthpai/sunrpc
+  version: b391efc699c0959743a585ad935ae75bc3414a5f
 - name: github.com/prometheus/client_golang
   version: e51041b3fa41cece0dca035740ba6411905be473
   subpackages:
@@ -165,6 +167,10 @@ imports:
   - model
 - name: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+- name: github.com/rasky/go-xdr
+  version: 0c28d859a3605aff6d82194ed425b9a85e5dbfee
+  subpackages:
+  - xdr2
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/soheilhy/cmux

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,3 +32,4 @@ import:
 - package: google.golang.org/grpc
   version: 1.0.4
 - package: github.com/soheilhy/cmux
+- package: github.com/prashanthpai/sunrpc

--- a/main.go
+++ b/main.go
@@ -11,9 +11,11 @@ import (
 	"github.com/gluster/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/peer"
 	"github.com/gluster/glusterd2/rpc/server"
+	"github.com/gluster/glusterd2/rpc/sunrpcserver"
 	"github.com/gluster/glusterd2/utils"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/prashanthpai/sunrpc"
 	"github.com/soheilhy/cmux"
 	flag "github.com/spf13/pflag"
 	config "github.com/spf13/viper"
@@ -116,12 +118,18 @@ func main() {
 
 	// Match connections
 	httpL := m.Match(cmux.HTTP1Fast())
-	// TODO: Add Sun RPC matcher / Any matcher here
+	sunrpcL := m.Match(sunrpc.CmuxMatcher())
 
 	// Start REST server and listen to HTTP requests from clients
 	err = gdctx.Rest.Serve(httpL)
 	if err != nil {
 		log.Fatal("Could not start GlusterD Rest Server. Aborting.")
+	}
+
+	// Start Sun RPC server and listen to requests from glusterfs clients
+	err = sunrpcserver.Start(sunrpcL)
+	if err != nil {
+		log.Fatal("Could not start Sun RPC server. Aborting.")
 	}
 
 	// Start serving client requests. This will start multiplexing the

--- a/rpc/sunrpcserver/dict.go
+++ b/rpc/sunrpcserver/dict.go
@@ -1,0 +1,149 @@
+package sunrpcserver
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+/*
+   Gluster dict serialized format:
+   ------------------------------------------------------
+   |  count | key len | val len | key     \0 | value    |
+   ------------------------------------------------------
+       4        4         4       <key len>   <value len>
+*/
+
+const (
+	dictHeaderLen = 4
+)
+
+// DictUnserialize unmarshals a slice of bytes into a map[string]string
+// Consumers of the map should typecast/extract information from the
+// map values which are of string type
+func DictUnserialize(buf []byte) (map[string]string, error) {
+
+	newDict := make(map[string]string)
+	tmpHeader := make([]byte, dictHeaderLen)
+
+	var keyLen uint32
+	var valueLen uint32
+
+	reader := bytes.NewReader(buf)
+
+	// Extract dict count
+	reader.Read(tmpHeader)
+	count := int(binary.BigEndian.Uint32(tmpHeader))
+
+	if count < 0 {
+		return nil, errors.New("Invalid dict count")
+	}
+
+	for i := 0; i < count; i++ {
+		// Read key length
+		reader.Read(tmpHeader)
+		keyLen = binary.BigEndian.Uint32(tmpHeader)
+
+		// Read value length
+		reader.Read(tmpHeader)
+		valueLen = binary.BigEndian.Uint32(tmpHeader)
+
+		// Read key
+		key := make([]byte, keyLen+1) // +1 for '/0'
+		reader.Read(key)
+
+		// Read value
+		value := make([]byte, valueLen)
+		reader.Read(value)
+
+		// Strings aren't NULL terminated in Go
+		newDict[string(key[:len(key)-1])] = string(value)
+	}
+
+	return newDict, nil
+}
+
+// DictSerialize marshals a map[string]string into a slice of bytes.
+func DictSerialize(dict map[string]string) ([]byte, error) {
+
+	dictSerializedSize, err := getSerializedDictLen(dict)
+	if err != nil {
+		return nil, err
+	}
+
+	// Force buffer to have fixed size by setting desired capacity
+	// but a length of 0
+	buffer := bytes.NewBuffer(make([]byte, 0, dictSerializedSize))
+	tmpHeader := make([]byte, dictHeaderLen)
+	var totalBytesWritten int
+
+	// Write dict count
+	count := len(dict)
+	binary.BigEndian.PutUint32(tmpHeader, uint32(count))
+	bytesWritten, err := buffer.Write(tmpHeader)
+	if err != nil {
+		return nil, err
+	}
+	totalBytesWritten += bytesWritten
+
+	for key, value := range dict {
+
+		// write key length
+		binary.BigEndian.PutUint32(tmpHeader, uint32(len(key)))
+		bytesWritten, err := buffer.Write(tmpHeader)
+		if err != nil {
+			return nil, err
+		}
+		totalBytesWritten += bytesWritten
+
+		// write value length
+		binary.BigEndian.PutUint32(tmpHeader, uint32(len(value)))
+		bytesWritten, err = buffer.Write(tmpHeader)
+		if err != nil {
+			return nil, err
+		}
+		totalBytesWritten += bytesWritten
+
+		// write key + '\0'
+		bytesWritten, err = buffer.Write([]byte(key))
+		if err != nil {
+			return nil, err
+		}
+		totalBytesWritten += bytesWritten
+		bytesWritten, err = buffer.Write([]byte("\x00"))
+		if err != nil {
+			return nil, err
+		}
+		totalBytesWritten += bytesWritten
+
+		// write value
+		bytesWritten, err = buffer.Write([]byte(value))
+		if err != nil {
+			return nil, err
+		}
+		totalBytesWritten += bytesWritten
+
+	}
+
+	if dictSerializedSize != totalBytesWritten {
+		return nil, errors.New("Dict serialized size mismatch")
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func getSerializedDictLen(dict map[string]string) (int, error) {
+
+	if dict == nil || len(dict) == 0 {
+		return 0, errors.New("Nil or empty dict")
+	}
+
+	totalSize := int(dictHeaderLen) // dict count
+	for key, value := range dict {
+		// Key length and value length
+		totalSize += dictHeaderLen + dictHeaderLen
+		totalSize += (len(key) + 1) + len(value)
+	}
+
+	return totalSize, nil
+}

--- a/rpc/sunrpcserver/handshake_prog.go
+++ b/rpc/sunrpcserver/handshake_prog.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gluster/glusterd2/utils"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
 )
 
@@ -100,14 +101,14 @@ func (t *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 
 	_, err = DictUnserialize(args.Xdata)
 	if err != nil {
-		fmt.Println(err)
+		log.WithError(err).Error("ServerGetspec(): DictUnserialize() failed")
 		goto Out
 	}
 
 	volFilePath = path.Join(utils.GetVolumeDir(args.Key), fmt.Sprintf("trusted-%s.tcp-fuse.vol", args.Key))
 	fileContents, err = ioutil.ReadFile(volFilePath)
 	if err != nil {
-		fmt.Println(err)
+		log.WithError(err).Error("ServerGetspec(): Could not read client volfile")
 		goto Out
 	}
 	reply.Spec = string(fileContents)

--- a/rpc/sunrpcserver/handshake_prog.go
+++ b/rpc/sunrpcserver/handshake_prog.go
@@ -1,0 +1,124 @@
+package sunrpcserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/rpc"
+	"path"
+
+	"github.com/gluster/glusterd2/utils"
+
+	"github.com/prashanthpai/sunrpc"
+)
+
+// TODO: The enum names here are copied from gluster code for simplicity.
+// golint checks will fail.
+
+const (
+	GLUSTER_HNDSK_PROGRAM uint32 = 14398633
+	GLUSTER_HNDSK_VERSION uint32 = 2
+)
+
+const (
+	// rpc/rpc-lib/src/protocol-common.h
+	GF_HNDSK_NULL uint32 = iota
+	GF_HNDSK_SETVOLUME
+	GF_HNDSK_GETSPEC // 2
+	GF_HNDSK_PING
+	GF_HNDSK_SET_LK_VER
+	GF_HNDSK_EVENT_NOTIFY
+	GF_HNDSK_GET_VOLUME_INFO
+	GF_HNDSK_GET_SNAPSHOT_INFO
+	GF_HNDSK_MAXVALUE
+)
+
+func registerHandshakeProgram(server *rpc.Server, port int) error {
+
+	err := server.Register(new(GfHandshake))
+	if err != nil {
+		return err
+	}
+
+	// TODO: As the number of procedures to be registered grows, we need
+	// to make this boilerplate code less verbose by following some
+	// naming conventions for the enums or procedures themselves.
+	err = sunrpc.RegisterProcedure(
+		sunrpc.ProcedureID{
+			GLUSTER_HNDSK_PROGRAM,
+			GLUSTER_HNDSK_VERSION,
+			GF_HNDSK_GETSPEC,
+		},
+		"GfHandshake.ServerGetspec")
+	if err != nil {
+		return err
+	}
+
+	if port != 0 {
+		_, err = sunrpc.PmapUnset(GLUSTER_HNDSK_PROGRAM, GLUSTER_HNDSK_VERSION)
+		if err != nil {
+			return err
+		}
+
+		_, err = sunrpc.PmapSet(
+			GLUSTER_HNDSK_PROGRAM, GLUSTER_HNDSK_VERSION,
+			sunrpc.IPProtoTCP, uint32(port))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GfGetspecReq is sent by glusterfs client and primarily contains volume name.
+// Xdata field is a serialized gluster dict containing op version.
+type GfGetspecReq struct {
+	Flags uint
+	Key   string // volume name
+	Xdata []byte // serialized dict
+}
+
+// GfGetspecRsp is response sent to glusterfs client in response to a
+// GfGetspecReq request
+type GfGetspecRsp struct {
+	OpRet   int
+	OpErrno int
+	Spec    string // volfile contents
+	Xdata   []byte // serialized dict
+}
+
+// GfHandshake is a placeholder type for all functions of GlusterFS Handshake
+// RPC program
+type GfHandshake int32
+
+// ServerGetspec returns the content of client volfile for the volume
+// specified by the client
+func (t *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) error {
+	var err error
+	var fileContents []byte
+	var volFilePath string
+
+	_, err = DictUnserialize(args.Xdata)
+	if err != nil {
+		fmt.Println(err)
+		goto Out
+	}
+
+	volFilePath = path.Join(utils.GetVolumeDir(args.Key), fmt.Sprintf("trusted-%s.tcp-fuse.vol", args.Key))
+	fileContents, err = ioutil.ReadFile(volFilePath)
+	if err != nil {
+		fmt.Println(err)
+		goto Out
+	}
+	reply.Spec = string(fileContents)
+	reply.OpRet = len(reply.Spec)
+	reply.OpErrno = 0
+
+Out:
+	if err != nil {
+		reply.OpRet = -1
+		reply.OpErrno = 0
+	}
+
+	return nil
+}

--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -1,0 +1,68 @@
+package sunrpcserver
+
+/* TODO:
+The rpc/* directory needs a more elegant subpackage structuring.
+Something like shown below but without package names conflicting with
+imported package names.
+
+    server -
+           |- grpc
+           |- sunrpc
+           |- rest
+
+Each subpackage will implement the server for that protocol.
+*/
+
+import (
+	"net"
+	"net/rpc"
+	"strconv"
+
+	"github.com/prashanthpai/sunrpc"
+)
+
+func getPortFromListener(listener net.Listener) int {
+
+	if listener == nil {
+		return 0
+	}
+
+	addr := listener.Addr().String()
+	_, portString, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0
+	}
+
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return 0
+	}
+
+	return port
+}
+
+// Start will start accepting Sun RPC client connections on the listener
+// provided.
+func Start(listener net.Listener) error {
+
+	// There is no graceful shutdown of Sun RPC server yet. So this
+	// instance doesn't have to be global variable or attached to gdctx.
+	server := rpc.NewServer()
+
+	err := registerHandshakeProgram(server, getPortFromListener(listener))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go server.ServeRequest(sunrpc.NewServerCodec(conn))
+		}
+	}()
+
+	return nil
+}

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -7,7 +7,7 @@
 
 RETVAL=0
 
-for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -not -name '*.pb.go' -print); do
+for file in $(find . -path ./vendor -prune -o -path ./rpc/sunrpcserver -prune -o -type f -name '*.go' -not -name '*.pb.go' -print); do
   golint -set_exit_status $file
   if [ $? -eq 1 -a $RETVAL -eq 0 ]; then
     RETVAL=1


### PR DESCRIPTION
The client port will now be used for serving both HTTP client requests
and also Sun RPC requests. This initial patch implements the getspec
function. Other functions can be added later.

Closes issue #224 

Signed-off-by: Prashanth Pai <ppai@redhat.com>