### PR TITLE
Use ServeCodec in sunrpc server

### DIFF
--- a/rpc/sunrpcserver/server.go
+++ b/rpc/sunrpcserver/server.go
@@ -84,7 +84,7 @@ func Start(listener net.Listener) error {
 				return
 			}
 			log.WithField("address", conn.RemoteAddr().String()).Info("glusterfs client connected")
-			go server.ServeRequest(sunrpc.NewServerCodec(conn))
+			go server.ServeCodec(sunrpc.NewServerCodec(conn))
 		}
 	}()
 


### PR DESCRIPTION
ServeRequest synchronously serves a single request. ServeCodec runs
the server on a single connection. ServeConn blocks, serving the
connection until the client hangs up.

Signed-off-by: Prashanth Pai <ppai@redhat.com>