### PR TITLE
Add mount rpc programs

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -168,7 +168,7 @@ imports:
 - name: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 - name: github.com/rasky/go-xdr
-  version: 0c28d859a3605aff6d82194ed425b9a85e5dbfee
+  version: 1a41d1a06c93bf8a0e0385be3847a277bb793187
   subpackages:
   - xdr2
 - name: github.com/Sirupsen/logrus

--- a/rpc/sunrpcserver/common.go
+++ b/rpc/sunrpcserver/common.go
@@ -1,0 +1,8 @@
+package sunrpcserver
+
+// GfCommonRsp is a generic RPC response type
+type GfCommonRsp struct {
+	OpRet   int
+	OpErrno int
+	Xdata   []byte
+}

--- a/rpc/sunrpcserver/dump_prog.go
+++ b/rpc/sunrpcserver/dump_prog.go
@@ -1,0 +1,90 @@
+package sunrpcserver
+
+// GfDump is a type for GlusterFS Dump RPC program
+type GfDump genericProgram
+
+func newGfDump() *GfDump {
+	// rpc/rpc-lib/src/xdr-common.h
+	return &GfDump{
+		name:        "GF-DUMP",
+		progNum:     uint32(123451501),
+		progVersion: uint32(1),
+		procedures: []Procedure{
+			Procedure{uint32(1), "Dump"}, // GF_DUMP_DUMP
+			Procedure{uint32(2), "Ping"}, // GF_DUMP_PING
+		},
+	}
+}
+
+// Name returns the name of the RPC program
+func (p *GfDump) Name() string {
+	return p.name
+}
+
+// Number returns the RPC Program number
+func (p *GfDump) Number() uint32 {
+	return p.progNum
+}
+
+// Version returns the RPC program version number
+func (p *GfDump) Version() uint32 {
+	return p.progVersion
+}
+
+// Procedures returns a list of procedures provided by the RPC program
+func (p *GfDump) Procedures() []Procedure {
+	return p.procedures
+}
+
+// GfDumpReq is request sent by the client
+type GfDumpReq struct {
+	GfsID uint64
+}
+
+// GfProcDetail contains details for individual RPC program
+type GfProcDetail struct {
+	ProgName string
+	ProgNum  uint64
+	ProgVer  uint64
+	Next     *GfProcDetail `xdr:"optional"`
+}
+
+// GfDumpRsp is response sent by server. It contains a list of GfProcDetail
+type GfDumpRsp struct {
+	GfsID   uint64
+	OpRet   int
+	OpErrno int
+	Prog    *GfProcDetail `xdr:"optional"`
+}
+
+// Dump will return a list of all available RPC programs
+func (p *GfDump) Dump(args *GfDumpReq, reply *GfDumpRsp) error {
+
+	// TODO: I don't like doing this in Go. Should abstract it.
+	var list *GfProcDetail
+	var trav *GfProcDetail
+
+	for _, p := range programsList {
+		tmp := &GfProcDetail{
+			ProgName: p.Name(),
+			ProgNum:  uint64(p.Number()),
+			ProgVer:  uint64(p.Version()),
+		}
+		if list == nil {
+			list = tmp
+			trav = list
+		} else {
+			trav.Next = tmp
+			trav = trav.Next
+		}
+	}
+	reply.Prog = list
+
+	return nil
+}
+
+// Ping is for availability check
+func (p *GfDump) Ping(_ *struct{}, reply *GfCommonRsp) error {
+
+	return nil
+}

--- a/rpc/sunrpcserver/handshake_prog.go
+++ b/rpc/sunrpcserver/handshake_prog.go
@@ -3,72 +3,46 @@ package sunrpcserver
 import (
 	"fmt"
 	"io/ioutil"
-	"net/rpc"
 	"path"
 
 	"github.com/gluster/glusterd2/utils"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/prashanthpai/sunrpc"
 )
 
-// TODO: The enum names here are copied from gluster code for simplicity.
-// golint checks will fail.
+// GfHandshake is a type for GlusterFS Handshake RPC program
+type GfHandshake genericProgram
 
