### PR TITLE
Volume Status: Handle nodes being down

### DIFF
--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -187,17 +187,16 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txn.Nodes = nodes
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc: "vol-create.Validate",
-			Nodes:  txn.Nodes,
+			Nodes:  nodes,
 		},
 		{
 			DoFunc:   "vol-create.GenerateBrickVolfiles",
 			UndoFunc: "vol-create.Rollback",
-			Nodes:    txn.Nodes,
+			Nodes:    nodes,
 		},
 		{
 			DoFunc: "vol-create.StoreVolume",

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -226,7 +226,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c, err := txn.Do()
+	err = txn.Do()
 	if err != nil {
 		logger.WithError(err).Error("volume create transaction failed")
 		if err == transaction.ErrLockTimeout {
@@ -237,12 +237,12 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = c.Get("volinfo", &vol); err != nil {
+	if err = txn.Ctx.Get("volinfo", &vol); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to get volinfo", api.ErrCodeDefault)
 		return
 	}
 
-	c.Logger().WithField("volname", vol.Name).Info("new volume created")
+	txn.Ctx.Logger().WithField("volname", vol.Name).Info("new volume created")
 
 	resp := createVolumeCreateResp(vol)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -109,7 +109,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn.Ctx.Set("volname", volname)
-	if _, err = txn.Do(); err != nil {
+	if err = txn.Do(); err != nil {
 		logger.WithError(err).WithField(
 			"volume", volname).Error("failed to delete the volume")
 		if err == transaction.ErrLockTimeout {

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -94,12 +94,12 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
 		return
 	}
-	txn.Nodes = vol.Nodes()
+
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc: "vol-delete.Commit",
-			Nodes:  txn.Nodes,
+			Nodes:  vol.Nodes(),
 		},
 		{
 			DoFunc: "vol-delete.Store",

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -280,7 +280,7 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err = txn.Do(); err != nil {
+	if err = txn.Do(); err != nil {
 		logger.WithError(err).Error("volume expand transaction failed")
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -236,16 +236,15 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txn.Nodes = nodes
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc: "vol-expand.CheckBrick",
-			Nodes:  txn.Nodes,
+			Nodes:  nodes,
 		},
 		{
 			DoFunc:   "vol-expand.StartBrick",
-			Nodes:    txn.Nodes,
+			Nodes:    nodes,
 			UndoFunc: "vol-expand.UndoStartBrick",
 		},
 		{
@@ -254,7 +253,7 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		{
 			DoFunc: "vol-expand.NotifyClients",
-			Nodes:  txn.Nodes,
+			Nodes:  nodes,
 		},
 		unlock,
 	}

--- a/glusterd2/commands/volumes/volume-info.go
+++ b/glusterd2/commands/volumes/volume-info.go
@@ -19,6 +19,7 @@ func volumeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	v, err := volume.GetVolume(volname)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		return
 	}
 
 	resp := createVolumeGetResp(v)

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -101,7 +101,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := txn.Do(); err != nil {
+	if err := txn.Do(); err != nil {
 		logger.WithError(err).Error("volume option transaction failed")
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -63,9 +63,6 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 	txn := transaction.NewTxn(ctx)
 	defer txn.Cleanup()
 
-	// thes txn framework checks if these nodes are online before txn starts
-	txn.Nodes = volinfo.Nodes()
-
 	allNodes, err := peer.GetPeerIDs()
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
@@ -80,11 +77,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		{
 			DoFunc: "vol-option.RegenerateVolfiles",
-			// BUG: Shouldn't be on all nodes ideally. Currently we
-			// can't know if it's a brick option or client option.
-			// If it's a brick option, the nodes list here should
-			// should be only volinfo.Nodes().
-			Nodes: allNodes,
+			Nodes:  volinfo.Nodes(),
 		},
 		{
 			DoFunc: "vol-option.NotifyVolfileChange",

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -113,13 +113,13 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
 		return
 	}
-	txn.Nodes = vol.Nodes()
+
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc:   "vol-start.Commit",
 			UndoFunc: "vol-start.Undo",
-			Nodes:    txn.Nodes,
+			Nodes:    vol.Nodes(),
 		},
 		unlock,
 	}

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -125,8 +125,8 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	txn.Ctx.Set("volname", volname)
 
-	_, e = txn.Do()
-	if e != nil {
+	err = txn.Do()
+	if err != nil {
 		logger.WithFields(log.Fields{
 			"error":  e.Error(),
 			"volume": volname,

--- a/glusterd2/commands/volumes/volume-status.go
+++ b/glusterd2/commands/volumes/volume-status.go
@@ -121,7 +121,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	txn.Ctx.Set("volname", volname)
 
-	rtxn, err := txn.Do()
+	err = txn.Do()
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"error":  err.Error(),
@@ -131,7 +131,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := createVolumeStatusResp(rtxn, volNodes)
+	result, err := createVolumeStatusResp(txn.Ctx, volNodes)
 	if err != nil {
 		errMsg := "Failed to aggregate brick status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)

--- a/glusterd2/commands/volumes/volume-status.go
+++ b/glusterd2/commands/volumes/volume-status.go
@@ -111,11 +111,11 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	txn := transaction.NewTxn(ctx)
 	defer txn.Cleanup()
-	txn.Nodes = vol.Nodes()
+	volNodes := vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		{
 			DoFunc: "vol-status.Check",
-			Nodes:  txn.Nodes,
+			Nodes:  volNodes,
 		},
 	}
 
@@ -131,7 +131,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := createVolumeStatusResp(rtxn, txn.Nodes)
+	result, err := createVolumeStatusResp(rtxn, volNodes)
 	if err != nil {
 		errMsg := "Failed to aggregate brick status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)

--- a/glusterd2/commands/volumes/volume-status.go
+++ b/glusterd2/commands/volumes/volume-status.go
@@ -122,7 +122,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	txn.Ctx.Set("volname", volname)
 
 	// Some nodes may not be up, which is okay.
-	txn.CheckAlive = false
+	txn.DontCheckAlive = true
 	txn.DisableRollback = true
 
 	err = txn.Do()

--- a/glusterd2/commands/volumes/volume-status.go
+++ b/glusterd2/commands/volumes/volume-status.go
@@ -121,6 +121,10 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	txn.Ctx.Set("volname", volname)
 
+	// Some nodes may not be up, which is okay.
+	txn.CheckAlive = false
+	txn.DisableRollback = true
+
 	err = txn.Do()
 	if err != nil {
 		logger.WithFields(log.Fields{
@@ -131,7 +135,7 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := createVolumeStatusResp(txn.Ctx, volNodes)
+	result, err := createVolumeStatusResp(txn.Ctx, vol)
 	if err != nil {
 		errMsg := "Failed to aggregate brick status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)
@@ -142,28 +146,36 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, result)
 }
 
-func createVolumeStatusResp(ctx transaction.TxnCtx, nodes []uuid.UUID) (*api.VolumeStatusResp, error) {
+func createVolumeStatusResp(ctx transaction.TxnCtx, vol *volume.Volinfo) (*api.VolumeStatusResp, error) {
+
+	bmap := make(map[string]*api.BrickStatus)
+
+	for _, b := range vol.Bricks {
+		bmap[b.ID.String()] = &api.BrickStatus{
+			Info: createBrickInfo(&b),
+		}
+	}
 
 	// Loop over each node on which txn was run.
 	// Fetch brick statuses stored by each node in transaction context.
-	var brickStatuses []brickstatus
-	for _, node := range nodes {
+	for _, node := range vol.Nodes() {
 		var tmp []brickstatus
 		err := ctx.GetNodeResult(node, brickStatusTxnKey, &tmp)
-		if err != nil {
-			return nil, err
+		if err != nil || len(tmp) == 0 {
+			// skip if we do not have information
+			continue
 		}
-		brickStatuses = append(brickStatuses, tmp...)
+		for _, b := range tmp {
+			entry := bmap[b.Info.ID.String()]
+			entry.Online = b.Online
+			entry.Port = b.Port
+			entry.Pid = b.Pid
+		}
 	}
 
 	var resp api.VolumeStatusResp
-	for _, b := range brickStatuses {
-		resp.Bricks = append(resp.Bricks, api.BrickStatus{
-			Info:   createBrickInfo(&b.Info),
-			Online: b.Online,
-			Pid:    b.Pid,
-			Port:   b.Port,
-		})
+	for _, v := range bmap {
+		resp.Bricks = append(resp.Bricks, *v)
 	}
 
 	return &resp, nil

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -106,12 +106,11 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
 		return
 	}
-	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc: "vol-stop.Commit",
-			Nodes:  txn.Nodes,
+			Nodes:  vol.Nodes(),
 		},
 		unlock,
 	}

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -116,7 +116,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	txn.Ctx.Set("volname", volname)
 
-	if _, err = txn.Do(); err != nil {
+	if err = txn.Do(); err != nil {
 		logger.WithError(err).WithField(
 			"volume", volname).Error("failed to stop volume")
 		if err == transaction.ErrLockTimeout {

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/gluster/glusterd2/glusterd2/store"
 
@@ -122,6 +123,10 @@ func (c *Tctx) Get(key string, value interface{}) error {
 			"key":   storeKey,
 		}).Error("failed to get value")
 		return e
+	}
+
+	if r.Count == 0 {
+		return errors.New("key not found")
 	}
 
 	if e = json.Unmarshal(r.Kvs[0].Value, value); e != nil {

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -75,10 +75,10 @@ func (t *Txn) checkAlive() error {
 }
 
 // Do runs the transaction on the cluster
-func (t *Txn) Do() (TxnCtx, error) {
+func (t *Txn) Do() error {
 	if t.CheckAlive {
 		if err := t.checkAlive(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -86,14 +86,14 @@ func (t *Txn) Do() (TxnCtx, error) {
 	expTxn.Add("initiated_txn_in_progress", 1)
 
 	for i, s := range t.Steps {
-		if e := s.do(t.Ctx); e != nil {
-			t.Ctx.Logger().WithError(e).Error("Transaction failed, rolling back changes")
+		if err := s.do(t.Ctx); err != nil {
+			t.Ctx.Logger().WithError(err).Error("Transaction failed, rolling back changes")
 			t.undo(i)
-			return nil, e
+			return err
 		}
 	}
 
-	return t.Ctx, nil
+	return nil
 }
 
 // undo undoes a transaction and will be automatically called by Perform if any step fails.

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -30,8 +30,8 @@ type Txn struct {
 	// Nodes is the union of the all the TxnStep.Nodes and is implicitly
 	// set in Txn.Do(). This list is used to determine liveness of the
 	// nodes before running the transaction steps.
-	CheckAlive bool
-	Nodes      []uuid.UUID
+	DontCheckAlive bool
+	Nodes          []uuid.UUID
 
 	DisableRollback bool
 }
@@ -46,7 +46,6 @@ func NewTxn(ctx context.Context) *Txn {
 		"txnid": t.id.String(),
 		"reqid": t.reqID.String(),
 	}).WithPrefix(prefix)
-	t.CheckAlive = true
 
 	return t
 }
@@ -78,7 +77,7 @@ func (t *Txn) checkAlive() error {
 
 // Do runs the transaction on the cluster
 func (t *Txn) Do() error {
-	if t.CheckAlive {
+	if !t.DontCheckAlive {
 		if err := t.checkAlive(); err != nil {
 			return err
 		}

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -26,9 +26,11 @@ type Txn struct {
 	reqID uuid.UUID
 	Ctx   TxnCtx
 	Steps []*Step
-	// Nodes should be a union of the all the TxnStep.Nodes and must be set
-	// before calling Txn.Do(). This is currently only used to determine
-	// liveness of the nodes before running the transaction steps.
+
+	CheckAlive bool
+	// Nodes is the union of the all the TxnStep.Nodes and is implicitly
+	// set in Txn.Do(). This list is used to determine liveness of the
+	// nodes before running the transaction steps.
 	Nodes []uuid.UUID
 }
 
@@ -42,6 +44,7 @@ func NewTxn(ctx context.Context) *Txn {
 		"txnid": t.id.String(),
 		"reqid": t.reqID.String(),
 	}).WithPrefix(prefix)
+	t.CheckAlive = true
 
 	return t
 }
@@ -52,20 +55,36 @@ func (t *Txn) Cleanup() {
 	expTxn.Add("initiated_txn_in_progress", -1)
 }
 
-// Do runs the transaction on the cluster
-func (t *Txn) Do() (TxnCtx, error) {
-	t.Ctx.Logger().Debug("Starting transaction")
+func (t *Txn) checkAlive() error {
 
-	// verify that all nodes are online
+	if len(t.Nodes) == 0 {
+		for _, s := range t.Steps {
+			t.Nodes = append(t.Nodes, s.Nodes...)
+		}
+	}
+	t.Nodes = nodesUnion(t.Nodes)
+
 	for _, node := range t.Nodes {
+		// TODO: Using prefixed query, get all alive nodes in a single etcd query
 		if !store.Store.IsNodeAlive(node) {
-			return nil, fmt.Errorf("node %s is probably down", node.String())
+			return fmt.Errorf("node %s is probably down", node.String())
 		}
 	}
 
+	return nil
+}
+
+// Do runs the transaction on the cluster
+func (t *Txn) Do() (TxnCtx, error) {
+	if t.CheckAlive {
+		if err := t.checkAlive(); err != nil {
+			return nil, err
+		}
+	}
+
+	t.Ctx.Logger().Debug("Starting transaction")
 	expTxn.Add("initiated_txn_in_progress", 1)
 
-	//Do the steps
 	for i, s := range t.Steps {
 		if e := s.do(t.Ctx); e != nil {
 			t.Ctx.Logger().WithError(e).Error("Transaction failed, rolling back changes")
@@ -83,4 +102,17 @@ func (t *Txn) undo(n int) {
 	for i := n; i >= 0; i-- {
 		t.Steps[i].undo(t.Ctx)
 	}
+}
+
+// nodesUnion removes duplicate nodes
+func nodesUnion(nodes []uuid.UUID) []uuid.UUID {
+	for i := 0; i < len(nodes); i++ {
+		for j := i + 1; j < len(nodes); j++ {
+			if uuid.Equal(nodes[i], nodes[j]) {
+				nodes = append(nodes[:j], nodes[j+1:]...)
+				j--
+			}
+		}
+	}
+	return nodes
 }

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -137,7 +137,6 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: Transaction step function for setting Volume Options
 	// As a workaround, Set volume options before enabling Geo-rep session
 
-	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
@@ -249,12 +248,11 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 		return
 	}
 
-	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		lock,
 		{
 			DoFunc: doFunc,
-			Nodes:  txn.Nodes,
+			Nodes:  vol.Nodes(),
 		},
 		unlock,
 	}
@@ -326,7 +324,7 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch Volume details and check if Volume exists
-	vol, e := volume.GetVolume(geoSession.MasterVol)
+	_, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
 		return
@@ -342,7 +340,6 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: Add transaction step to clean xattrs specific to georep session
-	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		lock,
 		{

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -147,8 +147,8 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	txn.Ctx.Set("geosession", geoSession)
 
-	_, e = txn.Do()
-	if e != nil {
+	err = txn.Do()
+	if err != nil {
 		logger.WithFields(log.Fields{
 			"error":       e.Error(),
 			"mastervolid": masterid,
@@ -259,8 +259,8 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	txn.Ctx.Set("mastervolid", masterid.String())
 	txn.Ctx.Set("slavevolid", slaveid.String())
 
-	_, e = txn.Do()
-	if e != nil {
+	err = txn.Do()
+	if err != nil {
 		logger.WithFields(log.Fields{
 			"error":       e.Error(),
 			"mastervolid": masterid,
@@ -351,8 +351,8 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	txn.Ctx.Set("mastervolid", masterid.String())
 	txn.Ctx.Set("slavevolid", slaveid.String())
 
-	_, e = txn.Do()
-	if e != nil {
+	err = txn.Do()
+	if err != nil {
 		logger.WithFields(log.Fields{
 			"error":       e.Error(),
 			"mastervolid": masterid,


### PR DESCRIPTION
Do not fail the transaction if few of the nodes are down.

Changes to transaction framework:
* Check if nodes are up is now configurable
* Transaction framework users need not explicitly set the list of nodes to be checked for liveness
* Add option to not rollback and ignore failures.

Closes #475 