### PR TITLE
cli: Added host flag to use CLI from different node

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -9,8 +9,8 @@ import (
 
 var client *restclient.Client
 
-func initRESTClient() {
-	client = restclient.New("http://localhost:24007", "", "")
+func initRESTClient(hostname string) {
+	client = restclient.New(hostname, "", "")
 }
 
 func failure(msg string, err int) {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,19 +8,22 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "gluster",
 	Short: "Gluster Console Manager (command line utility)",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		initRESTClient(flagHostname)
+	},
 }
 
 var (
 	flagXMLOutput  bool
 	flagJSONOutput bool
+	flagHostname   string
 )
 
 func init() {
-	initRESTClient()
-
 	// Global flags, applicable for all sub commands
 	RootCmd.PersistentFlags().BoolVarP(&flagXMLOutput, "xml", "", false, "XML Output")
 	RootCmd.PersistentFlags().BoolVarP(&flagJSONOutput, "json", "", false, "JSON Output")
+	RootCmd.PersistentFlags().StringVarP(&flagHostname, "host", "", "http://localhost:24007", "Host")
 }
 
 // Execute function parses flags and executes command


### PR DESCRIPTION
    ./build/glustercli --host=http://node1:24007 peer status

Updates: #205
Signed-off-by: Aravinda VK <avishwan@redhat.com>