### PR TITLE
Internal events framework

### DIFF
--- a/glusterd2/commands/volumes/events.go
+++ b/glusterd2/commands/volumes/events.go
@@ -15,9 +15,10 @@ const (
 )
 
 func newVolumeEvent(e volumeEvent, v *volume.Volinfo) *events.Event {
-	data := make(map[string]string)
-	data["volume.name"] = v.Name
-	data["volume.id"] = v.ID.String()
+	data := map[string]string{
+		"volume.name": v.Name,
+		"volume.id":   v.ID.String(),
+	}
 
 	return events.New(string(e), data, true)
 }

--- a/glusterd2/commands/volumes/events.go
+++ b/glusterd2/commands/volumes/events.go
@@ -1,0 +1,23 @@
+package volumecommands
+
+import (
+	"github.com/gluster/glusterd2/glusterd2/events"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+)
+
+type volumeEvent string
+
+const (
+	eventVolumeCreated volumeEvent = "volume.created"
+	eventVolumeStarted             = "volume.started"
+	eventVolumeStopped             = "volume.stopped"
+	eventVolumeDeleted             = "volume.deleted"
+)
+
+func newVolumeEvent(e volumeEvent, v *volume.Volinfo) *events.Event {
+	data := make(map[string]string)
+	data["volume.name"] = v.Name
+	data["volume.id"] = v.ID.String()
+
+	return events.New(string(e), data, true)
+}

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
@@ -244,6 +245,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.Logger().WithField("volname", vol.Name).Info("new volume created")
+	events.Broadcast(newVolumeEvent(eventVolumeCreated, vol))
 
 	resp := createVolumeCreateResp(vol)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -3,6 +3,7 @@ package volumecommands
 import (
 	"net/http"
 
+	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
@@ -120,5 +121,6 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	events.Broadcast(newVolumeEvent(eventVolumeDeleted, vol))
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, nil)
 }

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -3,6 +3,7 @@ package volumecommands
 import (
 	"net/http"
 
+	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
@@ -142,5 +143,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
 		return
 	}
+
+	events.Broadcast(newVolumeEvent(eventVolumeStarted, vol))
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, vol)
 }

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gluster/glusterd2/glusterd2/brick"
 	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
@@ -135,5 +136,6 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
 		return
 	}
+	events.Broadcast(newVolumeEvent(eventVolumeStopped, vol))
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, vol)
 }

--- a/glusterd2/daemon/events.go
+++ b/glusterd2/daemon/events.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"strconv"
+
+	"github.com/gluster/glusterd2/glusterd2/events"
+)
+
+type daemonEvent string
+
+const (
+	daemonStarting       daemonEvent = "daemon.starting"
+	daemonStarted                    = "daemon.started"
+	daemonStartFailed                = "daemon.startfailed"
+	daemonStopping                   = "daemon.stopping"
+	daemonStopped                    = "daemon.stopped"
+	daemonStopFailed                 = "daemon.stopfailed"
+	daemonStartingAll                = "daemon.startingall"
+	daemonStartedAll                 = "daemon.startedall"
+	daemonStartAllFailed             = "daemon.startallfailed"
+)
+
+// newEvent returns an event of given type with daemon data filled
+func newEvent(d Daemon, e daemonEvent, pid int) *events.Event {
+	data := make(map[string]string)
+	data["name"] = d.Name()
+	data["id"] = d.ID()
+	data["binary"] = d.Path()
+	data["args"] = d.Args()
+	data["pid"] = strconv.Itoa(pid)
+
+	return events.New(string(e), data, false)
+}

