### PR TITLE
add arbiter support

### DIFF
--- a/glusterd2/commands/volumes/utils.go
+++ b/glusterd2/commands/volumes/utils.go
@@ -31,6 +31,7 @@ func createVolumeInfoResp(v *volume.Volinfo) *api.VolumeInfo {
 		Transport:    v.Transport,
 		DistCount:    v.DistCount,
 		ReplicaCount: v.ReplicaCount,
+		ArbiterCount: v.ArbiterCount,
 		State:        api.VolState(v.State),
 		Options:      v.Options,
 		Bricks:       blist,

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -56,6 +56,13 @@ func createVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
 		v.ReplicaCount = req.Replica
 	}
 
+	if req.Arbiter != 0 {
+		if req.Replica != 3 || req.Arbiter != 1 {
+			return nil, errors.New("For arbiter configuration, replica count must be 3 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter")
+		}
+		v.ArbiterCount = 1
+	}
+
 	if (len(req.Bricks) % v.ReplicaCount) != 0 {
 		return nil, errors.New("Invalid number of bricks")
 	}

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -64,6 +64,7 @@ type Volinfo struct {
 	Transport    string
 	DistCount    int
 	ReplicaCount int
+	ArbiterCount int
 	Options      map[string]string
 	State        VolState
 	Checksum     uint64

--- a/pkg/api/volume_req.go
+++ b/pkg/api/volume_req.go
@@ -5,6 +5,7 @@ type VolCreateReq struct {
 	Name      string            `json:"name"`
 	Transport string            `json:"transport,omitempty"`
 	Replica   int               `json:"replica,omitempty"`
+	Arbiter   int               `json:"arbiter,omitempty"`
 	Bricks    []string          `json:"bricks"`
 	Options   map[string]string `json:"options,omitempty"`
 	Force     bool              `json:"force,omitempty"`

--- a/pkg/api/volume_resp.go
+++ b/pkg/api/volume_resp.go
@@ -31,6 +31,7 @@ type VolumeInfo struct {
 	Transport    string            `json:"transport"`
 	DistCount    int               `json:"distribute-count"`
 	ReplicaCount int               `json:"replica-count"`
+	ArbiterCount int               `json:"arbiter-count"`
 	Options      map[string]string `json:"options"`
 	State        VolState          `json:"state"`
 	Bricks       []BrickInfo       `json:"bricks"`


### PR DESCRIPTION
This patch adds partial support for arbiter volume creation and
displaying volume info in the output. brick volgen support is still
pending, wherein we need to insert the arbiter xlator into every 3rd
brick of the replica. For now, even if you create arbiter volume, the
3rd brick becomes a full fledged data brick.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>