### PR TITLE
auth: Initial patch for authenticating local request

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+func isAuthorized(r *http.Request) bool {
+	// TODO: Add configuration to enable this Auth
+	// This configuration should not be as command line option
+	// Because, one glusterd can be run with `--no-auth` and
+	// other glusterd with auth enabled.
+	if strings.HasPrefix(r.RemoteAddr, "127.0.0.1:") {
+		return true
+	}
+	// TODO: Add Auth for requests from Remote IPs
+	// Without that, this feature is no impact on
+	// existing(Without Auth). Returning true so that it
+	// will not break the existing consumers/tests till Auth introduced
+	return true
+}
+
+// Auth is a middleware which validates the incoming request is from local node or remote node
+func Auth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isAuthorized(r) {
+			next.ServeHTTP(w, r)
+		} else {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		}
+	})
+}

--- a/servers/rest/rest.go
+++ b/servers/rest/rest.go
@@ -38,7 +38,7 @@ func NewMuxed(m cmux.CMux) *GDRest {
 
 // Serve begins serving client HTTP requests served by REST server
 func (r *GDRest) Serve() {
-	chain := alice.New(middleware.LogRequest, middleware.ReqIDGenerator).Then(r.Routes)
+	chain := alice.New(middleware.Auth, middleware.LogRequest, middleware.ReqIDGenerator).Then(r.Routes)
 	log.WithField("ip:port", r.listener.Addr().String()).Info("Started GlusterD ReST server")
 	if err := http.Serve(r.listener, chain); err != nil {
 		//TODO: Correctly handle valid errors. We could also be having errors when stopping


### PR DESCRIPTION
Introduced new middleware for Authentication. This middleware
allows local requests without Auth.

Access to local users can be controlled using iptable rules

For example, Glusterd2 REST API port is 24007

    iptables -I OUTPUT -p tcp --dport 24007 -j REJECT
    iptables -I OUTPUT -p tcp --dport 24007 --match owner \
        --gid-owner gluster -j ACCEPT
    iptables -I OUTPUT -p tcp --dport 24007 --match owner \
        --uid-owner root -j ACCEPT

Updates: #252
Signed-off-by: Aravinda VK <avishwan@redhat.com>