### PR TITLE
Fix TestVolumeOptions and running unit test as non-root

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 )
@@ -24,6 +25,14 @@ func TestMain(m *testing.M) {
 		// go test -tags 'novirt noaugeas' ./e2e -v -functest
 		return
 	}
+
+	if os.Geteuid() != 0 {
+		fmt.Println("Skipping functional tests (requires root)")
+		return
+	}
+
+	// Cleanup leftovers from previous test runs. But don't cleanup after.
+	os.RemoveAll("/tmp/gd2_func_test")
 
 	v := m.Run()
 	os.Exit(v)

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -76,7 +76,7 @@ func TestVolumeOptions(t *testing.T) {
 	volname := "testvol"
 	createReq := api.VolCreateReq{
 		Name:   volname,
-		Bricks: []string{gds[0].PeerAddress + ":" + brickPath},
+		Bricks: []string{gds[0].PeerID() + ":" + brickPath},
 		Force:  true,
 	}
 

--- a/extras/centos-ci.sh
+++ b/extras/centos-ci.sh
@@ -26,6 +26,16 @@ cd $GD2SRC
 # install the build and test requirements
 ./scripts/install-reqs.sh
 
+# install glusterfs from source (master branch)
+yum install -y epel-release
+yum install -y git autoconf automake gcc libtool bison flex make rpm-build python-devel libaio-devel librdmacm-devel libattr-devel libxml2-devel readline-devel openssl-devel libibverbs-devel fuse-devel glib2-devel userspace-rcu-devel libacl-devel sqlite-devel
+git clone https://review.gluster.org/glusterfs; cd glusterfs
+./autogen.sh
+./configure --enable-debug
+make -j
+make install; ldconfig
+cd -
+
 # install vendored dependencies
 make vendor-install
 


### PR DESCRIPTION
TestVolumeOptions used to be skipped on CentOS CI as it didn't have glusterfs
installed from source. Fixed that test to reflect change in volume create API.
`TestVolumeOptions` is not skipped anymore. GlusterFS is installed from source, for now.

`make test` when run as non-root only runs unit tests now.

Signed-off-by: Prashanth Pai <ppai@redhat.com>