### PR TITLE
Parse newly added fields of volume_option_t struct

### DIFF
--- a/xlator/options.go
+++ b/xlator/options.go
@@ -45,4 +45,8 @@ type Option struct {
 	Min          float64
 	Max          float64
 	Validate     OptionValidateType
+	OpVersion    []uint32
+	Deprecated   []uint32
+	Flags        uint32
+	Tags         []string
 }

--- a/xlator/options.h
+++ b/xlator/options.h
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdint.h>
 
 // These definitions are borrowed from libglusterfs/src/options.h file in
 // glusterfs source. Maintaining this copy here has very little overhead
@@ -31,6 +32,7 @@ typedef enum {
         GF_OPT_VALIDATE_MAX,
 } opt_validate_type_t;
 
+#define GF_MAX_RELEASES 4
 #define ZR_VOLUME_MAX_NUM_KEY    4
 #define ZR_OPTION_MAX_ARRAY_SIZE 64
 
@@ -43,4 +45,8 @@ typedef struct volume_options {
         char                    *default_value;
         char                    *description;
         opt_validate_type_t     validate;
+        uint32_t                op_version[GF_MAX_RELEASES];
+        uint32_t                deprecated[GF_MAX_RELEASES];
+        uint32_t                flags;
+        char                    *tags[ZR_OPTION_MAX_ARRAY_SIZE];
 } volume_option_t;

--- a/xlator/xlator.go
+++ b/xlator/xlator.go
@@ -43,6 +43,8 @@ func structifyOption(option *C.volume_option_t) Option {
 	x.DefaultValue = C.GoString(option.default_value)
 	x.Description = C.GoString(option.description)
 	x.Validate = OptionValidateType(option.validate)
+	// Other fields (OpVersion, Deprecated, Flags, Tags) are not populated
+	// for now
 
 	return x
 }


### PR DESCRIPTION
Loading xlator options in glusterd2 was broken when new fields were added to
volume_option_t struct by this patch: https://review.gluster.org/18059

P.S: This also means that glusterd2 is now only compatible with the latest
     glusterfs master.

Closes issue #366 
Signed-off-by: Prashanth Pai <ppai@redhat.com>