### PR TITLE
volgen2: Provide option to ignore options

### DIFF
--- a/glusterd2/volgen2/volfile_bitd.go
+++ b/glusterd2/volgen2/volfile_bitd.go
@@ -16,7 +16,7 @@ func generateBitdVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, nodeid
 	for volIdx, vol := range clusterinfo {
 		// TODO: If bitrot not enabled for volume, then skip
 		name := fmt.Sprintf("%s-bit-rot-%d", vol.Name, volIdx)
-		bitdvol := bitd.Add("features/bit-rot", vol, nil).SetName(name)
+		bitdvol := bitd.Add("features/bit-rot", vol, nil).SetName(name).SetIgnoreOptions([]string{"scrubber"})
 		clusterGraph(bitdvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
 	}
 }


### PR DESCRIPTION
Some components like bit-rot uses same xlator for both `bitd` and
`scrubd`, if option `scrubber=on` present in volfile then the daemon
becomes `scrubber` else it becomes `bitd`. While generating `bitd`
volfile `scrubber` option should not be added.

Updates: #431
Signed-off-by: Aravinda VK <avishwan@redhat.com>