### PR TITLE
Added Logfile support

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ func parseFlags() {
 	flag.String("localstatedir", "", "Directory to store local state information. (default: workdir)")
 	flag.String("rundir", "", "Directory to store runtime data. (default: workdir/run)")
 	flag.String("logdir", "", "Directory to store logs. (default: workdir/log)")
+	flag.String("logfile", "-", "Log file name. (default: -)")
 	flag.String("config", "", "Configuration file for GlusterD. By default looks for glusterd.(yaml|toml|json) in /etc/glusterd and current working directory.")
 	flag.String("loglevel", defaultLogLevel, "Severity of messages to be logged.")
 

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ func parseFlags() {
 	flag.String("localstatedir", "", "Directory to store local state information. (default: workdir)")
 	flag.String("rundir", "", "Directory to store runtime data. (default: workdir/run)")
 	flag.String("logdir", "", "Directory to store logs. (default: workdir/log)")
-	flag.String("logfile", "-", "Log file name. (default: -)")
+	flag.String("logfile", "-", "Log file name. (default: STDERR)")
 	flag.String("config", "", "Configuration file for GlusterD. By default looks for glusterd.(yaml|toml|json) in /etc/glusterd and current working directory.")
 	flag.String("loglevel", defaultLogLevel, "Severity of messages to be logged.")
 

--- a/logging.go
+++ b/logging.go
@@ -2,16 +2,51 @@ package main
 
 import (
 	"io"
+	"os"
+	"path"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
 
-func initLog(logLevel string, out io.Writer) {
+var logWriter io.WriteCloser
+
+func reloadLog(logdir string, logFileName string, logLevel string) {
+	if logFileName != "-" {
+		// Close the previously opened Log file
+		if logWriter != nil {
+			logWriter.Close()
+		}
+
+		// Reopen the log file again and update logWriter
+		logFilePath := path.Join(logdir, logFileName)
+		logFile, logFileErr := openLogFile(logFilePath)
+		if logFileErr != nil {
+			initLog(logLevel, os.Stderr)
+			log.WithError(logFileErr).Fatalf("Failed to open log file %s", logFilePath)
+			return
+		}
+
+		log.SetOutput(logFile)
+		logWriter = logFile
+	}
+}
+
+func openLogFile(filepath string) (io.WriteCloser, error) {
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func initLog(logLevel string, out io.WriteCloser) {
 	l, err := log.ParseLevel(strings.ToLower(logLevel))
 	if err != nil {
 		log.WithField("error", err).Fatal("Failed to parse log level")
 	}
 	log.SetLevel(l)
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 	log.SetOutput(out)
+	logWriter = out
 }

--- a/logging.go
+++ b/logging.go
@@ -11,27 +11,6 @@ import (
 
 var logWriter io.WriteCloser
 
-func reloadLog(logdir string, logFileName string, logLevel string) {
-	if logFileName != "-" {
-		// Close the previously opened Log file
-		if logWriter != nil {
-			logWriter.Close()
-		}
-
-		// Reopen the log file again and update logWriter
-		logFilePath := path.Join(logdir, logFileName)
-		logFile, logFileErr := openLogFile(logFilePath)
-		if logFileErr != nil {
-			initLog(logLevel, os.Stderr)
-			log.WithError(logFileErr).Fatalf("Failed to open log file %s", logFilePath)
-			return
-		}
-
-		log.SetOutput(logFile)
-		logWriter = logFile
-	}
-}
-
 func openLogFile(filepath string) (io.WriteCloser, error) {
 	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
@@ -40,13 +19,32 @@ func openLogFile(filepath string) (io.WriteCloser, error) {
 	return f, nil
 }
 
-func initLog(logLevel string, out io.WriteCloser) {
+func initLog(logdir string, logFileName string, logLevel string) {
+	// Close the previously opened Log file
+	if logWriter != nil {
+		logWriter.Close()
+	}
+
 	l, err := log.ParseLevel(strings.ToLower(logLevel))
 	if err != nil {
+		log.SetOutput(os.Stderr)
 		log.WithField("error", err).Fatal("Failed to parse log level")
 	}
 	log.SetLevel(l)
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
-	log.SetOutput(out)
-	logWriter = out
+
+	if strings.ToLower(logFileName) == "stderr" || logFileName == "-" {
+		log.SetOutput(os.Stderr)
+	} else if strings.ToLower(logFileName) == "stdout" {
+		log.SetOutput(os.Stdout)
+	} else {
+		logFilePath := path.Join(logdir, logFileName)
+		logFile, logFileErr := openLogFile(logFilePath)
+		if logFileErr != nil {
+			log.SetOutput(os.Stderr)
+			log.WithError(logFileErr).Fatalf("Failed to open log file %s", logFilePath)
+		}
+		log.SetOutput(logFile)
+		logWriter = logFile
+	}
 }


### PR DESCRIPTION
New CLI flag "logfile" added. Default value is "-" which writes to
StdErr. Logfile can be specified using,

    ./glusterd2 --logfile glusterd.log

NOTE: Use the flag `--logdir` to configure the log directory if required

    ./glusterd2 --logfile glusterd.log --logdir /var/log/glusterfs

Also added support for logrotate, if log file rotated, notify the running
glusterd process by sending SIGHUP(`kill -SIGHUP $PID`)

Closes #274
Signed-off-by: Aravinda VK <avishwan@redhat.com>