### PR TITLE
bitrot: Add scrub ondemand support

### DIFF
--- a/glusterd2/servers/sunrpc/dict/dict.go
+++ b/glusterd2/servers/sunrpc/dict/dict.go
@@ -1,4 +1,4 @@
-package sunrpc
+package dict
 
 import (
 	"bytes"
@@ -22,10 +22,10 @@ const (
 	dictHeaderLen = 4
 )
 
-// DictUnserialize unmarshals a slice of bytes into a map[string]string
+// Unserialize unmarshals a slice of bytes into a map[string]string
 // Consumers of the map should typecast/extract information from the
 // map values which are of string type
-func DictUnserialize(buf []byte) (map[string]string, error) {
+func Unserialize(buf []byte) (map[string]string, error) {
 
 	newDict := make(map[string]string)
 	tmpHeader := make([]byte, dictHeaderLen)
@@ -67,8 +67,8 @@ func DictUnserialize(buf []byte) (map[string]string, error) {
 	return newDict, nil
 }
 
-// DictSerialize marshals a map[string]string into a slice of bytes.
-func DictSerialize(dict map[string]string) ([]byte, error) {
+// Serialize marshals a map[string]string into a slice of bytes.
+func Serialize(dict map[string]string) ([]byte, error) {
 
 	dictSerializedSize, err := getSerializedDictLen(dict)
 	if err != nil {

--- a/glusterd2/servers/sunrpc/handshake_prog.go
+++ b/glusterd2/servers/sunrpc/handshake_prog.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/gluster/glusterd2/glusterd2/servers/sunrpc/dict"
 	"github.com/gluster/glusterd2/glusterd2/store"
 	"github.com/gluster/glusterd2/glusterd2/volume"
 
@@ -88,9 +89,9 @@ func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 	var err error
 	var fileContents []byte
 
-	_, err = DictUnserialize(args.Xdata)
+	_, err = dict.Unserialize(args.Xdata)
 	if err != nil {
-		log.WithError(err).Error("ServerGetspec(): DictUnserialize() failed")
+		log.WithError(err).Error("ServerGetspec(): dict.Unserialize() failed")
 	}
 
 	// Get Volfile from store
@@ -156,9 +157,9 @@ func (p *GfHandshake) ServerGetVolumeInfo(args *GfGetVolumeInfoReq, reply *GfGet
 	)
 	respDict := make(map[string]string)
 
-	reqDict, err := DictUnserialize(args.Dict)
+	reqDict, err := dict.Unserialize(args.Dict)
 	if err != nil {
-		log.WithError(err).Error("DictUnserialize() failed")
+		log.WithError(err).Error("dict unserialize failed")
 		goto Out
 	}
 
@@ -191,7 +192,7 @@ func (p *GfHandshake) ServerGetVolumeInfo(args *GfGetVolumeInfoReq, reply *GfGet
 		respDict["volume_id"] = volinfo.ID.String()
 	}
 
-	reply.Dict, err = DictSerialize(respDict)
+	reply.Dict, err = dict.Serialize(respDict)
 	if err != nil {
 		log.WithError(err).Error("failed to serialize dict")
 	}

--- a/glusterd2/volgen2/volfile_scrub.go
+++ b/glusterd2/volgen2/volfile_scrub.go
@@ -17,7 +17,7 @@ func generateScrubVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, nodei
 		//If bitrot not enabled for volume, then skip those bricks
 		val, exists := vol.Options[volume.VkeyFeaturesBitrot]
 		if exists && val == "on" {
-			name := fmt.Sprintf("%s-scrub-%d", vol.Name, volIdx)
+			name := fmt.Sprintf("%s-bit-rot-%d", vol.Name, volIdx)
 			scrubvol := scrub.Add("features/bit-rot", vol, nil).SetName(name)
 			clusterGraph(scrubvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
 		}

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -27,3 +27,12 @@ func isBrickPathAvailable(nodeID uuid.UUID, brickPath string) error {
 	}
 	return nil
 }
+
+// IsBitrotEnabled returns true if bitrot is enabled for a volume and false otherwise
+func IsBitrotEnabled(v *Volinfo) bool {
+	val, exists := v.Options[VkeyFeaturesBitrot]
+	if exists && val == "on" {
+		return true
+	}
+	return false
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -34,6 +34,7 @@ var (
 	ErrProcessAlreadyRunning   = errors.New("Process is already running")
 	ErrBitrotAlreadyEnabled    = errors.New("Bitrot is already enabled")
 	ErrBitrotAlreadyDisabled   = errors.New("Bitrot is already disabled")
+	ErrBitrotNotEnabled        = errors.New("Bitrot is not enabled")
 	ErrUnknownValue            = errors.New("unknown value specified")
 	ErrGetFailed               = errors.New("failed to get value from the store")
 	ErrUnmarshallFailed        = errors.New("failed to unmarshall from json")

--- a/plugins/bitrot/init.go
+++ b/plugins/bitrot/init.go
@@ -35,6 +35,12 @@ func (p *Plugin) RestRoutes() route.Routes {
 			Pattern:     "/volumes/{volname}/bitrot/disable",
 			Version:     1,
 			HandlerFunc: bitrotDisableHandler},
+		route.Route{
+			Name:        "ScrubOndemand",
+			Method:      "POST",
+			Pattern:     "/volumes/{volname}/bitrot/scrubondemand",
+			Version:     1,
+			HandlerFunc: bitrotScrubOndemandHandler},
 	}
 }
 
@@ -43,5 +49,6 @@ func (p *Plugin) RestRoutes() route.Routes {
 func (p *Plugin) RegisterStepFuncs() {
 	transaction.RegisterStepFunc(txnBitrotEnableDisable, "bitrot-enable.Commit")
 	transaction.RegisterStepFunc(txnBitrotEnableDisable, "bitrot-disable.Commit")
+	transaction.RegisterStepFunc(txnBitrotScrubOndemand, "bitrot-scrubondemand.Commit")
 	return
 }


### PR DESCRIPTION
Bitrot scrubber daemon supports ondemand scrub by
providing brick-op service. Glusterd invokes rpc
to avail the service.

Updates: #431
Signed-off-by: Kotresh HR <khiremat@redhat.com>