### PR TITLE
Remove brick entry from store on volume stop

### DIFF
--- a/commands/volumes/volume-stop.go
+++ b/commands/volumes/volume-stop.go
@@ -61,6 +61,15 @@ func stopBricks(c transaction.TxnCtx) error {
 				c.Logger().WithError(err).WithField(
 					"brick", b.String()).Error("failed to send terminate RPC, sending SIGTERM")
 				daemon.Stop(brickDaemon, false)
+				continue
+			}
+
+			// On graceful shutdown of brick, daemon.Stop() isn't called.
+			if err := daemon.DelDaemon(brickDaemon); err != nil {
+				log.WithFields(log.Fields{
+					"name": brickDaemon.Name(),
+					"id":   brickDaemon.ID(),
+				}).WithError(err).Warn("failed to delete brick entry from store, it may be restarted on GlusterD restart")
 			}
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,7 +164,7 @@ func Stop(d Daemon, force bool) error {
 		}).Error("Stopping daemon failed.")
 	}
 
-	if err := delDaemon(d); err != nil {
+	if err := DelDaemon(d); err != nil {
 		log.WithFields(log.Fields{
 			"name": d.Name(),
 			"pid":  pid,

--- a/daemon/store.go
+++ b/daemon/store.go
@@ -30,7 +30,9 @@ func saveDaemon(d Daemon) error {
 	return err
 }
 
-func delDaemon(d Daemon) error {
+// DelDaemon removes the daemon's entry from the store. This will ensure that
+// the daemon isn't restarted during glusterd2's restart.
+func DelDaemon(d Daemon) error {
 	p := path.Join(daemonsPrefix, gdctx.MyUUID.String(), d.ID())
 
 	_, err := store.Store.Delete(context.TODO(), p)


### PR DESCRIPTION
This should prevent glusterd2 from spawning bricks of volume that is
in stopped state, during glusterd2's restart.

Fixes #408

Signed-off-by: Prashanth Pai <ppai@redhat.com>