### PR TITLE
Make UUID:path as the ONLY way of specifying brick during volume create

### DIFF
--- a/brick/glusterfsd.go
+++ b/brick/glusterfsd.go
@@ -87,7 +87,8 @@ func (b *Glusterfsd) SocketFile() string {
 	// First we form a fake path to the socket file
 	// Example: /var/lib/glusterd/vols/<vol-name>/run/<host-name>-<brick-path>
 	brickPathWithoutSlashes := strings.Trim(strings.Replace(b.brickinfo.Path, "/", "-", -1), "-")
-	fakeSockFileName := fmt.Sprintf("%s-%s", b.brickinfo.Hostname, brickPathWithoutSlashes)
+	// FIXME: The brick can no longer clean this up on clean shut down
+	fakeSockFileName := fmt.Sprintf("%s-%s", b.brickinfo.NodeID.String(), brickPathWithoutSlashes)
 	volumedir := utils.GetVolumeDir(b.brickinfo.VolumeName)
 	fakeSockFilePath := path.Join(volumedir, "run", fakeSockFileName)
 
@@ -109,7 +110,8 @@ func (b *Glusterfsd) PidFile() string {
 
 	rundir := config.GetString("rundir")
 	brickPathWithoutSlashes := strings.Trim(strings.Replace(b.brickinfo.Path, "/", "-", -1), "-")
-	pidfilename := fmt.Sprintf("%s-%s.pid", b.brickinfo.Hostname, brickPathWithoutSlashes)
+	// FIXME: The brick can no longer clean this up on clean shut down
+	pidfilename := fmt.Sprintf("%s-%s.pid", b.brickinfo.NodeID.String(), brickPathWithoutSlashes)
 	b.pidfilepath = path.Join(rundir, "gluster", pidfilename)
 
 	return b.pidfilepath

--- a/brick/types.go
+++ b/brick/types.go
@@ -6,11 +6,14 @@ import (
 
 // Brickinfo is the static information about the brick
 type Brickinfo struct {
-	Hostname   string
 	NodeID     uuid.UUID
 	Path       string
 	VolumeName string
 	VolumeID   uuid.UUID
+}
+
+func (b *Brickinfo) String() string {
+	return b.NodeID.String() + ":" + b.Path
 }
 
 // Brickstatus represents real-time status of the brick and contains dynamic

--- a/commands/volumes/brickutils.go
+++ b/commands/volumes/brickutils.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gluster/glusterd2/brick"
 	"github.com/gluster/glusterd2/daemon"
-	"github.com/gluster/glusterd2/peer"
 	"github.com/gluster/glusterd2/utils"
 
 	"github.com/pborman/uuid"
@@ -85,11 +84,6 @@ func nodesFromBricks(bricks []string) ([]uuid.UUID, error) {
 	for _, b := range bricks {
 		present = false
 
-		// Bricks specified can have one of the following formats:
-		// <peer-uuid>:<brick-path>
-		// <ip>:<port>:<brick-path>
-		// <ip>:<brick-path>
-
 		host, _, err := utils.ParseHostAndBrickPath(b)
 		if err != nil {
 			return nil, err
@@ -97,13 +91,11 @@ func nodesFromBricks(bricks []string) ([]uuid.UUID, error) {
 
 		id := uuid.Parse(host)
 		if id == nil {
-			// Host specified is IP or IP:port
-			id, err = peer.GetPeerIDByAddrF(host)
-			if err != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
+		// if multiple bricks are on the same node, include the node
+		// only once in the returned list
 		for _, n := range nodes {
 			if uuid.Equal(id, n) == true {
 				present = true

--- a/commands/volumes/volume-create_test.go
+++ b/commands/volumes/volume-create_test.go
@@ -54,11 +54,12 @@ func TestUnmarshalVolCreateRequest(t *testing.T) {
 // TestCreateVolinfo validates createVolinfo()
 func TestCreateVolinfo(t *testing.T) {
 	defer heketitests.Patch(&peer.GetPeerIDByAddrF, peer.GetPeerIDByAddrMockGood).Restore()
+	defer heketitests.Patch(&peer.GetPeerF, peer.GetPeerFMockGood).Restore()
 
 	msg := new(VolCreateRequest)
-
+	u := uuid.NewRandom()
 	msg.Name = "vol"
-	msg.Bricks = []string{"127.0.0.1:/tmp/b1", "127.0.0.1:/tmp/b2"}
+	msg.Bricks = []string{u.String() + ":/tmp/b1", u.String() + ":/tmp/b2"}
 	vol, e := createVolinfo(msg)
 	tests.Assert(t, e == nil && vol != nil)
 
@@ -75,7 +76,8 @@ func TestValidateVolumeCreate(t *testing.T) {
 	msg := new(VolCreateRequest)
 
 	msg.Name = "vol"
-	msg.Bricks = []string{"127.0.0.1:/tmp/b1", "127.0.0.1:/tmp/b2"}
+	u := uuid.NewRandom()
+	msg.Bricks = []string{u.String() + ":/tmp/b1", u.String() + ":/tmp/b2"}
 
 	c := transaction.NewMockCtx()
 	c.Set("req", msg)
@@ -84,6 +86,7 @@ func TestValidateVolumeCreate(t *testing.T) {
 		return 0, nil
 	}).Restore()
 	defer heketitests.Patch(&peer.GetPeerIDByAddrF, peer.GetPeerIDByAddrMockGood).Restore()
+	defer heketitests.Patch(&peer.GetPeerF, peer.GetPeerFMockGood).Restore()
 
 	vol, e := createVolinfo(msg)
 	tests.Assert(t, e == nil)

--- a/commands/volumes/volume-expand.go
+++ b/commands/volumes/volume-expand.go
@@ -77,7 +77,7 @@ func startBricksOnExpand(c transaction.TxnCtx) error {
 
 		c.Logger().WithFields(log.Fields{
 			"volume": b.VolumeName,
-			"brick":  b.Hostname + ":" + b.Path,
+			"brick":  b.String(),
 		}).Info("Starting brick")
 
 		if err := startBrick(b); err != nil {
@@ -104,14 +104,14 @@ func undoStartBricksOnExpand(c transaction.TxnCtx) error {
 
 		c.Logger().WithFields(log.Fields{
 			"volume": b.VolumeName,
-			"brick":  b.Hostname + ":" + b.Path,
+			"brick":  b.String(),
 		}).Info("volume expand failed, stopping brick")
 
 		if err := stopBrick(b); err != nil {
 			c.Logger().WithFields(log.Fields{
 				"error":  err,
 				"volume": b.VolumeName,
-				"brick":  b.Hostname + ":" + b.Path,
+				"brick":  b.String(),
 			}).Debug("stopping brick failed")
 			// can't know here which of the new bricks started
 			// so stopping brick might fail, but log anyway
@@ -121,7 +121,7 @@ func undoStartBricksOnExpand(c transaction.TxnCtx) error {
 			c.Logger().WithFields(log.Fields{
 				"error":  err,
 				"volume": b.VolumeName,
-				"brick":  b.Hostname + ":" + b.Path,
+				"brick":  b.String(),
 			}).Debug("failed to remove brick volfile")
 		}
 	}

--- a/commands/volumes/volume-start.go
+++ b/commands/volumes/volume-start.go
@@ -33,7 +33,7 @@ func startAllBricks(c transaction.TxnCtx) error {
 
 		c.Logger().WithFields(log.Fields{
 			"volume": b.VolumeName,
-			"brick":  b.Hostname + ":" + b.Path,
+			"brick":  b.String(),
 		}).Info("Starting brick")
 
 		if err := startBrick(b); err != nil {
@@ -72,7 +72,7 @@ func stopAllBricks(c transaction.TxnCtx) error {
 
 		c.Logger().WithFields(log.Fields{
 			"volume": b.VolumeName,
-			"brick":  b.Hostname + ":" + b.Path,
+			"brick":  b.String(),
 		}).Info("volume start failed, stopping brick")
 
 		if err := stopBrick(b); err != nil {

--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -40,14 +40,13 @@ func stopBricks(c transaction.TxnCtx) error {
 				return err
 			}
 
-			brickname := b.Hostname + ":" + b.Path
 			c.Logger().WithFields(log.Fields{
-				"volume": volname, "brick": brickname}).Info("Stopping brick")
+				"volume": volname, "brick": b.String()}).Info("Stopping brick")
 
 			client, err := daemon.GetRPCClient(brickDaemon)
 			if err != nil {
 				c.Logger().WithError(err).WithField(
-					"brick", brickname).Error("failed to connect to brick, sending SIGTERM")
+					"brick", b.String()).Error("failed to connect to brick, sending SIGTERM")
 				daemon.Stop(brickDaemon, false)
 				continue
 			}
@@ -60,7 +59,7 @@ func stopBricks(c transaction.TxnCtx) error {
 			err = client.Call("BrickOp", req, &rsp)
 			if err != nil || rsp.OpRet != 0 {
 				c.Logger().WithError(err).WithField(
-					"brick", brickname).Error("failed to send terminate RPC, sending SIGTERM")
+					"brick", b.String()).Error("failed to send terminate RPC, sending SIGTERM")
 				daemon.Stop(brickDaemon, false)
 			}
 		}

--- a/e2e/restart_test.go
+++ b/e2e/restart_test.go
@@ -26,7 +26,7 @@ func TestRestart(t *testing.T) {
 	createReq := api.VolCreateReq{
 		Name: "vol1",
 		Bricks: []string{
-			gd.PeerAddress + ":" + dir,
+			gd.PeerID() + ":" + dir,
 		},
 		Force: true,
 	}

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -18,6 +18,7 @@ func TestVolumeCreateDelete(t *testing.T) {
 	defer teardownCluster(gds)
 
 	brickDir, err := ioutil.TempDir("", "TestVolumeCreateDelete")
+	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 
 	var brickPaths []string

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -35,10 +35,10 @@ func TestVolumeCreateDelete(t *testing.T) {
 		Name:    volname,
 		Replica: 2,
 		Bricks: []string{
-			gds[0].PeerAddress + ":" + brickPaths[0],
-			gds[1].PeerAddress + ":" + brickPaths[1],
-			gds[0].PeerAddress + ":" + brickPaths[2],
-			gds[1].PeerAddress + ":" + brickPaths[3]},
+			gds[0].PeerID() + ":" + brickPaths[0],
+			gds[1].PeerID() + ":" + brickPaths[1],
+			gds[0].PeerID() + ":" + brickPaths[2],
+			gds[1].PeerID() + ":" + brickPaths[3]},
 		Force: true,
 	}
 	_, errVolCreate := client.VolumeCreate(createReq)

--- a/peer/store-utils-mock.go
+++ b/peer/store-utils-mock.go
@@ -13,6 +13,12 @@ func GetPeerIDByAddrMockGood(addr string) (uuid.UUID, error) {
 	return uuid.NewRandom(), nil
 }
 
+// GetPeerFMockGood returns a mock Peer
+func GetPeerFMockGood(id string) (*Peer, error) {
+	var p Peer
+	return &p, nil
+}
+
 // GetPeerIDByAddrMockBad returns an error when called
 func GetPeerIDByAddrMockBad(addr string) (uuid.UUID, error) {
 	return nil, errors.ErrPeerNotFound

--- a/pkg/api/resp.go
+++ b/pkg/api/resp.go
@@ -25,7 +25,6 @@ type VolAuth struct {
 
 // Brickinfo is the static information about the brick
 type Brickinfo struct {
-	Hostname   string
 	NodeID     uuid.UUID
 	Path       string
 	VolumeName string

--- a/servers/sunrpc/handshake_prog.go
+++ b/servers/sunrpc/handshake_prog.go
@@ -102,7 +102,6 @@ func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 			log.WithError(err).Error("ServerGetspec(): Could not read brick volfile")
 			goto Out
 		}
-		log.Info(fileContents)
 	} else {
 		// client volfile
 		resp, err := store.Store.Get(context.TODO(), volfilePrefix+args.Key)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -37,7 +37,6 @@ func TestIsLocalAddress(t *testing.T) {
 }
 
 func TestParseHostAndBrickPath(t *testing.T) {
-	hostname := "abc"
 	brick := "/brick"
 	brickPath := "abc:/brick"
 	var h, b string
@@ -45,7 +44,6 @@ func TestParseHostAndBrickPath(t *testing.T) {
 
 	h, b, e = ParseHostAndBrickPath(brickPath)
 	tests.Assert(t, e == nil)
-	tests.Assert(t, h == hostname)
 	tests.Assert(t, b == brick)
 
 	h, b, e = ParseHostAndBrickPath("invalid brick")
@@ -78,23 +76,23 @@ func TestValidateBrickSubDirLength(t *testing.T) {
 }
 
 func TestValidateBrickPathStats(t *testing.T) {
-	tests.Assert(t, ValidateBrickPathStats("/bricks/b1", "host", false) != nil)
-	tests.Assert(t, ValidateBrickPathStats("/bricks/b1", "host", true) == nil)
-	tests.Assert(t, ValidateBrickPathStats("/tmp", "host", false) != nil)
+	tests.Assert(t, ValidateBrickPathStats("/bricks/b1", false) != nil)
+	tests.Assert(t, ValidateBrickPathStats("/bricks/b1", true) == nil)
+	tests.Assert(t, ValidateBrickPathStats("/tmp", false) != nil)
 	//TODO : In build system /tmp is considered as root, hence passing
 	//force = true
-	tests.Assert(t, ValidateBrickPathStats("/tmp/bricks/b1", "host", true) == nil)
+	tests.Assert(t, ValidateBrickPathStats("/tmp/bricks/b1", true) == nil)
 	cmd := exec.Command("touch", "/tmp/bricks/b1/b2")
 	err := cmd.Run()
 	tests.Assert(t, err == nil)
-	tests.Assert(t, ValidateBrickPathStats("/tmp/bricks/b1/b2", "host", false) != nil)
+	tests.Assert(t, ValidateBrickPathStats("/tmp/bricks/b1/b2", false) != nil)
 }
 
 func TestValidateXattrSupport(t *testing.T) {
 	defer heketitests.Patch(&Setxattr, tests.MockSetxattr).Restore()
 	defer heketitests.Patch(&Getxattr, tests.MockGetxattr).Restore()
 	defer heketitests.Patch(&Removexattr, tests.MockRemovexattr).Restore()
-	tests.Assert(t, ValidateXattrSupport("/tmp/b1", "localhost", uuid.NewRandom(), true) == nil)
+	tests.Assert(t, ValidateXattrSupport("/tmp/b1", uuid.NewRandom(), true) == nil)
 
 	// Some negative tests
 	var xattrErr error
@@ -105,18 +103,18 @@ func TestValidateXattrSupport(t *testing.T) {
 	defer heketitests.Patch(&Setxattr, func(path string, attr string, data []byte, flags int) (err error) {
 		return xattrErr
 	}).Restore()
-	tests.Assert(t, ValidateXattrSupport("/tmp/b1", "localhost", uuid.NewRandom(), true) == baderror)
+	tests.Assert(t, ValidateXattrSupport("/tmp/b1", uuid.NewRandom(), true) == baderror)
 
 	// Now check what happens when getxattr fails
 	defer heketitests.Patch(&Getxattr, func(path string, attr string, dest []byte) (sz int, err error) {
 		return 0, xattrErr
 	}).Restore()
-	tests.Assert(t, ValidateXattrSupport("/tmp/b1", "localhost", uuid.NewRandom(), true) == baderror)
+	tests.Assert(t, ValidateXattrSupport("/tmp/b1", uuid.NewRandom(), true) == baderror)
 
 	// Now check what happens when removexattr fails
 	defer heketitests.Patch(&Removexattr, func(path string, attr string) (err error) {
 		return xattrErr
 	}).Restore()
-	tests.Assert(t, ValidateXattrSupport("/tmp/b1", "localhost", uuid.NewRandom(), true) == baderror)
+	tests.Assert(t, ValidateXattrSupport("/tmp/b1", uuid.NewRandom(), true) == baderror)
 
 }

--- a/volgen/client-template.go
+++ b/volgen/client-template.go
@@ -76,7 +76,6 @@ volume <volume-name>-client-<child-index>
     option transport.address-family inet
     option transport-type tcp
     option remote-subvolume <brick-path>
-    option remote-host <remote-host>
     option ping-timeout 42
 end-volume
 `

--- a/volgen/core.go
+++ b/volgen/core.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"strconv"
@@ -34,19 +33,12 @@ func GenerateClientVolfile(vinfo *volume.Volinfo) error {
 	// Insert leaf nodes i.e client xlators
 	for index, b := range vinfo.Bricks {
 
-		address, err := utils.FormRemotePeerAddress(b.Hostname)
-		if err != nil {
-			return err
-		}
-		remoteHost, _, _ := net.SplitHostPort(address)
-
 		replacer := strings.NewReplacer(
 			"<child-index>", strconv.Itoa(index),
 			"<brick-path>", b.Path,
 			"<volume-name>", vinfo.Name,
 			"<trusted-username>", vinfo.Auth.Username,
-			"<trusted-password>", vinfo.Auth.Password,
-			"<remote-host>", remoteHost)
+			"<trusted-password>", vinfo.Auth.Password)
 
 		volfile.WriteString(replacer.Replace(clientLeafTemplate))
 	}

--- a/volume/volume-utils.go
+++ b/volume/volume-utils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gluster/glusterd2/errors"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pborman/uuid"
 )
 
 var (
@@ -14,7 +15,7 @@ var (
 
 // isBrickPathAvailable validates whether the brick is consumed by other
 // volume
-func isBrickPathAvailable(hostname string, brickPath string) error {
+func isBrickPathAvailable(nodeID uuid.UUID, brickPath string) error {
 	volumes, e := getVolumesFunc()
 	if e != nil || volumes == nil {
 		// In case cluster doesn't have any volumes configured yet,
@@ -24,7 +25,7 @@ func isBrickPathAvailable(hostname string, brickPath string) error {
 	}
 	for _, v := range volumes {
 		for _, b := range v.Bricks {
-			if b.Hostname == hostname && b.Path == brickPath {
+			if uuid.Equal(b.NodeID, nodeID) && b.Path == brickPath {
 				log.Error("Brick is already used by ", v.Name)
 				return errors.ErrBrickPathAlreadyInUse
 			}


### PR DESCRIPTION
* Remove Hostname field from Brickinfo
* Remove "remote-host" hardcoded in client volfile
* Fix unit tests, logging and e2e tests accordingly
* Add String() method to Brickinfo type

This partially fixes issues #356 

TODO (separate PR): Add REST API to change IP address of the peer.