### PR TITLE
options: Framework to manage Cluster and Volume options

### DIFF
--- a/options/common.go
+++ b/options/common.go
@@ -39,12 +39,16 @@ func GetClusterOption(key string) (interface{}, error) {
 	}
 
 	// Else return error
-	return "", errors.New("Invalid Option")
+	return nil, errors.New("Invalid Option")
 }
 
 // SetClusterOption validates and saves the cluster configuration in
 // etcd store.
 func SetClusterOption(key string, value interface{}) error {
+	if _, ok := clusterDefaultOptions[key]; !ok {
+		return errors.New("Invalid Key")
+	}
+
 	clusterKey := clusterOptsPrefix + key
 	if clusterOptValidate(key, value) {
 		d, err := json.Marshal(value)
@@ -59,6 +63,10 @@ func SetClusterOption(key string, value interface{}) error {
 
 // ResetClusterOption deletes cluster configurations stored in etcd store.
 func ResetClusterOption(key string) error {
+	if _, ok := clusterDefaultOptions[key]; !ok {
+		return errors.New("Invalid Key")
+	}
+
 	clusterKey := clusterOptsPrefix + key
 	_, e := gdctx.Store.Delete(context.TODO(), clusterKey)
 	return e
@@ -88,12 +96,16 @@ func GetVolumeOption(volname string, key string) (interface{}, error) {
 	}
 
 	// Else return error
-	return "", errors.New("Invalid Option")
+	return nil, errors.New("Invalid Option")
 }
 
 // SetVolumeOption validates and saves the volume configuration in
 // etcd store.
 func SetVolumeOption(volname string, key string, value interface{}) error {
+	if _, ok := volumeDefaultOptions[key]; !ok {
+		return errors.New("Invalid Key")
+	}
+
 	volumeKey := volumeOptsPrefix + volname + "/" + key
 	if volumeOptValidate(key, value) {
 		d, err := json.Marshal(value)
@@ -108,6 +120,10 @@ func SetVolumeOption(volname string, key string, value interface{}) error {
 
 // ResetVolumeOption deletes volume configurations stored in etcd store.
 func ResetVolumeOption(volname string, key string) error {
+	if _, ok := volumeDefaultOptions[key]; !ok {
+		return errors.New("Invalid Key")
+	}
+
 	volumeKey := volumeOptsPrefix + volname + "/" + key
 	_, e := gdctx.Store.Delete(context.TODO(), volumeKey)
 	return e

--- a/options/common.go
+++ b/options/common.go
@@ -1,0 +1,114 @@
+package options
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/gluster/glusterd2/gdctx"
+	"github.com/gluster/glusterd2/store"
+)
+
+const (
+	clusterOptsPrefix string = store.GlusterPrefix + "clusteropts/"
+	volumeOptsPrefix  string = store.GlusterPrefix + "volumeopts/"
+)
+
+// GetClusterOption gets cluster configuration from etcd store,
+// returns default value if not available in store. Returns error if
+// not available in defaults list.
+func GetClusterOption(key string) (interface{}, error) {
+	var v interface{}
+
+	// Get Value from Store
+	clusterKey := clusterOptsPrefix + key
+	resp, e := gdctx.Store.Get(context.TODO(), clusterKey)
+	if e == nil {
+		if resp.Count == 1 {
+			if e = json.Unmarshal(resp.Kvs[0].Value, &v); e != nil {
+				return nil, e
+			}
+			return v, nil
+		}
+	}
+
+	// If not available get value from defaults
+	dv, dvOk := clusterDefaultOptions[key]
+	if dvOk {
+		return dv.defaultValue, nil
+	}
+
+	// Else return error
+	return "", errors.New("Invalid Option")
+}
+
+// SetClusterOption validates and saves the cluster configuration in
+// etcd store.
+func SetClusterOption(key string, value interface{}) error {
+	clusterKey := clusterOptsPrefix + key
+	if clusterOptValidate(key, value) {
+		d, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, e := gdctx.Store.Put(context.TODO(), clusterKey, string(d))
+		return e
+	}
+	return errors.New("Invalid Value")
+}
+
+// ResetClusterOption deletes cluster configurations stored in etcd store.
+func ResetClusterOption(key string) error {
+	clusterKey := clusterOptsPrefix + key
+	_, e := gdctx.Store.Delete(context.TODO(), clusterKey)
+	return e
+}
+
+// GetVolumeOption gets volume configuration from etcd store,
+// returns default value if not available in store. Returns error if
+// not available in defaults list.
+func GetVolumeOption(volname string, key string) (interface{}, error) {
+	// Get Value from Store
+	var v interface{}
+	volumeKey := volumeOptsPrefix + volname + "/" + key
+	resp, e := gdctx.Store.Get(context.TODO(), volumeKey)
+	if e == nil {
+		if resp.Count == 1 {
+			if e = json.Unmarshal(resp.Kvs[0].Value, &v); e != nil {
+				return nil, e
+			}
+			return v, nil
+		}
+	}
+
+	// If not available get value from defaults
+	dv, dvOk := volumeDefaultOptions[key]
+	if dvOk {
+		return dv.defaultValue, nil
+	}
+
+	// Else return error
+	return "", errors.New("Invalid Option")
+}
+
+// SetVolumeOption validates and saves the volume configuration in
+// etcd store.
+func SetVolumeOption(volname string, key string, value interface{}) error {
+	volumeKey := volumeOptsPrefix + volname + "/" + key
+	if volumeOptValidate(key, value) {
+		d, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, e := gdctx.Store.Put(context.TODO(), volumeKey, string(d))
+		return e
+	}
+	return errors.New("Invalid Value")
+}
+
+// ResetVolumeOption deletes volume configurations stored in etcd store.
+func ResetVolumeOption(volname string, key string) error {
+	volumeKey := volumeOptsPrefix + volname + "/" + key
+	_, e := gdctx.Store.Delete(context.TODO(), volumeKey)
+	return e
+}

--- a/options/options.go
+++ b/options/options.go
@@ -1,0 +1,23 @@
+package options
+
+type validationFunc func(val interface{}) bool
+
+type optionDetails struct {
+	defaultValue    interface{}
+	validationFuncs []validationFunc
+	help            string
+}
+
+var clusterDefaultOptions = map[string]optionDetails{
+	"cluster.lookup-unhashed": optionDetails{
+		"on",
+		[]validationFunc{stringValidation, onOffValidation},
+		"This option if set to ON, does a lookup through all the sub-volumes, in case a lookup didn't return any result from the hash subvolume. If set to OFF, it does not do a lookup on the remaining subvolumes."},
+}
+
+var volumeDefaultOptions = map[string]optionDetails{
+	"features.read-only": optionDetails{
+		"off",
+		[]validationFunc{stringValidation, onOffValidation},
+		"When \"on\", makes a volume read-only. It is turned \"off\" by default."},
+}

--- a/options/validations.go
+++ b/options/validations.go
@@ -1,0 +1,37 @@
+package options
+
+func clusterOptValidate(key string, value interface{}) bool {
+	status := true
+	for _, fn := range clusterDefaultOptions[key].validationFuncs {
+		if !fn(value) {
+			status = false
+			break
+		}
+	}
+	return status
+}
+
+func volumeOptValidate(key string, value interface{}) bool {
+	status := true
+	for _, fn := range volumeDefaultOptions[key].validationFuncs {
+		if !fn(value) {
+			status = false
+			break
+		}
+	}
+	return status
+}
+
+func boolValidation(val interface{}) bool {
+	_, ok := val.(bool)
+	return ok
+}
+
+func stringValidation(val interface{}) bool {
+	_, ok := val.(string)
+	return ok
+}
+
+func onOffValidation(val interface{}) bool {
+	return (val == "on" || val == "off")
+}


### PR DESCRIPTION
This framework provides facility to store the Cluster options and volume
options in etcd store.(`volume set` command in glusterd 1)

During Get request, fetches the value from etcd store, if not found fetches
from the defaults list. Returns error if not found in both places.

Validation facility added while adding/updating options in store.

Following APIs exposed under `options` subpackage

    import "github.com/gluster/glusterd2/options"

    options.GetClusterOption(key string) (interface{}, error)
    options.GetVolumeOption(volname string, key string) (interface{}, error)

    options.SetClusterOption(key string, value interface{}) error
    options.SetVolumeOption(volname string, key string,
                            value interface{}) error

    options.ResetClusterOption(key string) error
    options.ResetVolumeOption(volname string, key string) error

TODO:
- Implement new APIs `GetAllClusterOptions` and `GetAllVolumeOptions`
- Add all existing default options, values and validation functions

This patch adds the framework required for Issue #266 and volgen.

Signed-off-by: Aravinda VK <mail@aravindavk.in>