### PR TITLE
Fixed parsing portless peer hostname.

### DIFF
--- a/utils/peerutils.go
+++ b/utils/peerutils.go
@@ -15,7 +15,7 @@ func FormRemotePeerAddress(peeraddress string) (string, error) {
 	host, port, err := net.SplitHostPort(peeraddress)
 	if err != nil {
 		// net.SplitHostPort() returns an error if port is missing.
-		if strings.HasPrefix(err.Error(), "missing port in address") {
+		if strings.HasSuffix(err.Error(), "missing port in address") {
 			host = peeraddress
 			port = config.GetString("defaultpeerport")
 		} else {


### PR DESCRIPTION
Peers hostnames without explicitly specified
port will be extended with default port values.

Fixes #280

Signed-off-by: Denis Chaplygin <dchaplyg@redhat.com>