### PR TITLE
plugins/geo-rep: REST APIs Placeholder for Geo-replication

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -162,3 +162,67 @@ func Stop(d Daemon, force bool) error {
 
 	return nil
 }
+
+// Pause function reads the PID from path returned by PidFile() and
+// sends SIGSTOP to the process
+func Pause(d Daemon) error {
+
+	// It is assumed that the process d has written to pidfile
+	pid, err := ReadPidFromFile(d.PidFile())
+	if err != nil {
+		return err
+	}
+
+	process, err := GetProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"name": d.Name(),
+		"pid":  pid,
+	}).Debug("Pausing daemon.")
+
+	err = process.Signal(syscall.SIGSTOP)
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"name": d.Name(),
+			"pid":  pid,
+		}).Error("Pausing daemon failed.")
+	}
+
+	return nil
+}
+
+// Resume function reads the PID from path returned by PidFile() and
+// sends SIGCONT to the process
+func Resume(d Daemon) error {
+
+	// It is assumed that the process d has written to pidfile
+	pid, err := ReadPidFromFile(d.PidFile())
+	if err != nil {
+		return err
+	}
+
+	process, err := GetProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"name": d.Name(),
+		"pid":  pid,
+	}).Debug("Resuming daemon.")
+
+	err = process.Signal(syscall.SIGCONT)
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"name": d.Name(),
+			"pid":  pid,
+		}).Error("Resuming daemon failed.")
+	}
+
+	return nil
+}

--- a/plugins/georeplication/errors.go
+++ b/plugins/georeplication/errors.go
@@ -1,0 +1,9 @@
+package georeplication
+
+// ErrGeorepSessionNotFound custom error to represent georep session not exists
+// in store
+type ErrGeorepSessionNotFound struct{}
+
+func (e *ErrGeorepSessionNotFound) Error() string {
+	return "geo-replication session not found"
+}

--- a/plugins/georeplication/gsyncd.go
+++ b/plugins/georeplication/gsyncd.go
@@ -1,0 +1,103 @@
+package georeplication
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+
+	"github.com/gluster/glusterd2/gdctx"
+
+	config "github.com/spf13/viper"
+)
+
+// Gsyncd type represents information about Gsyncd process
+type Gsyncd struct {
+	// Externally consumable using methods of Glusterfsd interface
+	binarypath     string
+	args           string
+	configFilePath string
+	pidfilepath    string
+	// For internal use
+	sessioninfo Session
+}
+
+// Name returns human-friendly name of the gsyncd process. This is used for logging.
+func (g *Gsyncd) Name() string {
+	return "gsyncd"
+}
+
+// Path returns absolute path to the binary of gsyncd process
+func (g *Gsyncd) Path() string {
+	return g.binarypath
+}
+
+// Args returns arguments to be passed to gsyncd process during spawn.
+func (g *Gsyncd) Args() string {
+	var buffer bytes.Buffer
+	buffer.WriteString(" monitor")
+	buffer.WriteString(fmt.Sprintf(" %s", g.sessioninfo.MasterVol))
+	buffer.WriteString(fmt.Sprintf(" %s@%s::%s", g.sessioninfo.SlaveUser, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol))
+	buffer.WriteString(fmt.Sprintf(" --local-node-id %s", gdctx.MyUUID.String()))
+	buffer.WriteString(fmt.Sprintf(" -c %s", g.ConfigFile()))
+
+	g.args = buffer.String()
+	return g.args
+}
+
+func (g *Gsyncd) statusArgs(localPath string) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(" status")
+	buffer.WriteString(fmt.Sprintf(" %s", g.sessioninfo.MasterVol))
+	buffer.WriteString(fmt.Sprintf(" %s@%s::%s", g.sessioninfo.SlaveUser, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol))
+	buffer.WriteString(fmt.Sprintf(" -c %s", g.ConfigFile()))
+	buffer.WriteString(fmt.Sprintf(" --local-path %s", localPath))
+
+	return buffer.String()
+}
+
+// ConfigFile returns path to the config file
+func (g *Gsyncd) ConfigFile() string {
+
+	if g.configFilePath != "" {
+		return g.configFilePath
+	}
+
+	g.configFilePath = path.Join(
+		config.GetString("localstatedir"),
+		"geo-replication",
+		fmt.Sprintf("%s_%s_%s", g.sessioninfo.MasterVol, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol),
+		"gsyncd.conf",
+	)
+	return g.configFilePath
+}
+
+// SocketFile returns path to the socket file, Gsyncd doesn't have socket file. This func is required for Daemon interface
+func (g *Gsyncd) SocketFile() string {
+	return ""
+}
+
+// PidFile returns path to the pid file of the gsyncd monitor process
+func (g *Gsyncd) PidFile() string {
+
+	if g.pidfilepath != "" {
+		return g.pidfilepath
+	}
+
+	rundir := config.GetString("rundir")
+	pidfilename := fmt.Sprintf("gsyncd-%s-%s-%s.pid", g.sessioninfo.MasterVol, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol)
+	g.pidfilepath = path.Join(rundir, "gluster", pidfilename)
+	return g.pidfilepath
+}
+
+// NewGsyncd returns a new instance of Gsyncd monitor type which implements the Daemon interface
+func NewGsyncd(sessioninfo Session) (*Gsyncd, error) {
+	// TODO Change this path to dynamic
+	path := "/usr/local/libexec/glusterfs/gsyncd"
+	sessionObject := &Gsyncd{binarypath: path, sessioninfo: sessioninfo}
+	return sessionObject, nil
+}
+
+// ID returns the unique identifier of the gsyncd.
+func (g *Gsyncd) ID() string {
+	return g.sessioninfo.MasterID.String() + "-" + g.sessioninfo.SlaveID.String()
+}

