### PR TITLE
Store client volfile in etcd

### DIFF
--- a/commands/peers/addpeer.go
+++ b/commands/peers/addpeer.go
@@ -28,7 +28,7 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(w, http.StatusBadRequest, errors.ErrNoHostnamesPresent.Error())
 		return
 	}
-	log.WithField("addresses", req.Addresses).Debug("recieved request to add new peer with given addresses")
+	log.WithField("addresses", req.Addresses).Debug("received request to add new peer with given addresses")
 
 	p, _ := peer.GetPeerByAddrs(req.Addresses)
 	if p != nil {

--- a/commands/peers/deletepeer.go
+++ b/commands/peers/deletepeer.go
@@ -31,7 +31,7 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 	//	- Send the Leave request
 
 	logger := log.WithField("peerid", id)
-	logger.Debug("recieved delete peer request")
+	logger.Debug("received delete peer request")
 
 	// Check whether the member exists
 	p, err := peer.GetPeerF(id)
@@ -40,14 +40,14 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(w, http.StatusInternalServerError, "could not validate delete request")
 		return
 	} else if p == nil {
-		logger.Debug("request denied, recieved request to remove unknown peer")
+		logger.Debug("request denied, received request to remove unknown peer")
 		restutils.SendHTTPError(w, http.StatusNotFound, "peer not found in cluster")
 		return
 	}
 
 	// You cannot remove yourself
 	if id == gdctx.MyUUID.String() {
-		logger.Debug("request denied, recieved request to delete self from cluster")
+		logger.Debug("request denied, received request to delete self from cluster")
 		restutils.SendHTTPError(w, http.StatusBadRequest, "removing self is disallowed.")
 		return
 	}

