### PR TITLE
plugins: Glusterd2 Plugins Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ _projects/
 # Ignore build and release directories
 build/
 releases/
+# Generated file
+plugins/plugins.go
+*.etcd
+uuid

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GOPATH := $(shell go env GOPATH)
 GOBIN := '$(GOPATH)/bin'
+PLUGINSDIR = "plugins"
 
 .PHONY: all build check check-go check-reqs install vendor-update verify glusterd2 release check-protoc
 
@@ -22,6 +23,7 @@ check-reqs:
 	@echo
 
 glusterd2:
+	@./scripts/detect-plugins.sh > $(PLUGINSDIR)/plugins.go
 	@./scripts/build.sh
 	@echo
 

--- a/plugins/common.go
+++ b/plugins/common.go
@@ -1,0 +1,12 @@
+package plugins
+
+import (
+	"github.com/gluster/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+)
+
+type Gd2Plugin interface{
+	SunRpcProcedures() program.Program
+	RestRoutes() route.Routes
+	RegisterStepFuncs()
+}

--- a/plugins/dump/init.go
+++ b/plugins/dump/init.go
@@ -1,0 +1,22 @@
+package dumpplugin
+
+import (
+	"github.com/gluster/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+)
+
+
+type DumpPlugin struct{
+}
+
+func (p *DumpPlugin) SunRpcProcedures() program.Program {
+	return &GfDump{}
+}
+
+func (p *DumpPlugin) RestRoutes() route.Routes {
+	return nil
+}
+
+func (p *DumpPlugin) RegisterStepFuncs() {
+	return
+}

--- a/plugins/dump/sunrpc.go
+++ b/plugins/dump/sunrpc.go
@@ -1,6 +1,12 @@
-package sunrpc
+package dumpplugin
+
+import (
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+	"github.com/gluster/glusterd2/servers/sunrpc/common"
+)
 
 const (
+	dumpProgName    = "GF-DUMP"
 	dumpProgNum     = 123451501
 	dumpProgVersion = 1
 )
@@ -12,39 +18,30 @@ const (
 )
 
 // GfDump is a type for GlusterFS Dump RPC program
-type GfDump genericProgram
-
-func newGfDump() *GfDump {
-	// rpc/rpc-lib/src/xdr-common.h
-	return &GfDump{
-		name:        "GF-DUMP",
-		progNum:     dumpProgNum,
-		progVersion: dumpProgVersion,
-		procedures: []Procedure{
-			Procedure{gfDumpDump, "Dump"}, // GF_DUMP_DUMP
-			Procedure{gfDumpPing, "Ping"}, // GF_DUMP_PING
-		},
-	}
-}
+// rpc/rpc-lib/src/xdr-common.h
+type GfDump struct{}
 
 // Name returns the name of the RPC program
 func (p *GfDump) Name() string {
-	return p.name
+	return dumpProgName
 }
 
 // Number returns the RPC Program number
 func (p *GfDump) Number() uint32 {
-	return p.progNum
+	return dumpProgNum
 }
 
 // Version returns the RPC program version number
 func (p *GfDump) Version() uint32 {
-	return p.progVersion
+	return dumpProgVersion
 }
 
 // Procedures returns a list of procedures provided by the RPC program
-func (p *GfDump) Procedures() []Procedure {
-	return p.procedures
+func (p *GfDump) Procedures() []program.Procedure {
+	return []program.Procedure{
+		program.Procedure{gfDumpDump, "Dump"}, // GF_DUMP_DUMP
+		program.Procedure{gfDumpPing, "Ping"}, // GF_DUMP_PING
+	}
 }
 
 // GfDumpReq is request sent by the client
@@ -75,7 +72,7 @@ func (p *GfDump) Dump(args *GfDumpReq, reply *GfDumpRsp) error {
 	var list *GfProcDetail
 	var trav *GfProcDetail
 
-	for _, p := range programsList {
+	for _, p := range program.ProgramsList {
 		tmp := &GfProcDetail{
 			ProgName: p.Name(),
 			ProgNum:  uint64(p.Number()),
@@ -95,7 +92,7 @@ func (p *GfDump) Dump(args *GfDumpReq, reply *GfDumpRsp) error {
 }
 
 // Ping is for availability check
-func (p *GfDump) Ping(_ *struct{}, reply *GfCommonRsp) error {
+func (p *GfDump) Ping(_ *struct{}, reply *common.GfCommonRsp) error {
 
 	return nil
 }

--- a/plugins/hello/init.go
+++ b/plugins/hello/init.go
@@ -1,0 +1,35 @@
+package helloplugin
+
+import (
+	"github.com/gluster/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+)
+
+
+type HelloPlugin struct{
+}
+
+func (p *HelloPlugin) SunRpcProcedures() program.Program {
+	return nil
+}
+
+func (p *HelloPlugin) RestRoutes() route.Routes {
+	return route.Routes{
+		route.Route{
+			Name:        "HelloGet",
+			Method:      "GET",
+			Pattern:     "/hello",
+			Version:     1,
+			HandlerFunc: helloGetHandler},
+		route.Route{
+			Name:        "HelloPost",
+			Method:      "POST",
+			Pattern:     "/hello",
+			Version:     1,
+			HandlerFunc: helloPostHandler},
+	}
+}
+
+func (p *HelloPlugin) RegisterStepFuncs() {
+	return
+}

--- a/plugins/hello/rest.go
+++ b/plugins/hello/rest.go
@@ -1,0 +1,15 @@
+package helloplugin
+
+import (
+	"net/http"
+
+	restutils "github.com/gluster/glusterd2/servers/rest/utils"
+)
+
+func helloGetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Hello Get")
+}
+
+func helloPostHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Hello Post")
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,0 +1,11 @@
+package plugins
+
+import (
+	"github.com/gluster/glusterd2/plugins/dump"
+	"github.com/gluster/glusterd2/plugins/hello"
+)
+
+var PluginsList = []Gd2Plugin{
+	&dumpplugin.DumpPlugin{},
+	&helloplugin.HelloPlugin{},
+}

--- a/scripts/detect-plugins.sh
+++ b/scripts/detect-plugins.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script fetches the list of plugins avalable in plugins directory
+
+IMPORT_PREFIX=github.com/gluster/glusterd2/plugins
+echo "package plugins"
+echo
+
+echo "import ("
+cd "plugins"
+for p in `ls -d */`
+do
+    # ${p%/} is to remove trailing slash
+    echo -e "\t\"${IMPORT_PREFIX}/${p%/}\""
+done
+echo ")"
+
+echo
+echo "var PluginsList = []Gd2Plugin{"
+
+for p in `ls -d */`
+do
+    p=${p%/}
+    # Like &helloplugin.HelloPlugin{}
+    echo -e "\t&${p}plugin.${p^}Plugin{},"
+done
+
+echo "}"

--- a/servers/rest/routes.go
+++ b/servers/rest/routes.go
@@ -2,9 +2,11 @@ package rest
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/gluster/glusterd2/commands"
 	"github.com/gluster/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/plugins"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -38,5 +40,15 @@ func (r *GDRest) registerRoutes() {
 		//XXX: This doesn't feel like the right place to be register step
 		//functions, but until we have a better place it can stay here.
 		c.RegisterStepFuncs()
+	}
+
+	// Load routes and Step functions from Plugins
+	for _, p := range plugins.PluginsList{
+		restRoutes := p.RestRoutes()
+		if restRoutes != nil{
+			r.setRoutes(restRoutes)
+			log.WithField("plugin", reflect.TypeOf(p)).Debug("loaded REST routes from plugin")
+		}
+		p.RegisterStepFuncs()
 	}
 }

--- a/servers/sunrpc/common/common.go
+++ b/servers/sunrpc/common/common.go
@@ -1,4 +1,4 @@
-package sunrpc
+package common
 
 // GfCommonRsp is a generic RPC response type
 type GfCommonRsp struct {

--- a/servers/sunrpc/handshake_prog.go
+++ b/servers/sunrpc/handshake_prog.go
@@ -6,7 +6,8 @@ import (
 	"path"
 
 	"github.com/gluster/glusterd2/utils"
-
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+	"github.com/gluster/glusterd2/servers/sunrpc/serialize"
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -26,8 +27,8 @@ func newGfHandshake() *GfHandshake {
 		name:        "Gluster Handshake",
 		progNum:     hndskProgNum,
 		progVersion: hndskProgVersion,
-		procedures: []Procedure{
-			Procedure{gfHndskGetSpec, "ServerGetspec"}, // GF_HNDSK_GETSPEC
+		procedures: []program.Procedure{
+			program.Procedure{gfHndskGetSpec, "ServerGetspec"}, // GF_HNDSK_GETSPEC
 		},
 	}
 }
@@ -48,7 +49,7 @@ func (p *GfHandshake) Version() uint32 {
 }
 
 // Procedures returns a list of procedures provided by the RPC program
-func (p *GfHandshake) Procedures() []Procedure {
+func (p *GfHandshake) Procedures() []program.Procedure {
 	return p.procedures
 }
 
@@ -76,7 +77,7 @@ func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 	var fileContents []byte
 	var volFilePath string
 
-	_, err = DictUnserialize(args.Xdata)
+	_, err = serialize.DictUnserialize(args.Xdata)
 	if err != nil {
 		log.WithError(err).Error("ServerGetspec(): DictUnserialize() failed")
 		goto Out

--- a/servers/sunrpc/portmap_prog.go
+++ b/servers/sunrpc/portmap_prog.go
@@ -1,5 +1,9 @@
 package sunrpc
 
+import (
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
+)
+
 const (
 	portmapProgNum     = 34123456
 	portmapProgVersion = 1
@@ -16,8 +20,8 @@ func newGfPortmap() *GfPortmap {
 		name:        "Gluster Portmap",
 		progNum:     portmapProgNum,
 		progVersion: portmapProgVersion,
-		procedures: []Procedure{
-			Procedure{gfPmapPortByBrick, "PortByBrick"}, // GF_PMAP_PORTBYBRICK
+		procedures: []program.Procedure{
+			program.Procedure{gfPmapPortByBrick, "PortByBrick"}, // GF_PMAP_PORTBYBRICK
 		},
 	}
 }
@@ -38,7 +42,7 @@ func (p *GfPortmap) Version() uint32 {
 }
 
 // Procedures returns a list of procedures provided by the RPC program
-func (p *GfPortmap) Procedures() []Procedure {
+func (p *GfPortmap) Procedures() []program.Procedure {
 	return p.procedures
 }
 

--- a/servers/sunrpc/program.go
+++ b/servers/sunrpc/program.go
@@ -4,33 +4,20 @@ import (
 	"net/rpc"
 	"reflect"
 
+	"github.com/gluster/glusterd2/servers/sunrpc/program"
 	log "github.com/Sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
 )
-
-// Procedure represents a procedure number, procedure name pair
-type Procedure struct {
-	Number uint32
-	Name   string
-}
-
-// Program is an interface that every RPC program should implement
-type Program interface {
-	Name() string
-	Number() uint32
-	Version() uint32
-	Procedures() []Procedure
-}
 
 // RPC program implementations can use this type for convenience
 type genericProgram struct {
 	name        string
 	progNum     uint32
 	progVersion uint32
-	procedures  []Procedure
+	procedures  []program.Procedure
 }
 
-func registerProgram(server *rpc.Server, program Program, port int) error {
+func registerProgram(server *rpc.Server, program program.Program, port int) error {
 	logger := log.WithFields(log.Fields{
 		"program": program.Name(),
 		"prognum": program.Number(),

--- a/servers/sunrpc/program/program.go
+++ b/servers/sunrpc/program/program.go
@@ -1,0 +1,17 @@
+package program
+
+// Procedure represents a procedure number, procedure name pair
+type Procedure struct {
+	Number uint32
+	Name   string
+}
+
+// Program is an interface that every RPC program should implement
+type Program interface {
+	Name() string
+	Number() uint32
+	Version() uint32
+	Procedures() []Procedure
+}
+
+var ProgramsList []Program

--- a/servers/sunrpc/serialize/dict.go
+++ b/servers/sunrpc/serialize/dict.go
@@ -1,4 +1,4 @@
-package sunrpc
+package serialize
 
 import (
 	"bytes"


### PR DESCRIPTION
This is initial code which enables creation of plugins for glusterd2.
Interface design is still in initial stage, do not start working on
any real plugin Yet!

Plugin interface is

    type Gd2Plugin interface{
        SunRpcProcedures() program.Program
        RestRoutes() route.Routes
        RegisterStepFuncs()
    }

Plugin can register sunrpc procedure, REST route and can register step
functions required for Transaction(Transaction APIs are not stable
yet)

Modified `servers/sunrpc/dump_prog.go` as plugin.
`plugins/dump/{init,sunrpc}.go` files shows how to add sunrpc
program into glusterd2's sunrpc server.

Included `hello` plugin, which plugs following REST routes into
glusterd2 REST server.

    GET  /v1/hello
    POST /v1/hello

TODO:
- Store APIs need to be finalized for Plugins
- Daemon management APIs for plugins(Enable/Disable/Start/Stop a
  daemon)
- Simplify the Plugin Interface for ease of use, reduce number of
  imports required inside plugin etc.

Closes #131
Signed-off-by: Aravinda VK <avishwan@redhat.com>