### PR TITLE
Allow option of the form <graph>.<xlator>.<option>

### DIFF
--- a/commands/volumes/common.go
+++ b/commands/volumes/common.go
@@ -23,22 +23,6 @@ func (e invalidOptionError) Error() string {
 	return e.option
 }
 
-func splitOptionName(option string) (string, string, string) {
-	// Option can be of the form <graph>.<xlator>.<option>
-	// where <graph> is optional and when omitted, the option change shall
-	// be applied to instances of the xlator loaded in all graphs.
-
-	tmp := strings.Split(strings.TrimSpace(option), ".")
-	switch len(tmp) {
-	case 2:
-		return "", tmp[0], tmp[1]
-	case 3:
-		return tmp[0], tmp[1], tmp[2]
-	}
-
-	return "", "", ""
-}
-
 func areOptionNamesValid(optsFromReq map[string]string) error {
 
 	var xlOptFound bool
@@ -49,7 +33,7 @@ func areOptionNamesValid(optsFromReq map[string]string) error {
 			return invalidOptionError{option: o}
 		}
 
-		_, xlatorType, xlatorOption := splitOptionName(o)
+		_, xlatorType, xlatorOption := volume.SplitVolumeOptionName(o)
 
 		options, ok := xlator.AllOptions[xlatorType]
 		if !ok {

--- a/commands/volumes/common.go
+++ b/commands/volumes/common.go
@@ -23,22 +23,33 @@ func (e invalidOptionError) Error() string {
 	return e.option
 }
 
+func splitOptionName(option string) (string, string, string) {
+	// Option can be of the form <graph>.<xlator>.<option>
+	// where <graph> is optional and when omitted, the option change shall
+	// be applied to instances of the xlator loaded in all graphs.
+
+	tmp := strings.Split(strings.TrimSpace(option), ".")
+	switch len(tmp) {
+	case 2:
+		return "", tmp[0], tmp[1]
+	case 3:
+		return tmp[0], tmp[1], tmp[2]
+	}
+
+	return "", "", ""
+}
+
 func areOptionNamesValid(optsFromReq map[string]string) error {
 
 	var xlOptFound bool
 	for o := range optsFromReq {
 
-		// assuming option to be of the form <domain>.<xlator-option>
-		// and <domain> will be the xlator type.
-		// Example: cluster/afr.eager-lock
-		// we know for certain that this isn't true
-
 		tmp := strings.Split(strings.TrimSpace(o), ".")
-		if len(tmp) != 2 {
+		if !(len(tmp) == 2 || len(tmp) == 3) {
 			return invalidOptionError{option: o}
 		}
-		xlatorType := tmp[0]
-		xlatorOption := tmp[1]
+
+		_, xlatorType, xlatorOption := splitOptionName(o)
 
 		options, ok := xlator.AllOptions[xlatorType]
 		if !ok {

--- a/commands/volumes/volume-create.go
+++ b/commands/volumes/volume-create.go
@@ -172,8 +172,9 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := areOptionNamesValid(req.Options); err != nil {
-		logger.WithField("option", err.Error()).Error("invalid option specified")
-		restutils.SendHTTPError(w, http.StatusBadRequest, fmt.Sprintf("invalid option specified: %s", err.Error()))
+		logger.WithField("option", err.Error()).Error("invalid volume option specified")
+		msg := fmt.Sprintf("invalid volume option specified: %s", err.Error())
+		restutils.SendHTTPError(w, http.StatusBadRequest, msg)
 		return
 	}
 

--- a/commands/volumes/volume-option.go
+++ b/commands/volumes/volume-option.go
@@ -11,15 +11,11 @@ import (
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/utils"
 	"github.com/gluster/glusterd2/volume"
+	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/pborman/uuid"
 
 	"github.com/gorilla/mux"
 )
-
-// VolOptionRequest represents an incoming request to set volume options
-type VolOptionRequest struct {
-	Options map[string]string `json:"options"`
-}
 
 func registerVolOptionStepFuncs() {
 	var sfs = []struct {
@@ -47,7 +43,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req VolOptionRequest
+	var req api.VolOptionReq
 	if err := utils.GetJSONFromRequest(r, &req); err != nil {
 		restutils.SendHTTPError(w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error())
 		return

--- a/commands/volumes/volume-option.go
+++ b/commands/volumes/volume-option.go
@@ -88,8 +88,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 			// BUG: Shouldn't be on all nodes ideally. Currently we
 			// can't know if it's a brick option or client option.
 			// If it's a brick option, the nodes list here should
-			// should be only volinfo.Nodes(). Moving client
-			// volfiles from disk to store should also be done.
+			// should be only volinfo.Nodes().
 			Nodes: allNodes,
 		},
 		{
@@ -100,6 +99,11 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for k, v := range req.Options {
+		// TODO: Normalize <graph>.<xlator>.<option> and just
+		// <xlator>.<option> to avoid ambiguity and duplication.
+		// For example, currently both the following representations
+		// will be stored in volinfo:
+		// {"afr.eager-lock":"on","gfproxy.afr.eager-lock":"on"}
 		volinfo.Options[k] = v
 	}
 

--- a/pkg/api/req.go
+++ b/pkg/api/req.go
@@ -2,14 +2,20 @@ package api
 
 // VolCreateReq represents a Volume Create Request
 type VolCreateReq struct {
-	Name      string   `json:"name"`
-	Transport string   `json:"transport,omitempty"`
-	Replica   int      `json:"replica,omitempty"`
-	Bricks    []string `json:"bricks"`
-	Force     bool     `json:"force,omitempty"`
+	Name      string            `json:"name"`
+	Transport string            `json:"transport,omitempty"`
+	Replica   int               `json:"replica,omitempty"`
+	Bricks    []string          `json:"bricks"`
+	Options   map[string]string `json:"options,omitempty"`
+	Force     bool              `json:"force,omitempty"`
 }
 
 // PeerAddReq represents a Peer Add Request
 type PeerAddReq struct {
 	Addresses []string `json:"addresses"`
+}
+
+// VolOptionReq represents an incoming request to set volume options
+type VolOptionReq struct {
+        Options map[string]string `json:"options"`
 }

--- a/volume/volume-utils.go
+++ b/volume/volume-utils.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"os"
+	"strings"
 
 	"github.com/gluster/glusterd2/brick"
 	"github.com/gluster/glusterd2/errors"
@@ -53,4 +54,20 @@ func isBrickPathAvailable(hostname string, brickPath string) error {
 		}
 	}
 	return nil
+}
+
+// SplitVolumeOptionName returns three strings by breaking volume option name
+// of the form <graph>.<xlator>.<option> into its constituents. Specifying
+// <graph> is optional and when omitted, the option change shall be applied to
+// instances of the xlator loaded in all graphs.
+func SplitVolumeOptionName(option string) (string, string, string) {
+	tmp := strings.Split(strings.TrimSpace(option), ".")
+	switch len(tmp) {
+	case 2:
+		return "", tmp[0], tmp[1]
+	case 3:
+		return tmp[0], tmp[1], tmp[2]
+	}
+
+	return "", "", ""
 }

--- a/xlator/global.go
+++ b/xlator/global.go
@@ -1,7 +1,9 @@
 package xlator
 
 // AllOptions contains all possible xlator options for all xlators
-// Other packages can directly import this
+// Other packages can directly import this.
+// The keys are of the form <xlator>.<option>
+// Example: afr.eager-lock
 var AllOptions map[string][]Option
 
 // InitOptions initializes the global variable xlator.AllOptions


### PR DESCRIPTION
Volume options can now be of the form `<graph>.<xlator>.<option>` where `<graph>`
is optional and when omitted, the option change shall be applied (by volgen)
to instances of the xlator loaded in all graphs.

Signed-off-by: Prashanth Pai <ppai@redhat.com>