### PR TITLE
Create .glusterfs/indices as a workaround

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -229,6 +229,12 @@ func ValidateBrickPathStats(brickPath string, host string, force bool) error {
 
 	}
 
+	// Workaround till https://review.gluster.org/#/c/18003/ gets in
+	if err := os.MkdirAll(filepath.Join(brickPath, ".glusterfs", "indices"), os.ModeDir|os.ModePerm); err != nil {
+		log.WithError(err).Error("failed to create .glusterfs/indices directory")
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The index xlator expects glusterd to create that directory.
This is needed until https://review.gluster.org/#/c/18003/ is merged.

Closes #353 

Signed-off-by: Prashanth Pai <ppai@redhat.com>