--- a/commands/peers/errors.go
+++ b/commands/peers/errors.go
@@ -21,7 +21,7 @@ func init() {
 	errorStrings[ErrAnotherCluster] = "peer is part of another cluster"
 	errorStrings[ErrHaveVolumes] = "peer has existing volumes"
 	errorStrings[ErrStoreReconfigFailed] = "store reconfigure failed on peer"
-	errorStrings[ErrUnknownPeer] = "request recieved from unknown peer"
+	errorStrings[ErrUnknownPeer] = "request received from unknown peer"
 }
 
 func (e Error) String() string {

--- a/commands/peers/peer-rpc-svc.go
+++ b/commands/peers/peer-rpc-svc.go
@@ -34,7 +34,7 @@ func (p *PeerService) Join(ctx context.Context, req *JoinReq) (*JoinRsp, error) 
 	// 	- TODO: Ensure no ongoing operations (transactions/other peer requests) are happening
 	// 	- TODO: Check is peer is part of another cluster
 	// 	- Check if the peer has volumes
-	//	- Reconfigure the store with recieved configuration
+	//	- Reconfigure the store with received configuration
 	// 	- Return your ID
 
 	// TODO: Ensure no other operations are happening
@@ -78,10 +78,10 @@ func (p *PeerService) Leave(ctx context.Context, req *LeaveReq) (*LeaveRsp, erro
 		logger.Info("could not verify peer")
 		return &LeaveRsp{int32(ErrUnknownPeer)}, nil
 	} else if p == nil {
-		logger.Info("rejecting leave, request recieved from unknown peer")
+		logger.Info("rejecting leave, request received from unknown peer")
 		return &LeaveRsp{int32(ErrUnknownPeer)}, nil
 	}
-	logger.Debug("request recieved from known peer")
+	logger.Debug("request received from known peer")
 
 	// TODO: Check if you can leave the cluster
 	// The peer sending the leave request should have done the check, but check
@@ -106,7 +106,7 @@ func ReconfigureStore(c *StoreConfig) error {
 	store.Destroy()
 	// TODO: Also need to destroy any old files in localstatedir (eg. volfiles)
 
-	// Restart the store with recieved configuration
+	// Restart the store with received configuration
 	cfg := store.GetConfig()
 	cfg.Endpoints = c.Endpoints
 

--- a/commands/volumes/volume-create.go
+++ b/commands/volumes/volume-create.go
@@ -139,7 +139,7 @@ func registerVolCreateStepFuncs() {
 		sf   transaction.StepFunc
 	}{
 		{"vol-create.Stage", validateVolumeCreate},
-		{"vol-create.Commit", generateVolfiles},
+		{"vol-create.Commit", generateBrickVolfiles},
 		{"vol-create.Store", storeVolume},
 		{"vol-create.Rollback", rollBackVolumeCreate},
 	}

--- a/commands/volumes/volume-create_test.go
+++ b/commands/volumes/volume-create_test.go
@@ -99,24 +99,3 @@ func TestValidateVolumeCreate(t *testing.T) {
 	e = validateVolumeCreate(c)
 	tests.Assert(t, e == errBad)
 }
-
-// TestStoreVolume tests storeVolume
-func TestStoreVolume(t *testing.T) {
-	defer heketitests.Patch(&peer.GetPeerIDByAddrF, peer.GetPeerIDByAddrMockGood).Restore()
-	msg := new(VolCreateRequest)
-
-	msg.Name = "vol"
-	msg.Bricks = []string{"127.0.0.1:/tmp/b1", "127.0.0.1:/tmp/b2"}
-
-	vol, e := createVolinfo(msg)
-
-	c := transaction.NewMockCtx()
-	c.Set("volinfo", vol)
-	// Mock store failure
-	defer heketitests.Patch(&volume.AddOrUpdateVolumeFunc, func(vinfo *volume.Volinfo) error {
-		return errBad
-	}).Restore()
-	e = storeVolume(c)
-	tests.Assert(t, e == errBad)
-
-}

--- a/commands/volumes/volume-option.go
+++ b/commands/volumes/volume-option.go
@@ -21,29 +21,13 @@ type VolOptionRequest struct {
 	Options map[string]string `json:"options"`
 }
 
-func updateVolinfoOnOptionChange(c transaction.TxnCtx) error {
-
-	var volinfo volume.Volinfo
-	if err := c.Get("volinfo", &volinfo); err != nil {
-		return err
-	}
-
-	if err := volume.AddOrUpdateVolumeFunc(&volinfo); err != nil {
-		c.Logger().WithError(err).WithField(
-			"volume", volinfo.Name).Debug("failed to store volume info")
-		return err
-	}
-
-	return nil
-}
-
 func registerVolOptionStepFuncs() {
 	var sfs = []struct {
 		name string
 		sf   transaction.StepFunc
 	}{
-		{"vol-option.UpdateVolinfo", updateVolinfoOnOptionChange},
-		{"vol-option.RegenerateVolfiles", generateVolfiles},
+		{"vol-option.UpdateVolinfo", storeVolume},
+		{"vol-option.RegenerateVolfiles", generateBrickVolfiles},
 		{"vol-option.NotifyVolfileChange", notifyVolfileChange},
 	}
 	for _, sf := range sfs {

--- a/pkg/elasticetcd/leader.go
+++ b/pkg/elasticetcd/leader.go
@@ -196,7 +196,7 @@ func (ee *ElasticEtcd) nominate(host string, urls types.URLs) error {
 	// Add the new host to the nominees list.
 	// Wait a little for the nominee to pick up the nomination.
 	// Then add the new host as an etcd member.
-	// If we add the new host as a member first, the embeded etcd will begin
+	// If we add the new host as a member first, the embedded etcd will begin
 	// trying to connect to the newly added member and which causes new requests
 	// to be blocked, for example the PUT request to add the new nominee.
 	// If we don't wait for a little while before adding the nominee as a member,


### PR DESCRIPTION
This will ensure that all nodes will have access to client volfile to serve
glusterfs clients (mounts). The client volfile will only be (re)generated
on the transaction's initiator node.

Closes #185, #340

Signed-off-by: Prashanth Pai <ppai@redhat.com>