### PR TITLE
Fix glusterfsd crash on glusterfs master

### DIFF
--- a/brick/brick.go
+++ b/brick/brick.go
@@ -76,6 +76,7 @@ func (b *Brick) Args() string {
 
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf(" --volfile %s", volfile))
+	buffer.WriteString(fmt.Sprintf(" --volfile-id %s", b.volName))
 	buffer.WriteString(fmt.Sprintf(" -p %s", b.PidFile()))
 	buffer.WriteString(fmt.Sprintf(" -S %s", b.SocketFile()))
 	buffer.WriteString(fmt.Sprintf(" --brick-name %s", b.brickinfo.Path))


### PR DESCRIPTION
This originated from the recent brick multiplex merge.
Here's the symptomatic fix in gluster for the crash.

	diff --git a/xlators/protocol/server/src/server.c b/xlators/protocol/server/src/server.c
	index 5be900a..ed34aba 100644
	--- a/xlators/protocol/server/src/server.c
	+++ b/xlators/protocol/server/src/server.c
	@@ -1236,8 +1236,10 @@ init (xlator_t *this)
		 }
	 #endif

	-        FIRST_CHILD(this)->volfile_id
	-                = gf_strdup (this->ctx->cmd_args.volfile_id);
	+        if (this->ctx->cmd_args.volfile_id) {
	+                FIRST_CHILD(this)->volfile_id
	+                        = gf_strdup (this->ctx->cmd_args.volfile_id);
	+        }

		 this->private = conf;
		 ret = 0;

Signed-off-by: Prashanth Pai <ppai@redhat.com>