--- a/plugins/georeplication/init.go
+++ b/plugins/georeplication/init.go
@@ -1,0 +1,137 @@
+package georeplication
+
+import (
+	"github.com/gluster/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/transaction"
+	"github.com/prashanthpai/sunrpc"
+)
+
+// Plugin is a structure which implements GlusterdPlugin interface
+type Plugin struct {
+}
+
+// Name returns name of plugin
+func (p *Plugin) Name() string {
+	return "geo-replication"
+}
+
+// SunRPCProgram returns sunrpc program to register with Glusterd
+func (p *Plugin) SunRPCProgram() sunrpc.Program {
+	return nil
+}
+
+// RestRoutes returns list of REST API routes to register with Glusterd
+func (p *Plugin) RestRoutes() route.Routes {
+	return route.Routes{
+		route.Route{
+			Name:        "GeoReplicationCreate",
+			Method:      "PUT",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}",
+			Version:     1,
+			HandlerFunc: georepCreateHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationUpdate",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}",
+			Version:     1,
+			HandlerFunc: georepCreateHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationStart",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/start",
+			Version:     1,
+			HandlerFunc: georepStartHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationPause",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/pause",
+			Version:     1,
+			HandlerFunc: georepPauseHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationResume",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/resume",
+			Version:     1,
+			HandlerFunc: georepResumeHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationStop",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/stop",
+			Version:     1,
+			HandlerFunc: georepStopHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationDelete",
+			Method:      "DELETE",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}",
+			Version:     1,
+			HandlerFunc: georepDeleteHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationStatus",
+			Method:      "GET",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}",
+			Version:     1,
+			HandlerFunc: georepStatusHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationConfigGet",
+			Method:      "GET",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/config",
+			Version:     1,
+			HandlerFunc: georepConfigGetHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationConfigSet",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/config",
+			Version:     1,
+			HandlerFunc: georepConfigSetHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationConfigReset",
+			Method:      "DELETE",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/config",
+			Version:     1,
+			HandlerFunc: georepConfigResetHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationCheckpointSet",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/checkpoint",
+			Version:     1,
+			HandlerFunc: georepCheckpointSetHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationCheckpointReset",
+			Method:      "DELETE",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/checkpoint",
+			Version:     1,
+			HandlerFunc: georepCheckpointResetHandler,
+		},
+		route.Route{
+			Name:        "GeoReplicationCheckpointGet",
+			Method:      "GET",
+			Pattern:     "/geo-replication/{masterid}/{slaveid}/checkpoint",
+			Version:     1,
+			HandlerFunc: georepCheckpointGetHandler,
+		},
+	}
+}
+
+// RegisterStepFuncs registers transaction step functions with
+// Glusterd Transaction framework
+func (p *Plugin) RegisterStepFuncs() {
+	transaction.RegisterStepFunc(txnGsyncdCreate, "georeplication-create.Commit")
+	transaction.RegisterStepFunc(txnGsyncdStart, "georeplication-start.Commit")
+	transaction.RegisterStepFunc(txnGsyncdPause, "georeplication-pause.Commit")
+	transaction.RegisterStepFunc(txnGsyncdResume, "georeplication-resume.Commit")
+	transaction.RegisterStepFunc(txnGsyncdStop, "georeplication-stop.Commit")
+	// transaction.RegisterStepFunc(txnGsyncdDelete, "georeplication-delete.Commit")
+	transaction.RegisterStepFunc(txnGsyncdStatus, "georeplication-status.Commit")
+}

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -1,0 +1,741 @@
+package georeplication
+
+import (
+	errs "errors"
+	"net/http"
+
+	"github.com/gluster/glusterd2/errors"
+	"github.com/gluster/glusterd2/gdctx"
+	restutils "github.com/gluster/glusterd2/servers/rest/utils"
+	"github.com/gluster/glusterd2/transaction"
+	"github.com/gluster/glusterd2/utils"
+	"github.com/gluster/glusterd2/volume"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
+)
+
+func validateMasterAndSlaveIDFormat(w http.ResponseWriter, masteridRaw string, slaveidRaw string) (uuid.UUID, uuid.UUID, error) {
+	// Validate UUID format of Master and Slave Volume ID
+	masterid := uuid.Parse(masteridRaw)
+	if masterid == nil {
+		restutils.SendHTTPError(w, http.StatusBadRequest, "Invalid Master Volume ID")
+		return nil, nil, errs.New("Invalid Master Volume ID")
+	}
+
+	// Validate UUID format of Slave Volume ID
+	slaveid := uuid.Parse(slaveidRaw)
+	if slaveid == nil {
+		restutils.SendHTTPError(w, http.StatusBadRequest, "Invalid Slave Volume ID")
+		return nil, nil, errs.New("Invalid Slave Volume ID")
+	}
+
+	return masterid, slaveid, nil
+}
+
+func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
+	// Collect inputs from URL
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPResponse(w, http.StatusOK, []Session{})
+		return
+	}
+
+	// Get Volume info, which is required to get the Bricks list
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	// Transaction which updates the Geo-rep session
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	lock, unlock, err := transaction.CreateLockSteps(masterid.String() + slaveid.String())
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// TODO: Transaction step function for setting Volume Options
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc: "georeplication-status",
+			Nodes:  []uuid.UUID{gdctx.MyUUID},
+		},
+		unlock,
+	}
+	txn.Ctx.Set("geosession", geoSession)
+
+	rtxn, e := txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to create geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	// Aggregate the results
+	result, err := aggregateGsyncdStatus(rtxn, txn.Nodes)
+	if err != nil {
+		errMsg := "Failed to aggregate gsyncd status results from multiple nodes."
+		logger.WithField("error", err.Error()).Error("gsyncdStatusHandler:" + errMsg)
+		restutils.SendHTTPError(w, http.StatusInternalServerError, errMsg)
+		return
+	}
+
+	for _, b := range vol.Bricks {
+		// Set default values to all status fields, If a node or worker is down and
+		// status not available these default values will be sent back in response
+		geoSession.Workers = append(geoSession.Workers, Worker{
+			MasterNode:                 b.Hostname,
+			MasterNodeID:               b.NodeID.String(),
+			MasterBrickPath:            b.Path,
+			MasterBrick:                b.NodeID.String() + ":" + b.Path,
+			Status:                     "Unknown",
+			LastSyncedTime:             "N/A",
+			LastSyncedTimeUTC:          "N/A",
+			LastEntrySyncedTime:        "N/A",
+			SlaveNode:                  "N/A",
+			ChangeDetection:            "N/A",
+			CheckpointTime:             "N/A",
+			CheckpointTimeUTC:          "N/A",
+			CheckpointCompleted:        false,
+			CheckpointCompletedTime:    "N/A",
+			CheckpointCompletedTimeUTC: "N/A",
+			MetaOps:                    "0",
+			EntryOps:                   "0",
+			DataOps:                    "0",
+			FailedOps:                  "0",
+			CrawlStatus:                "N/A",
+		})
+	}
+
+	// Iterating and assigning status of each brick and not doing direct
+	// assignment. So that order of the workers will be maintained similar
+	// to order of bricks in Master Volume
+	for idx, w := range geoSession.Workers {
+		statusData := (*result)[w.MasterNodeID+":"+w.MasterBrickPath]
+		geoSession.Workers[idx].Status = statusData.Status
+		geoSession.Workers[idx].LastSyncedTime = statusData.LastSyncedTime
+		geoSession.Workers[idx].LastSyncedTimeUTC = statusData.LastSyncedTimeUTC
+		geoSession.Workers[idx].LastEntrySyncedTime = statusData.LastEntrySyncedTime
+		geoSession.Workers[idx].SlaveNode = statusData.SlaveNode
+		geoSession.Workers[idx].ChangeDetection = statusData.ChangeDetection
+		geoSession.Workers[idx].CheckpointTime = statusData.CheckpointTime
+		geoSession.Workers[idx].CheckpointTimeUTC = statusData.CheckpointTimeUTC
+		geoSession.Workers[idx].CheckpointCompleted = statusData.CheckpointCompleted
+		geoSession.Workers[idx].CheckpointCompletedTime = statusData.CheckpointCompletedTime
+		geoSession.Workers[idx].CheckpointCompletedTimeUTC = statusData.CheckpointCompletedTimeUTC
+		geoSession.Workers[idx].MetaOps = statusData.MetaOps
+		geoSession.Workers[idx].EntryOps = statusData.EntryOps
+		geoSession.Workers[idx].DataOps = statusData.DataOps
+		geoSession.Workers[idx].FailedOps = statusData.FailedOps
+		geoSession.Workers[idx].CrawlStatus = statusData.CrawlStatus
+	}
+
+	// Send aggregated result back to the client
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
+	// Collect inputs from URL
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Same handler for both Create and Update, if HTTP method is POST then
+	// it is update request
+	updateRequest := false
+	if r.Method == http.MethodPost {
+		updateRequest = true
+	}
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Parse the JSON body to get additional details of request
+	var req GeorepCreateRequest
+	if err := utils.GetJSONFromRequest(r, &req); err != nil {
+		restutils.SendHTTPError(w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error())
+		return
+	}
+
+	// TODO: Add validation for POST fields
+
+	// Check if Master volume exists and Matches with passed Volume ID
+	vol, e := volume.GetVolume(req.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	// Check if Master Volume ID from store matches the input Master Volume ID
+	if !uuid.Equal(vol.ID, masterid) {
+		restutils.SendHTTPError(w, http.StatusBadRequest, "Master volume ID doesn't match")
+		return
+	}
+
+	// Fetch existing session details from Store, if same
+	// session exists then return error
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err == nil {
+		if !updateRequest {
+			restutils.SendHTTPError(w, http.StatusConflict, "Session already exists")
+			return
+		}
+	} else {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Fail if update request received for non existing Geo-rep session
+		if updateRequest {
+			restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+			return
+		}
+
+		geoSession = new(Session)
+		geoSession.MasterID = masterid
+		geoSession.SlaveID = slaveid
+	}
+
+	// If Update request then it is not allowed to change master volume,
+	// slave volname, Master Volume name and ID is already verified earlier
+	// only validate for slave vol name here
+	if updateRequest && geoSession.SlaveVol != req.SlaveVol {
+		restutils.SendHTTPError(w, http.StatusBadRequest, "Slave Volume name can't be modified")
+		return
+	}
+
+	// Set/Update the input details
+	geoSession.MasterVol = req.MasterVol
+	geoSession.SlaveVol = req.SlaveVol
+	geoSession.SlaveHosts = req.SlaveHosts
+	geoSession.SlaveUser = req.SlaveUser
+
+	// Set Slave user as root if request doesn't contains user name
+	if geoSession.SlaveUser == "" {
+		geoSession.SlaveUser = "root"
+	}
+
+	geoSession.Workers = []Worker{}
+
+	// Transaction which updates the Geo-rep session
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// TODO: Transaction step function for setting Volume Options
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc: "georeplication-create.Commit",
+			Nodes:  []uuid.UUID{gdctx.MyUUID},
+		},
+		unlock,
+	}
+	txn.Ctx.Set("geosession", geoSession)
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to create geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	geoSession.Status = georepStatusCreated
+
+	e = addOrUpdateSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	respCode := http.StatusCreated
+	if updateRequest {
+		respCode = http.StatusOK
+	}
+
+	restutils.SendHTTPResponse(w, respCode, geoSession)
+}
+
+func georepStartHandler(w http.ResponseWriter, r *http.Request) {
+	// Collect inputs from URL
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Fetch existing session details from Store, error if not exists
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+		return
+	}
+
+	if geoSession.Status == georepStatusStarted {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "session already started")
+		return
+	}
+
+	// TODO: Check Volume is in Started State
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	if vol.Status != volume.VolStarted {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "master volume not started")
+		return
+	}
+
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	// TODO: change the lock key
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc: "georeplication-start.Commit",
+			Nodes:  txn.Nodes,
+		},
+		unlock,
+	}
+	txn.Ctx.Set("masterid", masterid.String())
+	txn.Ctx.Set("slaveid", slaveid.String())
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to start geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	geoSession.Status = georepStatusStarted
+
+	e = addOrUpdateSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepPauseHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Fetch existing session details from Store, error if not exists
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+		return
+	}
+
+	if geoSession.Status == georepStatusPaused {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "session already in pause state")
+		return
+	}
+
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	// TODO: change the lock key
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc:   "georeplication-pause.Commit",
+			UndoFunc: "georeplication-pause.Undo",
+			Nodes:    txn.Nodes,
+		},
+		unlock,
+	}
+	txn.Ctx.Set("masterid", masterid.String())
+	txn.Ctx.Set("slaveid", slaveid.String())
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to start geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	geoSession.Status = georepStatusPaused
+
+	e = addOrUpdateSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepResumeHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Fetch existing session details from Store, error if not exists
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+		return
+	}
+
+	if geoSession.Status != georepStatusPaused {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "session not in paused state")
+		return
+	}
+
+	// TODO: Check Volume is in Started State
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	if vol.Status != volume.VolStarted {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "master volume not started")
+		return
+	}
+
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	// TODO: change the lock key
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc:   "georeplication-resume.Commit",
+			UndoFunc: "georeplication-resume.Undo",
+			Nodes:    txn.Nodes,
+		},
+		unlock,
+	}
+	txn.Ctx.Set("masterid", masterid.String())
+	txn.Ctx.Set("slaveid", slaveid.String())
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to resume geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	geoSession.Status = georepStatusStarted
+
+	e = addOrUpdateSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepStopHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Fetch existing session details from Store, error if not exists
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+		return
+	}
+
+	if geoSession.Status == georepStatusStopped {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "session already stopped")
+		return
+	}
+
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	// TODO: change the lock key
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc:   "georeplication-stop.Commit",
+			UndoFunc: "georeplication-stop.Undo",
+			Nodes:    txn.Nodes,
+		},
+		unlock,
+	}
+	txn.Ctx.Set("masterid", masterid.String())
+	txn.Ctx.Set("slaveid", slaveid.String())
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to stop geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	geoSession.Status = georepStatusStopped
+
+	e = addOrUpdateSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	masteridRaw := p["masterid"]
+	slaveidRaw := p["slaveid"]
+
+	reqID, logger := restutils.GetReqIDandLogger(r)
+
+	// Validate UUID format of Master and Slave Volume ID
+	masterid, slaveid, err := validateMasterAndSlaveIDFormat(w, masteridRaw, slaveidRaw)
+	if err != nil {
+		return
+	}
+
+	// Fetch existing session details from Store, error if not exists
+	geoSession, err := getSession(masterid.String(), slaveid.String())
+	if err != nil {
+		// Continue only if NotFound error, return if other errors like
+		// error while fetching from store or JSON marshal errors
+		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
+			restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		restutils.SendHTTPError(w, http.StatusBadRequest, "geo-replication session not found")
+		return
+	}
+
+	if geoSession.Status == georepStatusStarted {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, "session already started")
+		return
+	}
+
+	// TODO: Check Volume is in Started State
+	vol, e := volume.GetVolume(geoSession.MasterVol)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusNotFound, errors.ErrVolNotFound.Error())
+		return
+	}
+
+	txn := transaction.NewTxn(reqID)
+	defer txn.Cleanup()
+	// TODO: change the lock key
+	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
+	if err != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	txn.Nodes = vol.Nodes()
+	txn.Steps = []*transaction.Step{
+		lock,
+		{
+			DoFunc:   "georeplication-delete.Commit",
+			UndoFunc: "georeplication-delete.Undo",
+			Nodes:    txn.Nodes,
+		},
+		unlock,
+	}
+	txn.Ctx.Set("masterid", masterid.String())
+	txn.Ctx.Set("slaveid", slaveid.String())
+
+	_, e = txn.Do()
+	if e != nil {
+		logger.WithFields(log.Fields{
+			"error":    e.Error(),
+			"masterid": masterid,
+			"slaveid":  slaveid,
+		}).Error("failed to delete geo-replication session")
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	e = deleteSession(geoSession)
+	if e != nil {
+		restutils.SendHTTPError(w, http.StatusInternalServerError, e.Error())
+		return
+	}
+
+	restutils.SendHTTPResponse(w, http.StatusOK, geoSession)
+}
+
+func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Config Get")
+}
+
+func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Config Set")
+}
+
+func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Config Reset")
+}
+
+func georepCheckpointSetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Checkpoint Set")
+}
+
+func georepCheckpointResetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Checkpoint Reset")
+}
+
+func georepCheckpointGetHandler(w http.ResponseWriter, r *http.Request) {
+	restutils.SendHTTPResponse(w, http.StatusOK, "Geo-replication Checkpoint Status")
+}

