### PR TITLE
Replace md5 with xxhash

### DIFF
--- a/brick/glusterfsd.go
+++ b/brick/glusterfsd.go
@@ -2,7 +2,6 @@ package brick
 
 import (
 	"bytes"
-	"crypto/md5"
 	"fmt"
 	"net"
 	"os/exec"
@@ -10,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cespare/xxhash"
 	"github.com/gluster/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/pmap"
 	"github.com/gluster/glusterd2/utils"
@@ -92,11 +92,10 @@ func (b *Glusterfsd) SocketFile() string {
 	volumedir := utils.GetVolumeDir(b.brickinfo.VolumeName)
 	fakeSockFilePath := path.Join(volumedir, "run", fakeSockFileName)
 
-	// Then md5sum of the above path shall be the name of socket file.
-	// Example: /var/run/gluster/<md5sum-hash>.socket
-	checksumData := []byte(fakeSockFilePath)
+	// Then xxhash of the above path shall be the name of socket file.
+	// Example: /var/run/gluster/<xxhash-hash>.socket
 	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
-	b.socketfilepath = fmt.Sprintf("%s/%x.socket", glusterdSockDir, md5.Sum(checksumData))
+	b.socketfilepath = fmt.Sprintf("%s/%x.socket", glusterdSockDir, xxhash.Sum64String(fakeSockFilePath))
 
 	return b.socketfilepath
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6dc001879e080ceb87e413aa1e1997452689078dff6ecaf4a1772d0ff7bc0071
-updated: 2017-09-26T14:39:34.203100663+05:30
+hash: 14ef21d3c8daa9e8e8635b760a675398ea17b689eb5a8086e1a2dfa19f5ea7cb
+updated: 2017-10-06T16:51:42.770270176+05:30
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -7,10 +7,12 @@ imports:
   - quantile
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+- name: github.com/cespare/xxhash
+  version: 5c37fe3735342a2e0d01c87a907579987c8936cc
 - name: github.com/cockroachdb/cmux
   version: 112f0506e7743d64a6eb8fedbcff13d9979bbf92
 - name: github.com/coreos/etcd
-  version: bb66589f8cf18960c7f3d56b1b83753caeed9c7a
+  version: e211fb6de3cb306aee245422e599ac521f6e21f7
   subpackages:
   - alarm
   - auth
@@ -181,7 +183,7 @@ imports:
 - name: github.com/pelletier/go-buffruneio
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: 5ccdfb18c776b740aecaf085c4d9a2779199c279
+  version: 16398bac157da96aa88f98a2df640c7f32af1da2
 - name: github.com/pkg/errors
   version: ff09b135c25aae272398c51a07235b90a75aa4f0
 - name: github.com/pkg/sftp
@@ -189,7 +191,7 @@ imports:
 - name: github.com/prashanthpai/sunrpc
   version: 8b1e9b0138a37e93705639161d846baed18290c7
 - name: github.com/prometheus/client_golang
-  version: 42552c195dd3f3089fbf9cf26e139da150af35aa
+  version: de4d4ffe63b9eff7f27484fdef6e421597e6abb4
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -269,7 +271,7 @@ imports:
 - name: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: golang.org/x/crypto
-  version: 7e9105388ebff089b3f99f0ef676ea55a6da3a7e
+  version: 850760c427c516be930bc91280636328f1a62286
   subpackages:
   - bcrypt
   - blowfish

--- a/glide.yaml
+++ b/glide.yaml
@@ -55,3 +55,5 @@ import:
   - assert
 - package: github.com/spf13/cobra
 - package: github.com/olekukonko/tablewriter
+- package: github.com/cespare/xxhash
+  version: ^1.0.0


### PR DESCRIPTION
MD5 will be phased out of Gluster, and xxhash is the most popular
replacement for non-security related uses. So GD2 should as well.

See: gluster/glusterfs#230