### PR TITLE
transaction: Use timeouts for etcd mutexes

### DIFF
--- a/commands/volumes/volume-create.go
+++ b/commands/volumes/volume-create.go
@@ -289,7 +289,11 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	c, err := txn.Do()
 	if err != nil {
 		logger.WithError(err).Error("volume create transaction failed")
-		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(w, http.StatusConflict, err.Error())
+		} else {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 

--- a/commands/volumes/volume-delete.go
+++ b/commands/volumes/volume-delete.go
@@ -110,7 +110,11 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	if _, err = txn.Do(); err != nil {
 		logger.WithError(err).WithField(
 			"volume", volname).Error("failed to delete the volume")
-		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(w, http.StatusConflict, err.Error())
+		} else {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
Transactions shouldn't wait forever to obtain a lock. If there is another
conflicting transaction in progress and current txn does not get a lock
for a certain period of time (set to 5 seconds), a 409 (HTTP Conflict)
response is sent to the client.

Signed-off-by: Prashanth Pai <ppai@redhat.com>