--- a/plugins/georeplication/store-utils.go
+++ b/plugins/georeplication/store-utils.go
@@ -1,0 +1,59 @@
+package georeplication
+
+import (
+	"context"
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gluster/glusterd2/store"
+)
+
+const (
+	georepPrefix string = store.GlusterPrefix + "georeplication/"
+)
+
+// getSession fetches the json object from the store and unmarshalls it into
+// Info object
+func getSession(masterid string, slaveid string) (*Session, error) {
+	var v Session
+	resp, e := store.Store.Get(context.TODO(), georepPrefix+masterid+"/"+slaveid)
+	if e != nil {
+		log.WithError(e).Error("Couldn't retrive geo-replication session from store")
+		return nil, e
+	}
+
+	if resp.Count != 1 {
+		return nil, &ErrGeorepSessionNotFound{}
+	}
+
+	if e = json.Unmarshal(resp.Kvs[0].Value, &v); e != nil {
+		log.WithError(e).Error("Failed to unmarshal the data into georepinfo object")
+		return nil, e
+	}
+	return &v, nil
+}
+
+// addOrUpdateSession marshals the georep session object and passes to store to add/update
+func addOrUpdateSession(v *Session) error {
+	json, e := json.Marshal(v)
+	if e != nil {
+		log.WithField("error", e).Error("Failed to marshal the Info object")
+		return e
+	}
+
+	_, e = store.Store.Put(context.TODO(), georepPrefix+v.MasterID.String()+"/"+v.SlaveID.String(), string(json))
+	if e != nil {
+		log.WithError(e).Error("Couldn't add georeplication session to store")
+		return e
+	}
+	return nil
+}
+
+func deleteSession(v *Session) error {
+	_, e := store.Store.Delete(context.TODO(), georepPrefix+v.MasterID.String()+"/"+v.SlaveID.String())
+	if e != nil {
+		log.WithError(e).Error("Couldn't remove georeplication session from store")
+		return e
+	}
+	return nil
+}

