### PR TITLE
plugins/georep: Geo-replication session start

### DIFF
--- a/pkg/restclient/georep.go
+++ b/pkg/restclient/georep.go
@@ -14,3 +14,11 @@ func (c *Client) GeorepCreate(mastervolid string, slavevolid string, req georepa
 	err := c.post(url, req, http.StatusCreated, &session)
 	return session, err
 }
+
+// GeorepStart starts Geo-replication session
+func (c *Client) GeorepStart(mastervolid string, slavevolid string) (georepapi.GeorepSession, error) {
+	var session georepapi.GeorepSession
+	url := fmt.Sprintf("/v1/geo-replication/%s/%s/start", mastervolid, slavevolid)
+	err := c.post(url, nil, http.StatusOK, &session)
+	return session, err
+}

--- a/plugins/georeplication/gsyncd.go
+++ b/plugins/georeplication/gsyncd.go
@@ -1,0 +1,96 @@
+package georeplication
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+
+	"github.com/gluster/glusterd2/gdctx"
+	georepapi "github.com/gluster/glusterd2/plugins/georeplication/api"
+
+	config "github.com/spf13/viper"
+)
+
+const (
+	gsyncdCommand = "python"
+	gsyncdPath    = "/usr/local/libexec/glusterfs/python/syncdaemon/gsyncd.py"
+)
+
+// Gsyncd type represents information about Gsyncd process
+type Gsyncd struct {
+	// Externally consumable using methods of Gsyncd interface
+	binarypath     string
+	args           string
+	configFilePath string
+	pidfilepath    string
+	// For internal use
+	sessioninfo georepapi.GeorepSession
+}
+
+// Name returns human-friendly name of the gsyncd process. This is used for logging.
+func (g *Gsyncd) Name() string {
+	return "gsyncd"
+}
+
+// Path returns absolute path to the binary of gsyncd process
+func (g *Gsyncd) Path() string {
+	return g.binarypath
+}
+
+// Args returns arguments to be passed to gsyncd process during spawn.
+func (g *Gsyncd) Args() string {
+	var buffer bytes.Buffer
+	buffer.WriteString(gsyncdPath)
+	buffer.WriteString(" monitor")
+	buffer.WriteString(fmt.Sprintf(" %s", g.sessioninfo.MasterVol))
+	buffer.WriteString(fmt.Sprintf(" %s@%s::%s", g.sessioninfo.SlaveUser, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol))
+	buffer.WriteString(fmt.Sprintf(" --local-node-id %s", gdctx.MyUUID.String()))
+	buffer.WriteString(fmt.Sprintf(" -c %s", g.ConfigFile()))
+
+	g.args = buffer.String()
+	return g.args
+}
+
+// ConfigFile returns path to the config file
+func (g *Gsyncd) ConfigFile() string {
+
+	if g.configFilePath != "" {
+		return g.configFilePath
+	}
+
+	g.configFilePath = path.Join(
+		config.GetString("localstatedir"),
+		"geo-replication",
+		fmt.Sprintf("%s_%s_%s", g.sessioninfo.MasterVol, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol),
+		"gsyncd.conf",
+	)
+	return g.configFilePath
+}
+
+// SocketFile returns path to the socket file, Gsyncd doesn't have socket file. This func is required for Daemon interface
+func (g *Gsyncd) SocketFile() string {
+	return ""
+}
+
+// PidFile returns path to the pid file of the gsyncd monitor process
+func (g *Gsyncd) PidFile() string {
+
+	if g.pidfilepath != "" {
+		return g.pidfilepath
+	}
+
+	rundir := config.GetString("rundir")
+	pidfilename := fmt.Sprintf("gsyncd-%s-%s-%s.pid", g.sessioninfo.MasterVol, g.sessioninfo.SlaveHosts[0], g.sessioninfo.SlaveVol)
+	g.pidfilepath = path.Join(rundir, "gluster", pidfilename)
+	return g.pidfilepath
+}
+
+// newGsyncd returns a new instance of Gsyncd monitor type which implements the Daemon interface
+func newGsyncd(sessioninfo georepapi.GeorepSession) (*Gsyncd, error) {
+	return &Gsyncd{binarypath: gsyncdCommand, sessioninfo: sessioninfo}, nil
+}
+
+// ID returns the unique identifier of the gsyncd.
+func (g *Gsyncd) ID() string {
+	return g.sessioninfo.MasterID.String() + "-" + g.sessioninfo.SlaveID.String()
+}

