### PR TITLE
Use proper store config when restarting store during probe

### DIFF
--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -107,7 +107,7 @@ func ReconfigureStore(c *StoreConfig) error {
 	// TODO: Also need to destroy any old files in localstatedir (eg. volfiles)
 
 	// Restart the store with recieved configuration
-	cfg := store.NewConfig()
+	cfg := store.GetConfig()
 	if c != nil {
 		cfg.Endpoints = c.Endpoints
 	}

--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -90,7 +90,7 @@ func (p *PeerService) Leave(ctx context.Context, req *LeaveReq) (*LeaveRsp, erro
 	logger.Debug("all checks passed, leaving cluster")
 
 	logger.Debug("reconfiguring store with defaults")
-	if err := ReconfigureStore(nil); err != nil {
+	if err := ReconfigureStore(&StoreConfig{store.NewConfig().Endpoints}); err != nil {
 		logger.WithError(err).Warn("failed to reconfigure store with defaults")
 		// XXX: We should probably keep retrying here?
 	}
@@ -108,9 +108,7 @@ func ReconfigureStore(c *StoreConfig) error {
 
 	// Restart the store with recieved configuration
 	cfg := store.GetConfig()
-	if c != nil {
-		cfg.Endpoints = c.Endpoints
-	}
+	cfg.Endpoints = c.Endpoints
 
 	if err := store.Init(cfg); err != nil {
 		log.WithError(err).WithField("endpoints", cfg.Endpoints).Error("failed to restart store with new endpoints")

--- a/e2e/config/3.yaml
+++ b/e2e/config/3.yaml
@@ -1,0 +1,6 @@
+workdir: "/tmp/gd2_func_test/w3"
+logfile: "w3.log"
+peeraddress: "127.0.0.1:22008"
+clientaddress: "127.0.0.1:22007"
+etcdcurls: "http://127.0.0.1:2279"
+etcdpurls: "http://127.0.0.1:2280"

--- a/e2e/peer_ops_test.go
+++ b/e2e/peer_ops_test.go
@@ -29,7 +29,7 @@ func TestAddRemovePeer(t *testing.T) {
 	defer g2.EraseWorkdir()
 	r.True(g2.IsRunning())
 
-	g3, err := spawnGlusterd("./config/3.yaml")
+	g3, err := spawnGlusterd("./config/3.yaml", true)
 	r.Nil(err)
 	defer g3.Stop()
 	defer g3.EraseWorkdir()

--- a/e2e/peer_ops_test.go
+++ b/e2e/peer_ops_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -28,24 +29,42 @@ func TestAddRemovePeer(t *testing.T) {
 	defer g2.EraseWorkdir()
 	r.True(g2.IsRunning())
 
+	g3, err := spawnGlusterd("./config/3.yaml")
+	r.Nil(err)
+	defer g3.Stop()
+	defer g3.EraseWorkdir()
+	r.True(g3.IsRunning())
+
 	// add peer: ask g1 to add g2 as peer
 	reqBody := strings.NewReader(fmt.Sprintf(`{"addresses": ["%s"]}`, g2.PeerAddress))
 	resp, err := http.Post("http://"+g1.ClientAddress+"/v1/peers", "application/json", reqBody)
 	r.Nil(err)
 	defer resp.Body.Close()
-	r.Equal(resp.StatusCode, 201)
+	r.Equal(http.StatusCreated, resp.StatusCode)
+
+	time.Sleep(5 * time.Second)
+
+	// add peer: ask g1 to add g3 as peer
+	reqBody = strings.NewReader(fmt.Sprintf(`{"addresses": ["%s"]}`, g3.PeerAddress))
+	resp, err = http.Post("http://"+g1.ClientAddress+"/v1/peers", "application/json", reqBody)
+	r.Nil(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusCreated, resp.StatusCode)
+
+	time.Sleep(5 * time.Second)
 
 	// list and check you have 2 peers in cluster
 	resp, err = http.Get("http://" + g1.ClientAddress + "/v1/peers")
 	r.Nil(err)
 	defer resp.Body.Close()
-	r.Equal(resp.StatusCode, http.StatusOK)
+	r.Equal(http.StatusOK, resp.StatusCode)
+
 	data, err := ioutil.ReadAll(resp.Body)
 	r.Nil(err)
 	var peers []peer.Peer
 	err = json.Unmarshal(data, &peers)
 	r.Nil(err)
-	r.Len(peers, 2)
+	r.Len(peers, 3)
 
 	// remove peer: ask g1 to remove g2 as peer
 	delURL := fmt.Sprintf("http://%s/v1/peers/%s", g1.ClientAddress, g2.PeerID())
@@ -54,5 +73,5 @@ func TestAddRemovePeer(t *testing.T) {
 	resp, err = http.DefaultClient.Do(req)
 	r.Nil(err)
 	defer resp.Body.Close()
-	r.Equal(resp.StatusCode, 204)
+	r.Equal(http.StatusNoContent, resp.StatusCode)
 }

--- a/e2e/peer_ops_test.go
+++ b/e2e/peer_ops_test.go
@@ -1,12 +1,16 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gluster/glusterd2/peer"
 )
 
 func TestAddRemovePeer(t *testing.T) {
@@ -30,6 +34,18 @@ func TestAddRemovePeer(t *testing.T) {
 	r.Nil(err)
 	defer resp.Body.Close()
 	r.Equal(resp.StatusCode, 201)
+
+	// list and check you have 2 peers in cluster
+	resp, err = http.Get("http://" + g1.ClientAddress + "/v1/peers")
+	r.Nil(err)
+	defer resp.Body.Close()
+	r.Equal(resp.StatusCode, http.StatusOK)
+	data, err := ioutil.ReadAll(resp.Body)
+	r.Nil(err)
+	var peers []peer.Peer
+	err = json.Unmarshal(data, &peers)
+	r.Nil(err)
+	r.Len(peers, 2)
 
 	// remove peer: ask g1 to remove g2 as peer
 	delURL := fmt.Sprintf("http://%s/v1/peers/%s", g1.ClientAddress, g2.PeerID())

--- a/e2e/peer_ops_test.go
+++ b/e2e/peer_ops_test.go
@@ -53,7 +53,7 @@ func TestAddRemovePeer(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	// list and check you have 2 peers in cluster
+	// list and check you have 3 peers in cluster
 	resp, err = http.Get("http://" + g1.ClientAddress + "/v1/peers")
 	r.Nil(err)
 	defer resp.Body.Close()

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -23,6 +23,7 @@ type volCreateReq struct {
 }
 
 func TestVolumeCreateDelete(t *testing.T) {
+	return
 	r := require.New(t)
 
 	gds, err := setupCluster("./config/1.yaml", "./config/2.yaml")

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -23,7 +23,6 @@ type volCreateReq struct {
 }
 
 func TestVolumeCreateDelete(t *testing.T) {
-	return
 	r := require.New(t)
 
 	gds, err := setupCluster("./config/1.yaml", "./config/2.yaml")

--- a/pkg/elasticetcd/volunteer.go
+++ b/pkg/elasticetcd/volunteer.go
@@ -10,12 +10,12 @@ import (
 func (ee *ElasticEtcd) volunteerSelf() error {
 	key := volunteerPrefix + ee.conf.Name
 	var val string
-	// Need to set advertisable CURLs here as the initial cluster lists for new
-	// servers will be formed from this, the default CURL is not advertisable.
-	if isDefaultCURL(ee.conf.CURLs) {
-		val = defaultACURLs.String()
+	// Need to set advertisable PURLs here as the initial cluster lists for new
+	// servers will be formed from this, the default PURL is not advertisable.
+	if isDefaultPURL(ee.conf.PURLs) {
+		val = defaultAPURLs.String()
 	} else {
-		val = ee.conf.CURLs.String()
+		val = ee.conf.PURLs.String()
 	}
 
 	_, err := ee.cli.Put(ee.cli.Ctx(), key, val, clientv3.WithLease(ee.session.Lease()))

--- a/store/config.go
+++ b/store/config.go
@@ -79,12 +79,12 @@ func (c *Config) Save() error {
 	return nil
 }
 
-// getConf returns a filled store config
+// GetConfig returns a filled store config
 // The config is filled with values from the following sources in order of preference,
 // 	- GD2 config
 // 	- Store config file
 // 	- Defaults
-func getConf() *Config {
+func GetConfig() *Config {
 	conf, err := readConfigFile()
 	if err != nil {
 		log.WithError(err).Warn("could not read store config file, continuing with defaults")

--- a/store/store.go
+++ b/store/store.go
@@ -76,7 +76,7 @@ func Destroy() {
 // If the given Config is nil, the saved store config is used.
 func New(conf *Config) (*GDStore, error) {
 	if conf == nil {
-		conf = getConf()
+		conf = GetConfig()
 	}
 	var (
 		store *GDStore


### PR DESCRIPTION
Instead of using the provided store config values, store was being
restarted with the default store config. This prevented GD2 from working
when non-default config is used.

A test has been added to the e2e suite to check this.