### PR TITLE
cli: Match gluster volume info output to Glusterd1

### DIFF
--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -272,12 +272,13 @@ func volumeInfoHandler2(cmd *cobra.Command, isInfo bool) error {
 	}
 	if isInfo {
 		for _, vol := range vols {
-			fmt.Println("Volume Name: ", vol.Name)
-			fmt.Println("Type: ", vol.Type)
-			fmt.Println("Volume ID: ", vol.ID)
-			fmt.Println("State: ", vol.State)
-			fmt.Println("Transport-type: ", vol.Transport)
-			fmt.Println("Number of Bricks: ", len(vol.Bricks))
+			fmt.Println()
+			fmt.Println("Volume Name:", vol.Name)
+			fmt.Println("Type:", vol.Type)
+			fmt.Println("Volume ID:", vol.ID)
+			fmt.Println("State:", vol.State)
+			fmt.Println("Transport-type:", vol.Transport)
+			fmt.Println("Number of Bricks:", len(vol.Bricks))
 			fmt.Println("Bricks:")
 			for i, brick := range vol.Bricks {
 				fmt.Printf("Brick%d: %s:%s\n", i+1, brick.NodeID, brick.Path)

--- a/pkg/api/volstate.go
+++ b/pkg/api/volstate.go
@@ -16,11 +16,11 @@ const (
 func (s VolState) String() string {
 	switch s {
 	case VolCreated:
-		return "created"
+		return "Created"
 	case VolStarted:
-		return "started"
+		return "Started"
 	case VolStopped:
-		return "stopped"
+		return "Stopped"
 	default:
 		return "invalid VolState"
 	}

--- a/pkg/api/voltype.go
+++ b/pkg/api/voltype.go
@@ -20,15 +20,15 @@ const (
 func (t VolType) String() string {
 	switch t {
 	case Distribute:
-		return "distribute"
+		return "Distribute"
 	case Replicate:
-		return "replicate"
+		return "Replicate"
 	case Disperse:
-		return "disperse"
+		return "Disperse"
 	case DistReplicate:
-		return "distribute-replicate"
+		return "Distributed-Replicate"
 	case DistDisperse:
-		return "distribute-disperse"
+		return "Distributed-Disperse"
 	default:
 		return "invalid VolState"
 	}


### PR DESCRIPTION
Except Bricks list(Currently shows as NODEID:BRICKPATH), all
other fields output matches with existing Gluster CLI output

Signed-off-by: Aravinda VK <avishwan@redhat.com>