--- a/plugins/georeplication/struct.go
+++ b/plugins/georeplication/struct.go
@@ -1,0 +1,57 @@
+package georeplication
+
+import (
+	"github.com/pborman/uuid"
+)
+
+const (
+	georepStatusCreated = "Created"
+	georepStatusStarted = "Started"
+	georepStatusStopped = "Stopped"
+	georepStatusPaused  = "Paused"
+)
+
+// Worker represents Geo-replication Worker
+type Worker struct {
+	MasterNode                 string `json:"master_node"`
+	MasterNodeID               string `json:"node_id"`
+	MasterBrickPath            string `json:"master_brick_path"`
+	MasterBrick                string `json:"master_brick"`
+	Status                     string `json:"status"`
+	LastSyncedTime             string `json:"last_synced_time"`
+	LastSyncedTimeUTC          string `json:"last_synced_time_utc"`
+	LastEntrySyncedTime        string `json:"last_synced_entry"`
+	SlaveNode                  string `json:"slave_node"`
+	ChangeDetection            string `json:"change_detection"`
+	CheckpointTime             string `json:"checkpoint_time"`
+	CheckpointTimeUTC          string `json:"checkpoint_time_utc"`
+	CheckpointCompleted        bool   `json:"checkpoint_completed"`
+	CheckpointCompletedTime    string `json:"checkpoint_completed_time"`
+	CheckpointCompletedTimeUTC string `json:"checkpoint_completed_time_utc"`
+	MetaOps                    string `json:"meta"`
+	EntryOps                   string `json:"entry"`
+	DataOps                    string `json:"data"`
+	FailedOps                  string `json:"failures"`
+	CrawlStatus                string `json:"crawl_status"`
+}
+
+// Session represents Geo-replication session
+type Session struct {
+	MasterID   uuid.UUID         `json:"master_volume_id"`
+	SlaveID    uuid.UUID         `json:"slave_volume_id"`
+	MasterVol  string            `json:"master_volume"`
+	SlaveUser  string            `json:"slave_user"`
+	SlaveHosts []string          `json:"slave_hosts"`
+	SlaveVol   string            `json:"slave_volume"`
+	Status     string            `json:"monitor_status"`
+	Workers    []Worker          `json:"workers"`
+	Options    map[string]string `json:"options"`
+}
+
+// GeorepCreateRequest represents REST API request to create Geo-rep session
+type GeorepCreateRequest struct {
+	MasterVol  string   `json:"mastervol"`
+	SlaveUser  string   `json:"slaveuser"`
+	SlaveHosts []string `json:"slavehosts"`
+	SlaveVol   string   `json:"slavevol"`
+}