--- a/plugins/georeplication/init.go
+++ b/plugins/georeplication/init.go
@@ -29,6 +29,12 @@ func (p *Plugin) RestRoutes() route.Routes {
 			Pattern:     "/geo-replication/{mastervolid}/{slavevolid}",
 			Version:     1,
 			HandlerFunc: georepCreateHandler},
+		route.Route{
+			Name:        "GeoreplicationStart",
+			Method:      "POST",
+			Pattern:     "/geo-replication/{mastervolid}/{slavevolid}/start",
+			Version:     1,
+			HandlerFunc: georepStartHandler},
 	}
 }
 
@@ -36,4 +42,5 @@ func (p *Plugin) RestRoutes() route.Routes {
 // Glusterd Transaction framework
 func (p *Plugin) RegisterStepFuncs() {
 	transaction.RegisterStepFunc(txnGeorepCreate, "georeplication-create.Commit")
+	transaction.RegisterStepFunc(txnGeorepStart, "georeplication-start.Commit")
 }

--- a/plugins/georeplication/transactions.go
+++ b/plugins/georeplication/transactions.go
@@ -1,8 +1,15 @@
 package georeplication
 
 import (
+	"github.com/gluster/glusterd2/daemon"
 	georepapi "github.com/gluster/glusterd2/plugins/georeplication/api"
 	"github.com/gluster/glusterd2/transaction"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	gsyncdStartMaxRetries = 10
 )
 
 func txnGeorepCreate(c transaction.TxnCtx) error {
@@ -16,6 +23,51 @@ func txnGeorepCreate(c transaction.TxnCtx) error {
 			"masterid", sessioninfo.MasterID).WithField(
 			"slaveid", sessioninfo.SlaveID).Debug(
 			"failed to store Geo-replication info")
+		return err
+	}
+
+	return nil
+}
+
+func startGsyncdMonitor(sess *georepapi.GeorepSession) error {
+
+	gsyncdDaemon, err := newGsyncd(*sess)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < gsyncdStartMaxRetries; i++ {
+		err = daemon.Start(gsyncdDaemon, true)
+		if err != nil {
+			return err
+		}
+
+		break
+	}
+
+	return nil
+}
+
+func txnGeorepStart(c transaction.TxnCtx) error {
+	var masterid string
+	var slaveid string
+	if err := c.Get("mastervolid", &masterid); err != nil {
+		return err
+	}
+	if err := c.Get("slavevolid", &slaveid); err != nil {
+		return err
+	}
+
+	sessioninfo, err := getSession(masterid, slaveid)
+	if err != nil {
+		return err
+	}
+	c.Logger().WithFields(log.Fields{
+		"master": sessioninfo.MasterVol,
+		"slave":  sessioninfo.SlaveHosts[0] + "::" + sessioninfo.SlaveVol,
+	}).Info("Starting gsyncd monitor")
+
+	if err := startGsyncdMonitor(sessioninfo); err != nil {
 		return err
 	}
 

--- a/plugins/georeplication/transactions.go
+++ b/plugins/georeplication/transactions.go
@@ -8,10 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	gsyncdStartMaxRetries = 10
-)
-
 func txnGeorepCreate(c transaction.TxnCtx) error {
 	var sessioninfo georepapi.GeorepSession
 	if err := c.Get("geosession", &sessioninfo); err != nil {
@@ -30,21 +26,15 @@ func txnGeorepCreate(c transaction.TxnCtx) error {
 }
 
 func startGsyncdMonitor(sess *georepapi.GeorepSession) error {
-
 	gsyncdDaemon, err := newGsyncd(*sess)
 	if err != nil {
 		return err
 	}
 
-	for i := 0; i < gsyncdStartMaxRetries; i++ {
-		err = daemon.Start(gsyncdDaemon, true)
-		if err != nil {
-			return err
-		}
-
-		break
+	err = daemon.Start(gsyncdDaemon, true)
+	if err != nil {
+		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
REST API:

    POST /v1/geo-replication/:mastervolid/:slavevolid/start

This API depends on the Geo-rep refactoring
patch(https://review.gluster.org/18257), not added any
tests since start of gsyncd will fail.

I need to find best way to not hard code the path of gsyncd
binary. That can be addressed in different patch.

Updates: #271
Signed-off-by: Aravinda VK <avishwan@redhat.com>