### PR TITLE
Get notified on sunrpc clients' disconnection

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 38c3f58b273d37f80ef907a5eff25b8ad61db07e3ef6db77b3f0d814286015e2
-updated: 2017-01-30T18:13:38.046511822+05:30
+updated: 2017-02-03T17:09:06.754520623+05:30
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -149,7 +149,7 @@ imports:
   - store
   - store/etcd
 - name: github.com/prashanthpai/sunrpc
-  version: b391efc699c0959743a585ad935ae75bc3414a5f
+  version: 9e68531510599fb5e0f3f00f9f736509ff81d5fb
 - name: github.com/prometheus/client_golang
   version: e51041b3fa41cece0dca035740ba6411905be473
   subpackages:


### PR DESCRIPTION
sunrpc codec can now notify (via a channel) whenever a sunrpc client
connection is closed. The sunrpc server maintains a list of clients
which is updated on connection and disconnection.
    
But there is no provision yet to know if these sunrpc clients are
glusterfs mount processes or something else.
