### PR TITLE
NFS-Ganesha integration : Sending dbus signals for start and stop

### DIFF
--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -50,7 +50,7 @@ func Broadcast(e *Event) error {
 func Start() error {
 	StartGlobal()
 	startEventLogger()
-
+	registerGaneshaHandler()
 	return nil
 }
 

--- a/glusterd2/events/nfs-ganesha.go
+++ b/glusterd2/events/nfs-ganesha.go
@@ -1,0 +1,41 @@
+package events
+
+import (
+	"fmt"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	eventVolumeStarted = "volume.started"
+	eventVolumeStopped = "volume.stopped"
+)
+
+type ganesha struct{}
+
+func (g *ganesha) Handle(e *Event) {
+	var option string
+	if e.Name == eventVolumeStarted {
+		option = "on"
+	} else if e.Name == eventVolumeStopped {
+		option = "off"
+	}
+	dbuscmdStr := fmt.Sprintf("/usr/libexec/ganesha/dbus-send.sh /etc/ganesha/ %s %s", option, e.Data["volume.name"])
+	ganeshaCmd := exec.Command("/bin/sh", "-c", dbuscmdStr)
+	err := ganeshaCmd.Run()
+	if err != nil {
+		log.WithError(err).WithField("command", dbuscmdStr).Error("Failed to execute command")
+	} else {
+		log.WithField("command", dbuscmdStr).Debug("Command succeeded")
+	}
+}
+
+func (g *ganesha) Events() []string {
+	return []string{eventVolumeStarted, eventVolumeStopped}
+}
+
+func registerGaneshaHandler() {
+	g := new(ganesha)
+	Register(g)
+}


### PR DESCRIPTION
If volume is already exported via Ganesha, then during stop the volume
need to be unexport and again re-export during volume start. The old glusterd
does this with help of dbus signals called via wrapper script "dbus-send.sh"
(available in glusterfs 3.10)

TODO :
* need to add validations before calling the script like
	i.) ganesha is running or not
	ii.) volume is exported or not
* Send a patch to include dbus-send.sh in master branch

Required to fix following issue/bug to work ganesha with GD2
* https://bugzilla.redhat.com/show_bug.cgi?id=1532238
* https://github.com/gluster/glusterd2/issues/518

Thanks ppai for all the help

Fixes: #434
Signed-off-by: Jiffin Tony Thottan <jthottan@redhat.com>