### PR TITLE
Do not wipe etcd local data on glusterd2 exit

### DIFF
--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -94,8 +94,8 @@ func (p *PeerService) ExportAndStoreETCDConfig(nc netctx.Context, c *EtcdConfigR
 		newEtcdConfig.Dir = newEtcdConfig.Name + ".etcd"
 	}
 
-	// Gracefully stop embedded etcd server
-	err = etcdmgmt.DestroyEmbeddedEtcd()
+	// Gracefully stop embedded etcd server and remove local etcd data
+	err = etcdmgmt.DestroyEmbeddedEtcd(true)
 	if err != nil {
 		opRet = -1
 		opError = fmt.Sprintf("Error stopping embedded etcd server.")

--- a/etcdmgmt/server.go
+++ b/etcdmgmt/server.go
@@ -50,8 +50,8 @@ func StartEmbeddedEtcd(cfg *embed.Config) error {
 }
 
 // DestroyEmbeddedEtcd will gracefully shut down the embedded etcd server and
-// deletes the etcd data directory.
-func DestroyEmbeddedEtcd() error {
+// optionally deletes the etcd data directory.
+func DestroyEmbeddedEtcd(deleteData bool) error {
 
 	etcdInstance.Lock()
 	defer etcdInstance.Unlock()
@@ -66,17 +66,21 @@ func DestroyEmbeddedEtcd() error {
 	etcdInstance.etcd = nil
 	log.Info("Etcd embedded server is stopped.")
 
-	err := os.RemoveAll(etcdConfig.Dir)
-	if err != nil {
-		return errors.New("Could not delete etcd data dir")
-	}
+	if deleteData {
+		err := os.RemoveAll(etcdConfig.Dir)
+		if err != nil {
+			return errors.New("Could not delete etcd data dir")
+		}
 
-	err = os.RemoveAll(etcdConfig.WalDir)
-	if err != nil {
-		return errors.New("Could not delete etcd WAL dir")
-	}
+		err = os.RemoveAll(etcdConfig.WalDir)
+		if err != nil {
+			return errors.New("Could not delete etcd WAL dir")
+		}
 
-	os.Remove(EtcdConfigFile)
+		os.Remove(EtcdConfigFile)
+
+		log.Info("Etcd data dir, WAL dir and config file removed")
+	}
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -84,7 +84,8 @@ func main() {
 		switch s {
 		case os.Interrupt:
 			log.WithField("signal", s).Info("Recieved SIGTERM. Stopping GlusterD.")
-			etcdmgmt.DestroyEmbeddedEtcd()
+			// Stop embedded etcd server, but don't wipe local etcd data
+			etcdmgmt.DestroyEmbeddedEtcd(false)
 			super.Stop()
 			log.Info("Terminating GlusterD.")
 			return


### PR DESCRIPTION
The etcd data dir, WAL dir and config file should only be wiped during
peer add and peer delete operations.

Closes #232 

Signed-off-by: Prashanth Pai <ppai@redhat.com>