--- a/plugins/georeplication/transactions.go
+++ b/plugins/georeplication/transactions.go
@@ -1,0 +1,341 @@
+package georeplication
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/gluster/glusterd2/daemon"
+	"github.com/gluster/glusterd2/gdctx"
+	"github.com/gluster/glusterd2/transaction"
+	"github.com/gluster/glusterd2/volume"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pborman/uuid"
+)
+
+const (
+	gsyncdCmd                    = "/usr/local/libexec/glusterfs/gsyncd"
+	gsyncdStartMaxRetries        = 10
+	gsyncdStatusTxnKey    string = "gsyncdstatuses"
+)
+
+func txnGsyncdCreate(c transaction.TxnCtx) error {
+	var sessioninfo Session
+	if err := c.Get("geosession", &sessioninfo); err != nil {
+		return err
+	}
+
+	if err := addOrUpdateSession(&sessioninfo); err != nil {
+		c.Logger().WithError(err).WithField(
+			"masterid", sessioninfo.MasterID).WithField(
+			"slaveid", sessioninfo.SlaveID).Debug(
+			"failed to store Geo-replication info")
+		return err
+	}
+
+	return nil
+}
+
+func startGsyncdMonitor(sess *Session) error {
+
+	gsyncdDaemon, err := NewGsyncd(*sess)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < gsyncdStartMaxRetries; i++ {
+		err = daemon.Start(gsyncdDaemon, true)
+		if err != nil {
+			return err
+		}
+
+		break
+	}
+
+	return nil
+}
+
+func stopGsyncdMonitor(sess *Session) error {
+	gsyncdDaemon, err := NewGsyncd(*sess)
+	if err != nil {
+		return err
+	}
+
+	err = daemon.Stop(gsyncdDaemon, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func pauseGsyncdMonitor(sess *Session) error {
+	gsyncdDaemon, err := NewGsyncd(*sess)
+	if err != nil {
+		return err
+	}
+
+	err = daemon.Pause(gsyncdDaemon)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resumeGsyncdMonitor(sess *Session) error {
+	gsyncdDaemon, err := NewGsyncd(*sess)
+	if err != nil {
+		return err
+	}
+
+	err = daemon.Resume(gsyncdDaemon)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txnGsyncdStart(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	if err := c.Get("masterid", &masterid); err != nil {
+		return err
+	}
+	if err := c.Get("slaveid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+	c.Logger().WithFields(log.Fields{
+		"master": sessioninfo.MasterVol,
+		"slave":  sessioninfo.SlaveHosts[0] + "::" + sessioninfo.SlaveVol,
+	}).Info("Starting gsyncd monitor")
+
+	if err := startGsyncdMonitor(sessioninfo); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txnGsyncdStop(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	if err := c.Get("masterid", &masterid); err != nil {
+		return err
+	}
+	if err := c.Get("slaveid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+	c.Logger().WithFields(log.Fields{
+		"master": sessioninfo.MasterVol,
+		"slave":  sessioninfo.SlaveHosts[0] + "::" + sessioninfo.SlaveVol,
+	}).Info("Stopping gsyncd monitor")
+
+	if err := stopGsyncdMonitor(sessioninfo); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txnGsyncdPause(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	if err := c.Get("masterid", &masterid); err != nil {
+		return err
+	}
+	if err := c.Get("slaveid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+	c.Logger().WithFields(log.Fields{
+		"master": sessioninfo.MasterVol,
+		"slave":  sessioninfo.SlaveHosts[0] + "::" + sessioninfo.SlaveVol,
+	}).Info("Pausing gsyncd monitor")
+
+	if err := pauseGsyncdMonitor(sessioninfo); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txnGsyncdResume(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	if err := c.Get("masterid", &masterid); err != nil {
+		return err
+	}
+	if err := c.Get("slaveid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+	c.Logger().WithFields(log.Fields{
+		"master": sessioninfo.MasterVol,
+		"slave":  sessioninfo.SlaveHosts[0] + "::" + sessioninfo.SlaveVol,
+	}).Info("Resuming gsyncd monitor")
+
+	if err := resumeGsyncdMonitor(sessioninfo); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txnGsyncdStatus(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	var err error
+
+	if err = c.Get("masterid", &masterid); err != nil {
+		return err
+	}
+
+	if err = c.Get("slaveid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+
+	// Get Master vol info to get the bricks List
+	volinfo, err := volume.GetVolume(sessioninfo.MasterVol)
+	if err != nil {
+		return err
+	}
+
+	var workersStatuses = make(map[string]Worker)
+
+	for _, w := range volinfo.Bricks {
+
+		if !uuid.Equal(w.NodeID, gdctx.MyUUID) {
+			continue
+		}
+
+		// Example output: This may change in future, gsyncd can provide json
+		// instead of this format.
+		// checkpoint_time: N/A
+		// last_synced_entry: 0
+		// last_synced_utc: N/A
+		// checkpoint_completion_time_utc: N/A
+		// checkpoint_completed: N/A
+		// meta: N/A
+		// entry: N/A
+		// slave_node: N/A
+		// data: N/A
+		// worker_status: Created
+		// checkpoint_completion_time: N/A
+		// checkpoint_completed_time: N/A
+		// last_synced: N/A
+		// checkpoint_time_utc: N/A
+		// failures: N/A
+		// crawl_status: N/A
+
+		gsyncd, err := NewGsyncd(*sessioninfo)
+		if err != nil {
+			return err
+		}
+		args := gsyncd.StatusArgs(w.Path)
+
+		out, err := exec.Command(gsyncdCmd, args).Output()
+		if err != nil {
+			return errors.New("Unable to execute gsyncd command")
+		}
+
+		data := strings.TrimSpace(string(out))
+
+		for _, line := range strings.Split(data, "\n") {
+			data := strings.SplitN(line, ":", 1)
+			var worker Worker
+
+			val := strings.TrimSpace(data[1])
+			switch data[0] {
+			case "checkpoint_time":
+				worker.CheckpointTime = val
+			case "last_synced_entry":
+				worker.LastEntrySyncedTime = val
+			case "last_synced_utc":
+				worker.LastSyncedTimeUTC = val
+			case "checkpoint_completion_time_utc":
+				worker.CheckpointCompletedTimeUTC = val
+			case "checkpoint_completed":
+				if val == "Yes" {
+					worker.CheckpointCompleted = true
+				} else {
+					worker.CheckpointCompleted = false
+				}
+			case "meta":
+				worker.MetaOps = val
+			case "entry":
+				worker.EntryOps = val
+			case "slave_node":
+				worker.SlaveNode = val
+			case "data":
+				worker.DataOps = val
+			case "worker_status":
+				worker.Status = val
+			case "checkpoint_completion_time":
+				worker.CheckpointCompletedTime = val
+			case "last_synced":
+				worker.LastSyncedTime = val
+			case "checkpoint_time_utc":
+				worker.CheckpointTimeUTC = val
+			case "failures":
+				worker.FailedOps = val
+			case "crawl_status":
+				worker.CrawlStatus = val
+			default:
+			}
+
+			// Unique key for master brick UUID:BRICK_PATH
+			key := gdctx.MyUUID.String() + ":" + w.Path
+			workersStatuses[key] = worker
+		}
+	}
+
+	c.SetNodeResult(gdctx.MyUUID, gsyncdStatusTxnKey, workersStatuses)
+	return nil
+}
+
+func aggregateGsyncdStatus(ctx transaction.TxnCtx, nodes []uuid.UUID) (*map[string]Worker, error) {
+	var workersStatuses = make(map[string]Worker)
+
+	// Loop over each node on which txn was run.
+	// Fetch brick statuses stored by each node in transaction context.
+	for _, node := range nodes {
+		var tmp = make(map[string]Worker)
+		err := ctx.GetNodeResult(node, gsyncdStatusTxnKey, &tmp)
+		if err != nil {
+			return nil, errors.New("aggregateGsyncdStatus: Could not fetch results from transaction context")
+		}
+
+		// Single final Hashmap
+		for k, v := range tmp {
+			workersStatuses[k] = v
+		}
+	}
+
+	return &workersStatuses, nil
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -3,10 +3,12 @@
 package plugins
 
 import (
+	"github.com/gluster/glusterd2/plugins/georeplication"
 	"github.com/gluster/glusterd2/plugins/hello"
 )
 
 // PluginsList is a list of plugins which implements GlusterdPlugin interface
 var PluginsList = []GlusterdPlugin{
 	&hello.Plugin{},
+	&georeplication.Plugin{},
 }


### PR DESCRIPTION
Added REST APIs placeholder for Geo-replication APIs, actual
implementation yet to be implemented.

Session Create API:
PUT /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}

Session Start/Stop/Pause/Resume API:
POST /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/{action}

Session Delete API:
DELETE /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}

Config Get, Set and Reset APIs:
GET /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/config
POST /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/config
DELETE /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/config

Session Status API:
GET /geo-replication

Checkpoint Get, Set and Reset APIs:
GET /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/checkpoint
POST /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/checkpoint
DELETE /geo-replication/{mastervol}/{slaveuser}/{slavehost}/{slavevol}/checkpoint

Updates: #271
Signed-off-by: Aravinda VK <avishwan@redhat.com>