--- a/glusterd2/daemon/events.go
+++ b/glusterd2/daemon/events.go
@@ -22,12 +22,13 @@ const (
 
 // newEvent returns an event of given type with daemon data filled
 func newEvent(d Daemon, e daemonEvent, pid int) *events.Event {
-	data := make(map[string]string)
-	data["name"] = d.Name()
-	data["id"] = d.ID()
-	data["binary"] = d.Path()
-	data["args"] = d.Args()
-	data["pid"] = strconv.Itoa(pid)
+	data := map[string]string{
+		"name":   d.Name(),
+		"id":     d.ID(),
+		"binary": d.Path(),
+		"args":   d.Args(),
+		"pid":    strconv.Itoa(pid),
+	}
 
 	return events.New(string(e), data, false)
 }

--- a/glusterd2/events/eventhandler.go
+++ b/glusterd2/events/eventhandler.go
@@ -70,8 +70,8 @@ func Register(h Handler, events ...string) HandlerID {
 	in := make(chan *Event)
 	id := addHandler(in)
 
+	handlers.wg.Add(1)
 	go func() {
-		handlers.wg.Add(1)
 		handleEvents(in, h, events...)
 		handlers.wg.Done()
 	}()
@@ -95,8 +95,8 @@ func handleEvents(in <-chan *Event, h Handler, events ...string) {
 
 	for e := range in {
 		if interested(e, events) {
+			wg.Add(1)
 			go func() {
-				wg.Add(1)
 				h.Handle(e)
 				wg.Done()
 			}()

--- a/glusterd2/events/eventhandler.go
+++ b/glusterd2/events/eventhandler.go
@@ -9,7 +9,7 @@ import (
 // Handler is a function that is registered to be called when an event happens
 // event is the name of the event that happened and data is any extra data that
 // was attached to the event as a json document
-type Handler func(Event)
+type Handler func(*Event)
 
 // HandlerID is returned when a Handler is registered. It can be used to unregister a registered Handler.
 type HandlerID uint64
@@ -19,16 +19,16 @@ var (
 		wg sync.WaitGroup
 
 		sync.RWMutex
-		chans map[HandlerID]chan<- Event
+		chans map[HandlerID]chan<- *Event
 		next  HandlerID
 	}
 )
 
 func init() {
-	handlers.chans = make(map[HandlerID]chan<- Event)
+	handlers.chans = make(map[HandlerID]chan<- *Event)
 }
 
-func addHandler(c chan<- Event) HandlerID {
+func addHandler(c chan<- *Event) HandlerID {
 	handlers.Lock()
 	defer handlers.Unlock()
 
@@ -39,7 +39,7 @@ func addHandler(c chan<- Event) HandlerID {
 	return id
 }
 
-func delHandler(id HandlerID) chan<- Event {
+func delHandler(id HandlerID) chan<- *Event {
 	handlers.Lock()
 	defer handlers.Unlock()
 
@@ -56,7 +56,7 @@ func delHandler(id HandlerID) chan<- Event {
 // Handlers need to be thread safe, as they can be called concurrently when
 // multiple events arrive at the same time.
 func Register(h Handler, events ...string) HandlerID {
-	in := make(chan Event)
+	in := make(chan *Event)
 	id := addHandler(in)
 
 	go func() {
@@ -77,7 +77,7 @@ func Unregister(id HandlerID) {
 	}
 }
 
-func handleEvents(in <-chan Event, h Handler, events ...string) {
+func handleEvents(in <-chan *Event, h Handler, events ...string) {
 	var wg sync.WaitGroup
 
 	events = normalizeEvents(events)
@@ -106,7 +106,7 @@ func normalizeEvents(events []string) []string {
 
 // interested returns true if given event is found in the events list
 // Returns true if found or if list is empty
-func interested(e Event, events []string) bool {
+func interested(e *Event, events []string) bool {
 	if len(events) == 0 {
 		return true
 	}

--- a/glusterd2/events/eventhandler.go
+++ b/glusterd2/events/eventhandler.go
@@ -1,0 +1,129 @@
+package events
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Handler is a function that is registered to be called when an event happens
+// event is the name of the event that happened and data is any extra data that
+// was attached to the event as a json document
+type Handler func(Event)
+
+// HandlerID is returned when a Handler is registered. It can be used to unregister a registered Handler.
+type HandlerID uint64
+
+var (
+	handlers struct {
+		wg sync.WaitGroup
+
+		sync.RWMutex
+		chans map[HandlerID]chan<- Event
+		next  HandlerID
+	}
+)
+
+func init() {
+	handlers.chans = make(map[HandlerID]chan<- Event)
+}
+
+func addHandler(c chan<- Event) HandlerID {
+	handlers.Lock()
+	defer handlers.Unlock()
+
+	id := handlers.next
+	handlers.chans[id] = c
+	handlers.next++
+
+	return id
+}
+
+func delHandler(id HandlerID) chan<- Event {
+	handlers.Lock()
+	defer handlers.Unlock()
+
+	c, ok := handlers.chans[id]
+	if !ok {
+		return nil
+	}
+	delete(handlers.chans, id)
+	return c
+}
+
+// Register a Handler to be called when the given events happen.
+// If no events are specified, handler function is called for all events
+// Handlers need to be thread safe, as they can be called concurrently when
+// multiple events arrive at the same time.
+func Register(h Handler, events ...string) HandlerID {
+	in := make(chan Event)
+	id := addHandler(in)
+
+	go func() {
+		handlers.wg.Add(1)
+		handleEvents(in, h, events...)
+		handlers.wg.Done()
+	}()
+
+	return id
+}
+
+// Unregister stops a registered Handler from being called for any further
+// events
+func Unregister(id HandlerID) {
+	c := delHandler(id)
+	if c != nil {
+		close(c)
+	}
+}
+
+func handleEvents(in <-chan Event, h Handler, events ...string) {
+	var wg sync.WaitGroup
+
+	events = normalizeEvents(events)
+
+	for e := range in {
+		if interested(e, events) {
+			go func() {
+				wg.Add(1)
+				h(e)
+				wg.Done()
+			}()
+		}
+	}
+
+	wg.Wait()
+}
+
+// normalizeEvents normalizes given list to lower case and then sorts it
+func normalizeEvents(events []string) []string {
+	for i, v := range events {
+		events[i] = strings.ToLower(v)
+	}
+	sort.Strings(events)
+	return events
+}
+
+// interested returns true if given event is found in the events list
+// Returns true if found or if list is empty
+func interested(e Event, events []string) bool {
+	if len(events) == 0 {
+		return true
+	}
+	i := sort.SearchStrings(events, e.Name)
+	return events[i] == e.Name
+}
+
+// stopHandlers stops all registered handlers
+func stopHandlers() error {
+	handlers.Lock()
+	defer handlers.Unlock()
+
+	for id, ch := range handlers.chans {
+		delete(handlers.chans, id)
+		close(ch)
+	}
+	handlers.wg.Wait()
+
+	return nil
+}

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -17,9 +17,9 @@ type Event struct {
 	// global should be set to true to broadcast event to the full GD2 cluster.
 	// If not event is only broadcast in the local node
 	global bool
-	// nodeid is used when broadcasting global events to prevent origin nodes
-	// rebroadcasting a global event
-	nodeid uuid.UUID
+	// Origin is used when broadcasting global events to prevent origin nodes
+	// rebroadcasting a global event. Event generators need not set this.
+	Origin uuid.UUID
 }
 
 // New returns a new Event with given information

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -1,0 +1,59 @@
+package events
+
+import (
+	"github.com/pborman/uuid"
+)
+
+// Event represents an event in GD2
+type Event struct {
+	// ID is a unique event ID
+	ID uuid.UUID
+	// Name is the the name of the event
+	Name string
+	// Data is any additional data attached to the event. Should be a JSON
+	// document
+	Data string
+	// global should be set to true to broadcast event to the full GD2 cluster.
+	// If not event is only broadcast in the local node
+	global bool
+}
+
+// New returns a new Event with given information
+// Set global to true if event should be broadast across cluster
+func New(name, data string, global bool) Event {
+	return Event{
+		ID:     uuid.NewRandom(),
+		Name:   name,
+		Data:   data,
+		global: global,
+	}
+}
+
+// Broadcast broadcasts events to all registered event handlers
+func Broadcast(e Event) error {
+	handlers.RLock()
+	defer handlers.RUnlock()
+
+	for _, h := range handlers.chans {
+		h <- e
+	}
+
+	return nil
+}
+
+// Start starts the events framework.
+// Should be called only after store is up.
+func Start() error {
+	// Nothing much to start other than global stuff
+	startGlobal()
+
+	return nil
+}
+
+// Stop stops the events framework, events will no longer be broadcast
+func Stop() error {
+	stopGlobal()
+	stopHandlers()
+
+	return nil
+}

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"strings"
+
 	"github.com/pborman/uuid"
 )
 
@@ -20,17 +22,17 @@ type Event struct {
 
 // New returns a new Event with given information
 // Set global to true if event should be broadast across cluster
-func New(name, data string, global bool) Event {
-	return Event{
+func New(name, data string, global bool) *Event {
+	return &Event{
 		ID:     uuid.NewRandom(),
-		Name:   name,
+		Name:   strings.ToLower(name),
 		Data:   data,
 		global: global,
 	}
 }
 
 // Broadcast broadcasts events to all registered event handlers
-func Broadcast(e Event) error {
+func Broadcast(e *Event) error {
 	handlers.RLock()
 	defer handlers.RUnlock()
 
@@ -44,14 +46,15 @@ func Broadcast(e Event) error {
 // Start starts the events framework.
 // Should be called only after store is up.
 func Start() error {
-	// Nothing much to start other than global stuff
 	startGlobal()
+	startEventLogger()
 
 	return nil
 }
 
 // Stop stops the events framework, events will no longer be broadcast
 func Stop() error {
+	stopEventLogger()
 	stopGlobal()
 	stopHandlers()
 

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -45,7 +45,7 @@ func Broadcast(e *Event) error {
 // Start starts the events framework.
 // Should be called only after store is up.
 func Start() error {
-	startGlobal()
+	StartGlobal()
 	startEventLogger()
 
 	return nil
@@ -54,7 +54,7 @@ func Start() error {
 // Stop stops the events framework, events will no longer be broadcast
 func Stop() error {
 	stopEventLogger()
-	stopGlobal()
+	StopGlobal()
 	stopHandlers()
 
 	return nil

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -12,9 +12,8 @@ type Event struct {
 	ID uuid.UUID
 	// Name is the the name of the event
 	Name string
-	// Data is any additional data attached to the event. Should be a JSON
-	// document
-	Data string
+	// Data is any additional data attached to the event.
+	Data map[string]string
 	// global should be set to true to broadcast event to the full GD2 cluster.
 	// If not event is only broadcast in the local node
 	global bool
@@ -22,7 +21,7 @@ type Event struct {
 
 // New returns a new Event with given information
 // Set global to true if event should be broadast across cluster
-func New(name, data string, global bool) *Event {
+func New(name string, data map[string]string, global bool) *Event {
 	return &Event{
 		ID:     uuid.NewRandom(),
 		Name:   strings.ToLower(name),

--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -17,6 +17,9 @@ type Event struct {
 	// global should be set to true to broadcast event to the full GD2 cluster.
 	// If not event is only broadcast in the local node
 	global bool
+	// nodeid is used when broadcasting global events to prevent origin nodes
+	// rebroadcasting a global event
+	nodeid uuid.UUID
 }
 
 // New returns a new Event with given information

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -23,7 +23,7 @@ var (
 )
 
 // globalHandler listens for events that are global and broadcasts them across the cluster
-func globalHandler(ev Event) {
+func globalHandler(ev *Event) {
 	if !ev.global {
 		return
 	}
@@ -76,7 +76,7 @@ func globalListener() {
 					log.WithField("event.id", string(sev.Kv.Key)).WithError(err).Error("could not unmarshal global event")
 					continue
 				}
-				Broadcast(ev)
+				Broadcast(&ev)
 			}
 		case <-glStop:
 			return

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -60,9 +60,7 @@ func globalHandler(ev *Event) {
 }
 
 // globalListener listens for new global events in the store and rebroadcasts them locally
-func globalListener() {
-	glStop = make(chan struct{}, 0)
-	glWg.Add(1)
+func globalListener(glStop chan struct{}) {
 	defer glWg.Done()
 
 	// Watch for new events being added to store
@@ -93,7 +91,9 @@ func globalListener() {
 // Should only be called after store is up.
 func StartGlobal() error {
 	ghID = Register(NewHandler(globalHandler))
-	go globalListener()
+	glStop = make(chan struct{}, 0)
+	glWg.Add(1)
+	go globalListener(glStop)
 
 	return nil
 }

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -31,7 +31,7 @@ func globalHandler(ev *Event) {
 	}
 
 	k := eventsPrefix + ev.ID.String()
-	ev.nodeid = gdctx.MyUUID
+	ev.Origin = gdctx.MyUUID
 	v, err := json.Marshal(ev)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -77,7 +77,7 @@ func globalListener(glStop chan struct{}) {
 					log.WithField("event.id", string(sev.Kv.Key)).WithError(err).Error("could not unmarshal global event")
 					continue
 				}
-				if !uuid.Equal(ev.nodeid, gdctx.MyUUID) {
+				if !uuid.Equal(ev.Origin, gdctx.MyUUID) {
 					Broadcast(&ev)
 				}
 			}

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -92,7 +92,7 @@ func globalListener() {
 // StartGlobal start the global events framework
 // Should only be called after store is up.
 func StartGlobal() error {
-	ghID = Register(globalHandler)
+	ghID = Register(NewHandler(globalHandler))
 	go globalListener()
 
 	return nil

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -21,7 +21,7 @@ var (
 	ghID HandlerID
 	// globalListener wait group and stop channel
 	glWg   sync.WaitGroup
-	glStop chan bool
+	glStop chan struct{}
 )
 
 // globalHandler listens for events that are global and broadcasts them across the cluster
@@ -61,7 +61,7 @@ func globalHandler(ev *Event) {
 
 // globalListener listens for new global events in the store and rebroadcasts them locally
 func globalListener() {
-	glStop = make(chan bool, 0)
+	glStop = make(chan struct{}, 0)
 	glWg.Add(1)
 	defer glWg.Done()
 

--- a/glusterd2/events/global.go
+++ b/glusterd2/events/global.go
@@ -84,17 +84,17 @@ func globalListener() {
 	}
 }
 
-// startGlobal start the global events framework
+// StartGlobal start the global events framework
 // Should only be called after store is up.
-func startGlobal() error {
+func StartGlobal() error {
 	ghID = Register(globalHandler)
 	go globalListener()
 
 	return nil
 }
 
-// stopGlobal stops the global events framework
-func stopGlobal() error {
+// StopGlobal stops the global events framework
+func StopGlobal() error {
 	Unregister(ghID)
 	close(glStop)
 	glWg.Wait()

--- a/glusterd2/events/logger.go
+++ b/glusterd2/events/logger.go
@@ -17,7 +17,7 @@ func eventLogger(e *Event) {
 
 // startEventLogger registers the eventLogger with the events framework
 func startEventLogger() {
-	lhID = Register(eventLogger)
+	lhID = Register(NewHandler(eventLogger))
 }
 
 // stopEventLogger unregisters the eventLogger

--- a/glusterd2/events/logger.go
+++ b/glusterd2/events/logger.go
@@ -1,0 +1,26 @@
+package events
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+var lhID HandlerID
+
+// eventLogger logs all events being generated in the GD2 cluster
+// The events are logged in DEBUG level only.
+func eventLogger(e *Event) {
+	log.WithFields(log.Fields{
+		"event.id":   e.ID.String(),
+		"event.name": e.Name,
+	}).Debug("new event")
+}
+
+// startEventLogger registers the eventLogger with the events framework
+func startEventLogger() {
+	lhID = Register(eventLogger)
+}
+
+// stopEventLogger unregisters the eventLogger
+func stopEventLogger() {
+	Unregister(lhID)
+}

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/glusterd2/peer"
 	"github.com/gluster/glusterd2/glusterd2/servers"
@@ -87,6 +88,11 @@ func main() {
 		log.WithError(err).Fatal("Failed to initialize store (etcd client)")
 	}
 
+	// Start the events framework after store is up
+	if err := events.Start(); err != nil {
+		log.WithError(err).Fatal("Failed to start internal events framework")
+	}
+
 	if err := peer.AddSelfDetails(); err != nil {
 		log.WithError(err).Fatal("Could not add self details into etcd")
 	}
@@ -115,6 +121,7 @@ func main() {
 		case unix.SIGINT:
 			log.Info("Received SIGTERM. Stopping GlusterD")
 			super.Stop()
+			events.Stop()
 			store.Close()
 			log.Info("Stopped GlusterD")
 			return


### PR DESCRIPTION
The events framework allows events to be generated and broadcast internally
within the GD2 cluster, with `events.Broadcast(Event)`.

`Event`s are either local or global. Local events are broadcast just locally
within a GD2. Global events are broadcast globally to other GD2s.

Interested parties can register handlers for all or specific events using
`events.Register(EventHandler, events ...string)`