### PR TITLE
Fix tests to catch gofmt violations

### DIFF
--- a/cli/cmd/peer.go
+++ b/cli/cmd/peer.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +58,7 @@ var peerProbeCmd = &cobra.Command{
 			log.WithField("host", hostname).Println("peer probe failed")
 			failure(fmt.Sprintf("Peer probe failed with %s", err.Error()), 1)
 		}
-		fmt.Println("Peer probe success\n")
+		fmt.Println("Peer probe success")
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"ID", "Name", "Addresses"})
 		table.Append([]string{peer.ID.String(), peer.Name, strings.Join(peer.Addresses, ",")})

--- a/cli/cmd/volume.go
+++ b/cli/cmd/volume.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/gluster/glusterd2/pkg/api"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gluster/glusterd2/cli/cmd"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/commands/peers/deletepeer.go
+++ b/commands/peers/deletepeer.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gluster/glusterd2/utils"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 func deletePeerHandler(w http.ResponseWriter, r *http.Request) {

--- a/commands/volumes/volume-expand.go
+++ b/commands/volumes/volume-expand.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gluster/glusterd2/volgen"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // VolExpandReq represents a request to expand the volume by adding more bricks

--- a/commands/volumes/volume-option.go
+++ b/commands/volumes/volume-option.go
@@ -7,11 +7,11 @@ import (
 	"github.com/gluster/glusterd2/errors"
 	"github.com/gluster/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/peer"
+	"github.com/gluster/glusterd2/pkg/api"
 	restutils "github.com/gluster/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/utils"
 	"github.com/gluster/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/pborman/uuid"
 
 	"github.com/gorilla/mux"

--- a/commands/volumes/volume-start.go
+++ b/commands/volumes/volume-start.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 func startAllBricks(c transaction.TxnCtx) error {

--- a/commands/volumes/volume-status.go
+++ b/commands/volumes/volume-status.go
@@ -13,9 +13,9 @@ import (
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/volume"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 func stopBricks(c transaction.TxnCtx) error {

--- a/daemon/connection.go
+++ b/daemon/connection.go
@@ -6,8 +6,8 @@ import (
 	"net/rpc"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
+	log "github.com/sirupsen/logrus"
 )
 
 type connection struct {

--- a/gdctx/global.go
+++ b/gdctx/global.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gluster/glusterd2/utils"
 	"github.com/gluster/glusterd2/version"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	config "github.com/spf13/viper"
 )
 

--- a/mgmt/mgmt.go
+++ b/mgmt/mgmt.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gluster/glusterd2/mgmt/gapi"
 
-	log "github.com/sirupsen/logrus"
 	mgmt "github.com/purpleidea/mgmt/lib"
+	log "github.com/sirupsen/logrus"
 	config "github.com/spf13/viper"
 )
 

--- a/middleware/request_logging.go
+++ b/middleware/request_logging.go
@@ -3,8 +3,8 @@ package middleware
 import (
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/handlers"
+	log "github.com/sirupsen/logrus"
 )
 
 // LogRequest is a middleware which logs HTTP requests in the

--- a/peer/store-utils.go
+++ b/peer/store-utils.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gluster/glusterd2/store"
 	"github.com/gluster/glusterd2/utils"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/elasticetcd/example/main.go
+++ b/pkg/elasticetcd/example/main.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gluster/glusterd2/pkg/elasticetcd"
 
-	"github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/pkg/types"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
 )

--- a/pkg/elasticetcd/server.go
+++ b/pkg/elasticetcd/server.go
@@ -7,10 +7,10 @@ import (
 	"path"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/embed"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/sirupsen/logrus"
 )
 
 type server struct {

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -12,5 +12,9 @@ for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -not -name '*
   if [ $? -eq 1 -a $RETVAL -eq 0 ]; then
     RETVAL=1
   fi
+  if [[ $(gofmt -l $file) ]]; then
+    echo -e "$file does not conform to gofmt rules. Run: gofmt -s -w $file"
+    RETVAL=1
+  fi
 done
 exit $RETVAL

--- a/servers/rest/rest.go
+++ b/servers/rest/rest.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/gluster/glusterd2/middleware"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	config "github.com/spf13/viper"
 )

--- a/servers/sunrpc/callback.go
+++ b/servers/sunrpc/callback.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gluster/glusterd2/transaction"
 	"github.com/gluster/glusterd2/utils"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
 	"github.com/rasky/go-xdr/xdr2"
+	log "github.com/sirupsen/logrus"
 )
 
 // NOTE:

--- a/servers/sunrpc/handshake_prog.go
+++ b/servers/sunrpc/handshake_prog.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gluster/glusterd2/store"
 	"github.com/gluster/glusterd2/utils"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/servers/sunrpc/program.go
+++ b/servers/sunrpc/program.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
+	log "github.com/sirupsen/logrus"
 )
 
 // RPC program implementations inside this package can use this type for convenience

--- a/servers/sunrpc/server.go
+++ b/servers/sunrpc/server.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gluster/glusterd2/plugins"
 	"github.com/gluster/glusterd2/pmap"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prashanthpai/sunrpc"
+	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 )
 

--- a/store/config.go
+++ b/store/config.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gluster/glusterd2/pkg/elasticetcd"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pelletier/go-toml"
+	log "github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 	config "github.com/spf13/viper"
 )

--- a/store/embed.go
+++ b/store/embed.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gluster/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/pkg/elasticetcd"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/pkg/types"
+	log "github.com/sirupsen/logrus"
 	config "github.com/spf13/viper"
 )
 

--- a/store/remote.go
+++ b/store/remote.go
@@ -3,9 +3,9 @@ package store
 import (
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
+	log "github.com/sirupsen/logrus"
 )
 
 func newRemoteStore(conf *Config) (*GDStore, error) {

--- a/transaction/context.go
+++ b/transaction/context.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gluster/glusterd2/store"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // TxnCtx is used to carry contextual information across the lifetime of a transaction

--- a/transaction/context_mock.go
+++ b/transaction/context_mock.go
@@ -2,8 +2,8 @@ package transaction
 
 import (
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // MockTctx implements a dummy context type that can be used in tests

--- a/transaction/rpc-client.go
+++ b/transaction/rpc-client.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gluster/glusterd2/peer"
 	"github.com/gluster/glusterd2/utils"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	netctx "golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gluster/glusterd2/store"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,9 +15,9 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gluster/glusterd2/errors"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/volume/store-utils.go
+++ b/volume/store-utils.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gluster/glusterd2/store"
 	"github.com/pborman/uuid"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/volume/struct.go
+++ b/volume/struct.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gluster/glusterd2/peer"
 	"github.com/gluster/glusterd2/utils"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // VolState is the current status of a volume

--- a/volume/volume-utils.go
+++ b/volume/volume-utils.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gluster/glusterd2/errors"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
The logrus repo rename was done using `sed` tool and the modified source
files were not subjected to gofmt.

Added gofmt check to tests so that we don't regress in future.

Signed-off-by: Prashanth Pai <ppai@redhat.com>