### PR TITLE
Introduce middlewares and do some cleanup

### DIFF
--- a/commands/volumes/volume-create.go
+++ b/commands/volumes/volume-create.go
@@ -169,8 +169,7 @@ func nodesForVolCreate(req *volume.VolCreateRequest) ([]uuid.UUID, error) {
 
 func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	req := new(volume.VolCreateRequest)
-	reqID := r.Header.Get("X-Request-ID")
-	logger := log.WithField("reqid", reqID)
+	reqID, logger := restutils.GetReqIDandLogger(r)
 
 	httpStatus, e := unmarshalVolCreateRequest(req, r)
 	if e != nil {

--- a/commands/volumes/volume-create.go
+++ b/commands/volumes/volume-create.go
@@ -19,16 +19,13 @@ import (
 func unmarshalVolCreateRequest(msg *volume.VolCreateRequest, r *http.Request) (int, error) {
 	e := utils.GetJSONFromRequest(r, msg)
 	if e != nil {
-		log.WithField("error", e).Error("Failed to parse the JSON Request")
 		return 422, gderrors.ErrJSONParsingFailed
 	}
 
 	if msg.Name == "" {
-		log.Error("Volume name is empty")
 		return http.StatusBadRequest, gderrors.ErrEmptyVolName
 	}
 	if len(msg.Bricks) <= 0 {
-		log.WithField("volume", msg.Name).Error("Brick list is empty")
 		return http.StatusBadRequest, gderrors.ErrEmptyBrickList
 	}
 	return 0, nil
@@ -150,8 +147,6 @@ func nodesForVolCreate(req *volume.VolCreateRequest) ([]uuid.UUID, error) {
 		// <peer-uuid>:<brick-path>
 		// <ip>:<port>:<brick-path>
 		// <ip>:<brick-path>
-		// TODO: Peer names, as of today, aren't unique. Support it ?
-		// TODO: Change API to have host and path as separate fields
 
 		host, _, err := utils.ParseHostAndBrickPath(b)
 		if err != nil {
@@ -174,9 +169,12 @@ func nodesForVolCreate(req *volume.VolCreateRequest) ([]uuid.UUID, error) {
 
 func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	req := new(volume.VolCreateRequest)
+	reqID := r.Header.Get("X-Request-ID")
+	logger := log.WithField("reqid", reqID)
 
 	httpStatus, e := unmarshalVolCreateRequest(req, r)
 	if e != nil {
+		logger.WithError(e).Error("Failed to unmarshal volume request")
 		restutils.SendHTTPError(w, httpStatus, e.Error())
 		return
 	}
@@ -186,12 +184,9 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reqid := uuid.NewRandom().String()
-	logger := log.WithField("reqid", reqid)
-
 	nodes, e := nodesForVolCreate(req)
 	if e != nil {
-		log.WithError(e).Error("could not prepare node list")
+		logger.WithError(e).Error("could not prepare node list")
 		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
 		return
 	}
@@ -203,10 +198,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		Commit:   "vol-create.Commit",
 		Store:    "vol-create.Store",
 		Rollback: "vol-create.Rollback",
-		LogFields: &log.Fields{
-			"reqid": reqid,
-		},
-	}).NewTxn()
+	}).NewTxn(reqID)
 	if e != nil {
 		logger.WithError(e).Error("failed to create transaction")
 		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())

--- a/commands/volumes/volume-delete.go
+++ b/commands/volumes/volume-delete.go
@@ -70,8 +70,7 @@ func registerVolDeleteStepFuncs() {
 func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-	reqID := r.Header.Get("X-Request-ID")
-	logger := log.WithField("reqid", reqID)
+	reqID, logger := restutils.GetReqIDandLogger(r)
 
 	if !volume.Exists(volname) {
 		restutils.SendHTTPError(w, http.StatusBadRequest, gderrors.ErrVolNotFound.Error())

--- a/commands/volumes/volume-delete.go
+++ b/commands/volumes/volume-delete.go
@@ -70,8 +70,8 @@ func registerVolDeleteStepFuncs() {
 func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-
-	log.Info("In Volume delete API")
+	reqID := r.Header.Get("X-Request-ID")
+	logger := log.WithField("reqid", reqID)
 
 	if !volume.Exists(volname) {
 		restutils.SendHTTPError(w, http.StatusBadRequest, gderrors.ErrVolNotFound.Error())
@@ -79,7 +79,6 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	vol, err := volume.GetVolume(volname)
 	if err != nil {
-		// this shouldn't happen
 		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -89,9 +88,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// This is an example of a freeform transaction, that doesn't use the simple transaction framework
-
-	txn := transaction.NewTxn()
+	txn := transaction.NewTxn(reqID)
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
@@ -115,7 +112,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, e := txn.Do()
 	if e != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"error":  e.Error(),
 			"volume": volname,
 		}).Error("Failed to delete the volume")

--- a/commands/volumes/volume-info.go
+++ b/commands/volumes/volume-info.go
@@ -7,7 +7,6 @@ import (
 	restutils "github.com/gluster/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 )
 
@@ -15,15 +14,10 @@ func volumeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
 
-	log.Debug("In Volume info API")
-
-	// Simple read operations, which just read information from the store, need
-	// not use the transaction framework
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
 		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
 	} else {
-
 		restutils.SendHTTPResponse(w, http.StatusOK, vol)
 	}
 }

--- a/commands/volumes/volume-list.go
+++ b/commands/volumes/volume-list.go
@@ -5,18 +5,11 @@ import (
 
 	restutils "github.com/gluster/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/volume"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 
-	log.Info("In Volume list API")
-
-	// Simple read operations, which just read information from the store, need
-	// not use the transaction framework
 	volumes, e := volume.GetVolumesList()
-
 	if e != nil {
 		restutils.SendHTTPError(w, http.StatusNotFound, e.Error())
 	} else {

--- a/commands/volumes/volume-start.go
+++ b/commands/volumes/volume-start.go
@@ -140,8 +140,7 @@ func registerVolStartStepFuncs() {
 func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-	reqID := r.Header.Get("X-Request-ID")
-	logger := log.WithField("reqid", reqID)
+	reqID, logger := restutils.GetReqIDandLogger(r)
 
 	vol, e := volume.GetVolume(volname)
 	if e != nil {

--- a/commands/volumes/volume-start.go
+++ b/commands/volumes/volume-start.go
@@ -140,8 +140,8 @@ func registerVolStartStepFuncs() {
 func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-
-	log.Info("In Volume start API")
+	reqID := r.Header.Get("X-Request-ID")
+	logger := log.WithField("reqid", reqID)
 
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
@@ -154,7 +154,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// A simple one-step transaction to start the brick processes
-	txn := transaction.NewTxn()
+	txn := transaction.NewTxn(reqID)
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
@@ -175,7 +175,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, e = txn.Do()
 	if e != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"error":  e.Error(),
 			"volume": volname,
 		}).Error("failed to start volume")
@@ -190,6 +190,5 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
 		return
 	}
-	log.WithField("volume", vol.Name).Debug("Volume updated into the store")
 	restutils.SendHTTPResponse(w, http.StatusOK, vol)
 }

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -109,6 +109,8 @@ func aggregateVolumeStatus(ctx transaction.TxnCtx, nodes []uuid.UUID) (*volume.V
 func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
+	reqID := r.Header.Get("X-Request-ID")
+	logger := log.WithField("reqid", reqID)
 
 	// Ensure that the volume exists.
 	vol, err := volume.GetVolume(volname)
@@ -120,7 +122,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// A very simple free-form transaction to query each node for brick
 	// status. Fetching volume status does not modify state/data on the
 	// remote node. So there's no need for locks.
-	txn := transaction.NewTxn()
+	txn := transaction.NewTxn(reqID)
 	defer txn.Cleanup()
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
@@ -139,7 +141,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// a way for the nodes store the results of the step runs.
 	rtxn, err := txn.Do()
 	if err != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"error":  err.Error(),
 			"volume": volname,
 		}).Error("volumeStatusHandler: Failed to get volume status.")
@@ -153,7 +155,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	result, err := aggregateVolumeStatus(rtxn, txn.Nodes)
 	if err != nil {
 		errMsg := "Failed to aggregate brick status results from multiple nodes."
-		log.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)
+		logger.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)
 		restutils.SendHTTPError(w, http.StatusInternalServerError, errMsg)
 		return
 	}

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -109,8 +109,7 @@ func aggregateVolumeStatus(ctx transaction.TxnCtx, nodes []uuid.UUID) (*volume.V
 func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-	reqID := r.Header.Get("X-Request-ID")
-	logger := log.WithField("reqid", reqID)
+	reqID, logger := restutils.GetReqIDandLogger(r)
 
 	// Ensure that the volume exists.
 	vol, err := volume.GetVolume(volname)

--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -64,8 +64,8 @@ func registerVolStopStepFuncs() {
 func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-
-	log.Info("In Volume stop API")
+	reqID := r.Header.Get("X-Request-ID")
+	logger := log.WithField("reqid", reqID)
 
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
@@ -78,7 +78,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// A simple one-step transaction to stop brick processes
-	txn := transaction.NewTxn()
+	txn := transaction.NewTxn(reqID)
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
@@ -98,7 +98,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, e = txn.Do()
 	if e != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"error":  e.Error(),
 			"volume": volname,
 		}).Error("failed to stop volume")
@@ -113,6 +113,5 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
 		return
 	}
-	log.WithField("volume", vol.Name).Debug("Volume updated into the store")
 	restutils.SendHTTPResponse(w, http.StatusOK, vol)
 }

--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -64,8 +64,7 @@ func registerVolStopStepFuncs() {
 func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	p := mux.Vars(r)
 	volname := p["volname"]
-	reqID := r.Header.Get("X-Request-ID")
-	logger := log.WithField("reqid", reqID)
+	reqID, logger := restutils.GetReqIDandLogger(r)
 
 	vol, e := volume.GetVolume(volname)
 	if e != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: adf01988e5ed54443a12558b56bf4a932959a06c90aea734e1a226a8f71bc4e1
-updated: 2017-04-10T15:19:03.432489462+05:30
+hash: c6cca88412810d810420798792e96ffef1a26e52e3081e882ffed320f3389087
+updated: 2017-04-13T19:44:54.706601251+05:30
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -99,6 +99,8 @@ imports:
   version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/handlers
+  version: 13d73096a474cac93275c679c7b8a2dc17ddba82
 - name: github.com/gorilla/mux
   version: 999ef73f5d50979cf6d12afed1726325b63f9570
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
@@ -124,6 +126,8 @@ imports:
   version: f3775cbcefd6822086c729e3ce4b70ca85a5bd21
 - name: github.com/jonboulle/clockwork
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+- name: github.com/justinas/alice
+  version: 1051eaf52fcafdd87ead59d28b065f1fcb8274ec
 - name: github.com/magiconair/properties
   version: b3b15ef068fd0b17ddf408a23669f20811d194d2
 - name: github.com/matttproud/golang_protobuf_extensions

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,3 +30,5 @@ import:
 - package: github.com/thejerf/suture
   version: ^2.0.0
 - package: github.com/prashanthpai/sunrpc
+- package: github.com/justinas/alice
+- package: github.com/gorilla/handlers

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/pborman/uuid"
+)
+
+// TODO
+// In Go, the idiomatic and recommended way to attach any request scoped
+// metadata information across goroutine and process boundaries is to use the
+// 'context' package. This is not useful unless we pass down this context
+// all through-out the request scope across nodes, and this involves some
+// code changes in function signatures at many places
+// The following simple implementation is good enough until then...
+
+// ReqIDGenerator is a middleware which generates a UUID for each incoming
+// HTTP request and sets this UUID as a header in request and in response.
+func ReqIDGenerator(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use the request id sent by the client, if any
+		reqID := r.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = uuid.NewRandom().String()
+			r.Header.Set("X-Request-ID", reqID)
+		}
+		// Set response header
+		w.Header().Set("X-Request-ID", reqID)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/request_logging.go
+++ b/middleware/request_logging.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/handlers"
+)
+
+// LogRequest is a middleware which logs HTTP requests in the
+// Apache Common Log Format (CLF)
+func LogRequest(next http.Handler) http.Handler {
+	return handlers.LoggingHandler(log.StandardLogger().Writer(), next)
+}

