### PR TITLE
store: Correctly namespace etcd client

### DIFF
--- a/glusterd2/store/embed.go
+++ b/glusterd2/store/embed.go
@@ -33,7 +33,14 @@ func newEmbedStore(sconf *Config) (*GDStore, error) {
 		return nil, err
 	}
 
-	return &GDStore{*sconf, ee.Client(), ee.Session(), ee}, nil
+	gds, err := newNamespacedStore(ee.Client(), sconf)
+	if err != nil {
+		return nil, err
+	}
+
+	gds.ee = ee
+
+	return gds, nil
 }
 
 func (s *GDStore) closeEmbedStore() {

--- a/glusterd2/store/liveness.go
+++ b/glusterd2/store/liveness.go
@@ -35,7 +35,7 @@ func (s *GDStore) IsNodeAlive(nodeID interface{}) bool {
 	defer cancel()
 
 	key := livenessKeyPrefix + keySuffix
-	resp, err := s.Client.Get(ctx, key)
+	resp, err := s.Get(ctx, key)
 	if err != nil {
 		return false
 	}

--- a/glusterd2/store/remote.go
+++ b/glusterd2/store/remote.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,17 +21,7 @@ func newRemoteStore(conf *Config) (*GDStore, error) {
 	}
 	log.Debug("etcd client connection created")
 
-	// Create a new session (lease kept alive for the lifetime of a client)
-	// This is currently used for:
-	// * distributed locking (Mutex)
-	// * representing liveness of the client
-	s, e := concurrency.NewSession(c, concurrency.WithTTL(sessionTTL))
-	if e != nil {
-		log.WithError(e).Error("failed to create an etcd session")
-		return nil, e
-	}
-
-	return &GDStore{*conf, c, s, nil}, nil
+	return newNamespacedStore(c, conf)
 }
 
 func (s *GDStore) closeRemoteStore() {


### PR DESCRIPTION
All etcd interfaces that needed to be namespaced (KV, Lease, Watcher,
Session) have been namespaced properly, for both remote store and
embedded stores.

As the etcd interfaces were not namespaced, some store operations
happened out of namespace. Also, elasticetcd unintentionally got
namespaced, causing some of its operations to happen in GD2s namespace.