### PR TITLE
Implement RPC callbacks

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: c6cca88412810d810420798792e96ffef1a26e52e3081e882ffed320f3389087
-updated: 2017-04-13T19:44:54.706601251+05:30
+updated: 2017-04-19T17:35:16.371614315+05:30
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -143,7 +143,7 @@ imports:
 - name: github.com/pelletier/go-toml
   version: 22139eb5469018e7374b3e7ef653de37ffb44f72
 - name: github.com/prashanthpai/sunrpc
-  version: 4c574af9889b29d781c148e89252d314d305f638
+  version: 9279be9f0b6b8e88fd1cecbfed8681c1f1aaad51
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:

--- a/servers/sunrpc/callback.go
+++ b/servers/sunrpc/callback.go
@@ -1,0 +1,121 @@
+package sunrpc
+
+import (
+	"bytes"
+	"net"
+	"sync/atomic"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/prashanthpai/sunrpc"
+	"github.com/rasky/go-xdr/xdr2"
+)
+
+// NOTE:
+// This adds support for the 'callback hack' from Gluster's RPC implementation
+// i.e enable RPC server (glusterd2) to make a call to a connected glusterfs
+// SunRPC client.
+// This implementation depends on the following facts:
+//     1. Multiple goroutines may invoke methods on a net.Conn simultaneously.
+//     2. SunRPC ServerCodec will always send entire RPC message in a single
+//        RPC fragment/record over the socket.
+//     3. The glusterfs RPC client processes will never send a RPC reply to
+//        these RPC calls sent by glusterd2.
+// If any of the above pre-conditions change, this implementation should be
+// revisited.
+
+// Stuff from glusterd1 that uses RPC callbacks:
+// - glusterd_fetchspec_notify()
+// - glusterd_fetchsnap_notify()
+// - (TODO) glusterd_client_statedump_submit_req()->rpcsvc_request_submit()
+
+// TODO:
+// Glusterd2 (and glusterd1) cannot yet recognize clients (as glusterfsd,
+// snapd, glusterfs etc). So these callback notifications are sent to all
+// the connected RPC clients.
+
+const (
+	glusterCbkProgram = 52743234 // GLUSTER_CBK_PROGRAM
+	glusterCbkVersion = 1        // GLUSTER_CBK_VERSION
+)
+
+var xidCounter uint32
+
+func getNewXid() uint32 {
+	return atomic.AddUint32(&xidCounter, 1)
+}
+
+func callbackClient(conn net.Conn, p sunrpc.ProcedureID, args interface{}) error {
+	payload := new(bytes.Buffer)
+
+	call := sunrpc.RPCMsg{
+		Xid:  getNewXid(),
+		Type: sunrpc.Call,
+		CBody: sunrpc.CallBody{
+			RPCVersion: sunrpc.RPCProtocolVersion,
+			Program:    p.ProgramNumber,
+			Version:    p.ProgramVersion,
+			Procedure:  p.ProcedureNumber,
+		},
+	}
+
+	if _, err := xdr.Marshal(payload, &call); err != nil {
+		return err
+	}
+
+	if args != nil {
+		if _, err := xdr.Marshal(payload, &args); err != nil {
+			return err
+		}
+	}
+
+	_, err := sunrpc.WriteFullRecord(conn, payload.Bytes())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type fetchOp uint8
+
+const (
+	// rpc/rpc-lib/src/protocol-common.h:gf_cbk_procnum
+	gfCbkFetchSpec fetchOp = 1
+	gfCbkGetSnaps  fetchOp = 4
+)
+
+func fetchNotify(op fetchOp) {
+	clientsList.RLock()
+	defer clientsList.RUnlock()
+
+	p := sunrpc.ProcedureID{
+		ProgramNumber:   glusterCbkProgram,
+		ProgramVersion:  glusterCbkVersion,
+		ProcedureNumber: uint32(op),
+	}
+
+	for conn := range clientsList.c {
+		go func(c net.Conn) {
+			if err := callbackClient(c, p, nil); err != nil {
+				// TODO: Use context logger if this is part of a user triggered operation
+				log.WithError(err).WithFields(log.Fields{
+					"client":    c.RemoteAddr().String(),
+					"procedure": op,
+				}).Warn("Failed to notify RPC client")
+			}
+			// TODO: goroutine leak ?
+		}(conn)
+	}
+}
+
+// FetchSpecNotify notifies all clients connected to glusterd that the volfile
+// has changed and the clients should fetch the new volfile.
+func FetchSpecNotify() {
+	fetchNotify(gfCbkFetchSpec)
+}
+
+// FetchSnapNotify notifies all clients connected to glusterd that a snapshot
+// has been created or modified.
+func FetchSnapNotify() {
+	fetchNotify(gfCbkGetSnaps)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -363,3 +363,40 @@ func GetLocalIP() (string, error) {
 func GetFuncName(fn interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 }
+
+// StringInSlice will return true if the given string is present in the
+// list of strings provided. Will return false otherwise.
+func StringInSlice(query string, list []string) bool {
+	for _, s := range list {
+		if s == query {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAddressSame checks is two host addresses are same
+func IsAddressSame(host1, host2 string) bool {
+
+	if host1 == host2 {
+		return true
+	}
+
+	addrs1, err := net.LookupHost(host1)
+	if err != nil {
+		return false
+	}
+
+	addrs2, err := net.LookupHost(host2)
+	if err != nil {
+		return false
+	}
+
+	for _, a := range addrs1 {
+		if StringInSlice(a, addrs2) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This callback mechanism is used to send notifications to RPC clients.

Closes #259

Signed-off-by: Prashanth Pai <ppai@redhat.com>