--- a/servers/rest/rest.go
+++ b/servers/rest/rest.go
@@ -5,8 +5,11 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/gluster/glusterd2/middleware"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
 	"github.com/soheilhy/cmux"
 )
 
@@ -35,8 +38,9 @@ func NewMuxed(m cmux.CMux) *GDRest {
 
 // Serve begins serving client HTTP requests served by REST server
 func (r *GDRest) Serve() {
+	chain := alice.New(middleware.LogRequest, middleware.ReqIDGenerator).Then(r.Routes)
 	log.WithField("ip:port", r.listener.Addr().String()).Info("Started GlusterD ReST server")
-	if err := http.Serve(r.listener, r.Routes); err != nil {
+	if err := http.Serve(r.listener, chain); err != nil {
 		//TODO: Correctly handle valid errors. We could also be having errors when stopping
 		log.WithError(err).Error("GlusterD ReST server failed")
 	}

--- a/servers/rest/utils/utils.go
+++ b/servers/rest/utils/utils.go
@@ -37,3 +37,10 @@ func SendHTTPError(rw http.ResponseWriter, statusCode int, errMsg string) {
 	rw.WriteHeader(statusCode)
 	rw.Write(bytes)
 }
+
+// GetReqIDandLogger returns a request ID and a request-scoped logger having
+// the request ID as a logging field.
+func GetReqIDandLogger(r *http.Request) (string, *log.Entry) {
+	reqID := r.Header.Get("X-Request-ID")
+	return reqID, log.WithField("reqid", reqID)
+}

--- a/transaction/simple.go
+++ b/transaction/simple.go
@@ -33,12 +33,12 @@ type SimpleTxn struct {
 }
 
 // NewTxn creates and returns a Txn using SimpleTxn as a template
-func (s *SimpleTxn) NewTxn() (*Txn, error) {
+func (s *SimpleTxn) NewTxn(id string) (*Txn, error) {
 	var simple *Txn
 	if s.LogFields == nil {
-		simple = NewTxn()
+		simple = NewTxn(id)
 	} else {
-		simple = NewTxnWithLoggingContext(*s.LogFields)
+		simple = NewTxnWithLoggingContext(*s.LogFields, id)
 	}
 	simple.Nodes = s.Nodes
 	simple.Steps = make([]*Step, 5)
@@ -72,14 +72,4 @@ func (s *SimpleTxn) NewTxn() (*Txn, error) {
 	simple.Steps[4] = unlockstep
 
 	return simple, nil
-}
-
-// Do runs the SimpleTxn on the cluster
-func (s *SimpleTxn) Do() (TxnCtx, error) {
-	t, err := s.NewTxn()
-	if err != nil {
-		return nil, err
-	}
-
-	return t.Do()
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -31,10 +31,12 @@ type Txn struct {
 func NewTxn(id string) *Txn {
 	t := new(Txn)
 
-	if uuid.Parse(id) != nil {
+	parsedID := uuid.Parse(id)
+	if parsedID != nil {
 		t.ID = uuid.Parse(id)
 	} else {
 		t.ID = uuid.NewRandom()
+		log.WithField("reqid", t.ID.String()).Warn("Invalid UUID set as request ID. Generated new request ID")
 	}
 
 	prefix := txnPrefix + t.ID.String()

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -31,10 +31,7 @@ type Txn struct {
 func NewTxn(id string) *Txn {
 	t := new(Txn)
 
-	parsedID := uuid.Parse(id)
-	if parsedID != nil {
-		t.ID = uuid.Parse(id)
-	} else {
+	if t.ID = uuid.Parse(id); t.ID == nil {
 		t.ID = uuid.NewRandom()
 		log.WithField("reqid", t.ID.String()).Warn("Invalid UUID set as request ID. Generated new request ID")
 	}

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -20,6 +20,7 @@ const (
 //
 // Nodes is a union of the all the TxnStep.Nodes
 type Txn struct {
+	// TODO: Any good reason for this to be not just string ?
 	ID    uuid.UUID
 	Ctx   TxnCtx
 	Steps []*Step
@@ -27,26 +28,29 @@ type Txn struct {
 }
 
 // NewTxn returns an initialized Txn without any steps
-func NewTxn() *Txn {
+func NewTxn(id string) *Txn {
 	t := new(Txn)
-	t.ID = uuid.NewRandom()
-	prefix := txnPrefix + t.ID.String()
 
+	if uuid.Parse(id) != nil {
+		t.ID = uuid.Parse(id)
+	} else {
+		t.ID = uuid.NewRandom()
+	}
+
+	prefix := txnPrefix + t.ID.String()
 	t.Ctx = NewCtxWithLogFields(log.Fields{
-		"txnid": t.ID.String(),
+		"reqid": t.ID.String(),
 	}).WithPrefix(prefix)
 
 	return t
 }
 
 // NewTxnWithLoggingContext creates a Txn with a Context with given logging fields
-func NewTxnWithLoggingContext(f log.Fields) *Txn {
-	t := new(Txn)
-	t.ID = uuid.NewRandom()
+func NewTxnWithLoggingContext(f log.Fields, id string) *Txn {
+	t := NewTxn(id)
 	prefix := txnPrefix + t.ID.String()
-
 	t.Ctx = NewCtxWithLogFields(log.Fields{
-		"txnid": t.ID.String(),
+		"reqid": t.ID.String(),
 	}).WithPrefix(prefix).WithLogFields(f)
 
 	return t


### PR DESCRIPTION
* Introduces two minimal middlewares:
    1. Request logger: logs all incoming REST requests
    2. Request ID Generator: Assigns a request ID to each request
* Middlewares are easily chained using alice.
  https://justinas.org/alice-painless-middleware-chaining-for-go/
* Removes a lot of old logging junk. Uses request scoped logger.

TODO: Use context and opentracing in future

Closes #287

Signed-off-by: Prashanth Pai <ppai@redhat.com>