-const (
-	GLUSTER_HNDSK_PROGRAM uint32 = 14398633
-	GLUSTER_HNDSK_VERSION uint32 = 2
-)
-
-const (
+func newGfHandshake() *GfHandshake {
 	// rpc/rpc-lib/src/protocol-common.h
-	GF_HNDSK_NULL uint32 = iota
-	GF_HNDSK_SETVOLUME
-	GF_HNDSK_GETSPEC // 2
-	GF_HNDSK_PING
-	GF_HNDSK_SET_LK_VER
-	GF_HNDSK_EVENT_NOTIFY
-	GF_HNDSK_GET_VOLUME_INFO
-	GF_HNDSK_GET_SNAPSHOT_INFO
-	GF_HNDSK_MAXVALUE
-)
-
-func registerHandshakeProgram(server *rpc.Server, port int) error {
-
-	err := server.Register(new(GfHandshake))
-	if err != nil {
-		return err
-	}
-
-	// TODO: As the number of procedures to be registered grows, we need
-	// to make this boilerplate code less verbose by following some
-	// naming conventions for the enums or procedures themselves.
-	err = sunrpc.RegisterProcedure(
-		sunrpc.ProcedureID{
-			GLUSTER_HNDSK_PROGRAM,
-			GLUSTER_HNDSK_VERSION,
-			GF_HNDSK_GETSPEC,
+	return &GfHandshake{
+		name:        "Gluster Handshake",
+		progNum:     uint32(14398633),
+		progVersion: uint32(2),
+		procedures: []Procedure{
+			Procedure{uint32(2), "ServerGetspec"}, // GF_HNDSK_GETSPEC
 		},
-		"GfHandshake.ServerGetspec")
-	if err != nil {
-		return err
 	}
+}
 
-	if port != 0 {
-		_, err = sunrpc.PmapUnset(GLUSTER_HNDSK_PROGRAM, GLUSTER_HNDSK_VERSION)
-		if err != nil {
-			return err
-		}
+// Name returns the name of the RPC program
+func (p *GfHandshake) Name() string {
+	return p.name
+}
 
-		_, err = sunrpc.PmapSet(
-			GLUSTER_HNDSK_PROGRAM, GLUSTER_HNDSK_VERSION,
-			sunrpc.IPProtoTCP, uint32(port))
-		if err != nil {
-			return err
-		}
-	}
+// Number returns the RPC Program number
+func (p *GfHandshake) Number() uint32 {
+	return p.progNum
+}
 
-	return nil
+// Version returns the RPC program version number
+func (p *GfHandshake) Version() uint32 {
+	return p.progVersion
+}
+
+// Procedures returns a list of procedures provided by the RPC program
+func (p *GfHandshake) Procedures() []Procedure {
+	return p.procedures
 }
 
 // GfGetspecReq is sent by glusterfs client and primarily contains volume name.
@@ -88,13 +62,9 @@ type GfGetspecRsp struct {
 	Xdata   []byte // serialized dict
 }
 
-// GfHandshake is a placeholder type for all functions of GlusterFS Handshake
-// RPC program
-type GfHandshake int32
-
 // ServerGetspec returns the content of client volfile for the volume
 // specified by the client
-func (t *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) error {
+func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) error {
 	var err error
 	var fileContents []byte
 	var volFilePath string

--- a/rpc/sunrpcserver/portmap_prog.go
+++ b/rpc/sunrpcserver/portmap_prog.go
@@ -1,0 +1,71 @@
+package sunrpcserver
+
+// GfPortmap is a type for GlusterFS Portmap RPC program
+type GfPortmap genericProgram
+
+func newGfPortmap() *GfPortmap {
+	// rpc/rpc-lib/src/protocol-common.h
+	return &GfPortmap{
+		name:        "Gluster Portmap",
+		progNum:     uint32(34123456),
+		progVersion: uint32(1),
+		procedures: []Procedure{
+			Procedure{uint32(1), "PortByBrick"}, // GF_PMAP_PORTBYBRICK
+		},
+	}
+}
+
+// Name returns the name of the RPC program
+func (p *GfPortmap) Name() string {
+	return p.name
+}
+
+// Number returns the RPC Program number
+func (p *GfPortmap) Number() uint32 {
+	return p.progNum
+}
+
+// Version returns the RPC program version number
+func (p *GfPortmap) Version() uint32 {
+	return p.progVersion
+}
+
+// Procedures returns a list of procedures provided by the RPC program
+func (p *GfPortmap) Procedures() []Procedure {
+	return p.procedures
+}
+
+// PmapPortByBrickReq is sent by the glusterfs client
+type PmapPortByBrickReq struct {
+	Brick string
+}
+
+// PmapPortByBrickRsp is sent to glusterfs client and contains the port
+// for the brick requested
+type PmapPortByBrickRsp struct {
+	OpRet   int
+	OpErrno int
+	Status  int
+	Port    int
+}
+
+// PortByBrick will return port number for the brick specified
+func (p *GfPortmap) PortByBrick(args *PmapPortByBrickReq, reply *PmapPortByBrickRsp) error {
+	// TODO: Do the real thing. Glusterd2 as of now, doesn't store brick
+	// port information in brickinfo. So can't return the ports. The
+	// following code just demonstrates that when glusterd2 does have
+	// that information, this will just work.
+
+	switch {
+	case args.Brick == "/export/brick1/data":
+		reply.Port = 49152
+	case args.Brick == "/export/brick2/data":
+		reply.Port = 49153
+	case args.Brick == "/export/brick3/data":
+		reply.Port = 49154
+	case args.Brick == "/export/brick4/data":
+		reply.Port = 49155
+	}
+
+	return nil
+}

--- a/rpc/sunrpcserver/program.go
+++ b/rpc/sunrpcserver/program.go
@@ -1,0 +1,71 @@
+package sunrpcserver
+
+import (
+	"net/rpc"
+	"reflect"
+
+	"github.com/prashanthpai/sunrpc"
+)
+
+// Procedure represents a procedure number, procedure name pair
+type Procedure struct {
+	Number uint32
+	Name   string
+}
+
+// Program is an interface that every RPC program should implement
+type Program interface {
+	Name() string
+	Number() uint32
+	Version() uint32
+	Procedures() []Procedure
+}
+
+// RPC program implementations can use this type for convenience
+type genericProgram struct {
+	name        string
+	progNum     uint32
+	progVersion uint32
+	procedures  []Procedure
+}
+
+func registerProgram(server *rpc.Server, program Program, port int) error {
+
+	// NOTE: This will throw some benign log messages complaining about
+	// signatures of methods in Program interface. rpc.Server.Register()
+	// expects all methods of program to be of the kind:
+	//         func (t *T) MethodName(argType T1, replyType *T2) error
+	// These log entries (INFO) can be ignored.
+	err := server.Register(program)
+	if err != nil {
+		return err
+	}
+
+	// Create procedure number to procedure name mappings for sunrpc codec
+	typeName := reflect.Indirect(reflect.ValueOf(program)).Type().Name()
+	for _, procedure := range program.Procedures() {
+		err = sunrpc.RegisterProcedure(
+			sunrpc.ProcedureID{
+				program.Number(),
+				program.Version(),
+				procedure.Number,
+			}, typeName+"."+procedure.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	if port != 0 {
+		_, err = sunrpc.PmapUnset(program.Number(), program.Version())
+		if err != nil {
+			return err
+		}
+
+		_, err = sunrpc.PmapSet(program.Number(), program.Version(), sunrpc.IPProtoTCP, uint32(port))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -63,7 +63,7 @@ func Start(listener net.Listener) error {
 	for _, program := range programsList {
 		err := registerProgram(server, program, port)
 		if err != nil {
-			log.WithError(err).Error("Could not register RPC program %s", program.Name())
+			log.WithError(err).Error("Could not register RPC program " + program.Name())
 			return err
 		}
 	}

--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -23,6 +23,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+var programsList []Program
+
 func getPortFromListener(listener net.Listener) int {
 
 	if listener == nil {
@@ -51,10 +53,17 @@ func Start(listener net.Listener) error {
 	// instance doesn't have to be global variable or attached to gdctx.
 	server := rpc.NewServer()
 
-	err := registerHandshakeProgram(server, getPortFromListener(listener))
-	if err != nil {
-		log.WithError(err).Error("Could not register handshake program")
-		return err
+	port := getPortFromListener(listener)
+
+	programsList = append(programsList, newGfHandshake())
+
+	// Register all programs
+	for _, program := range programsList {
+		err := registerProgram(server, program, port)
+		if err != nil {
+			log.WithError(err).Error("Could not register RPC program %s", program.Name())
+			return err
+		}
 	}
 
 	go func() {

--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -57,6 +57,7 @@ func Start(listener net.Listener) error {
 
 	programsList = append(programsList, newGfHandshake())
 	programsList = append(programsList, newGfDump())
+	programsList = append(programsList, newGfPortmap())
 
 	// Register all programs
 	for _, program := range programsList {

--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -56,6 +56,7 @@ func Start(listener net.Listener) error {
 	port := getPortFromListener(listener)
 
 	programsList = append(programsList, newGfHandshake())
+	programsList = append(programsList, newGfDump())
 
 	// Register all programs
 	for _, program := range programsList {

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -7,7 +7,7 @@
 
 RETVAL=0
 
-for file in $(find . -path ./vendor -prune -o -path ./rpc/sunrpcserver -prune -o -type f -name '*.go' -not -name '*.pb.go' -print); do
+for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -not -name '*.pb.go' -print); do
   golint -set_exit_status $file
   if [ $? -eq 1 -a $RETVAL -eq 0 ]; then
     RETVAL=1


### PR DESCRIPTION
This PR refactors and simplifies the process of adding new RPC programs
and new procedures. Following RPC programs have been introduced
(procedures are not exhaustive yet) on top of it:

`Glusterfs Handshake`
`Gluster Dump`
`GlusterFS Portmap`