### PR TITLE
Separate Peer and Client Addresses in Peer object

### DIFF
--- a/glustercli/cmd/peer.go
+++ b/glustercli/cmd/peer.go
@@ -60,8 +60,8 @@ var peerProbeCmd = &cobra.Command{
 		}
 		fmt.Println("Peer probe success")
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"ID", "Name", "Addresses"})
-		table.Append([]string{peer.ID.String(), peer.Name, strings.Join(peer.Addresses, ",")})
+		table.SetHeader([]string{"ID", "Name", "PeerAddresses"})
+		table.Append([]string{peer.ID.String(), peer.Name, strings.Join(peer.PeerAddresses, ",")})
 		table.Render()
 	},
 }
@@ -88,9 +88,9 @@ func peerStatusHandler(cmd *cobra.Command) {
 		failure(fmt.Sprintf("Error getting Peers list %s", err.Error()), 1)
 	}
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "Name", "Addresses"})
+	table.SetHeader([]string{"ID", "Name", "PeerAddresses"})
 	for _, peer := range peers {
-		table.Append([]string{peer.ID.String(), peer.Name, strings.Join(peer.Addresses, ",")})
+		table.Append([]string{peer.ID.String(), peer.Name, strings.Join(peer.PeerAddresses, ",")})
 	}
 	table.Render()
 }

--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -126,7 +126,7 @@ func bricksAsUUID(bricks []string) ([]api.BrickReq, error) {
 		host := strings.Split(brick, ":")[0]
 		path := strings.Split(brick, ":")[1]
 		for _, peer := range peers {
-			for _, addr := range peer.Addresses {
+			for _, addr := range peer.PeerAddresses {
 				// TODO: Normalize presence/absence of port in peer address
 				if strings.Split(addr, ":")[0] == strings.Split(host, ":")[0] {
 					brickUUIDs = append(brickUUIDs, api.BrickReq{

--- a/glusterd2/commands/peers/addpeer.go
+++ b/glusterd2/commands/peers/addpeer.go
@@ -95,8 +95,9 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 
 func createPeerAddResp(p *peer.Peer) *api.PeerAddResp {
 	return &api.PeerAddResp{
-		ID:        p.ID,
-		Name:      p.Name,
-		Addresses: p.Addresses,
+		ID:              p.ID,
+		Name:            p.Name,
+		PeerAddresses:   p.PeerAddresses,
+		ClientAddresses: p.ClientAddresses,
 	}
 }

--- a/glusterd2/commands/peers/deletepeer.go
+++ b/glusterd2/commands/peers/deletepeer.go
@@ -73,9 +73,9 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	remotePeerAddress, err := utils.FormRemotePeerAddress(p.Addresses[0])
+	remotePeerAddress, err := utils.FormRemotePeerAddress(p.PeerAddresses[0])
 	if err != nil {
-		logger.WithError(err).WithField("address", p.Addresses[0]).Error("failed to parse peer address")
+		logger.WithError(err).WithField("address", p.PeerAddresses[0]).Error("failed to parse peer address")
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "failed to parse remote address", api.ErrCodeDefault)
 		return
 	}

--- a/glusterd2/commands/peers/getpeer.go
+++ b/glusterd2/commands/peers/getpeer.go
@@ -31,9 +31,10 @@ func getPeerHandler(w http.ResponseWriter, r *http.Request) {
 
 func createPeerGetResp(p *peer.Peer) *api.PeerGetResp {
 	return &api.PeerGetResp{
-		ID:        p.ID,
-		Name:      p.Name,
-		Addresses: p.Addresses,
-		Online:    store.Store.IsNodeAlive(p.ID),
+		ID:              p.ID,
+		Name:            p.Name,
+		PeerAddresses:   p.PeerAddresses,
+		ClientAddresses: p.ClientAddresses,
+		Online:          store.Store.IsNodeAlive(p.ID),
 	}
 }

--- a/glusterd2/commands/peers/getpeers.go
+++ b/glusterd2/commands/peers/getpeers.go
@@ -27,10 +27,11 @@ func createPeerListResp(peers []*peer.Peer) *api.PeerListResp {
 
 	for _, p := range peers {
 		resp = append(resp, api.PeerGetResp{
-			ID:        p.ID,
-			Name:      p.Name,
-			Addresses: p.Addresses,
-			Online:    store.Store.IsNodeAlive(p.ID),
+			ID:              p.ID,
+			Name:            p.Name,
+			PeerAddresses:   p.PeerAddresses,
+			ClientAddresses: p.ClientAddresses,
+			Online:          store.Store.IsNodeAlive(p.ID),
 		})
 	}
 

--- a/glusterd2/peer/peer.go
+++ b/glusterd2/peer/peer.go
@@ -7,9 +7,10 @@ import (
 
 // Peer reperesents a GlusterD
 type Peer struct {
-	ID        uuid.UUID
-	Name      string
-	Addresses []string
+	ID              uuid.UUID
+	Name            string
+	PeerAddresses   []string
+	ClientAddresses []string
 }
 
 // ETCDConfig represents the structure which holds the ETCD env variables &

--- a/glusterd2/peer/self.go
+++ b/glusterd2/peer/self.go
@@ -1,17 +1,55 @@
 package peer
 
 import (
+	"fmt"
+	"net"
+
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 
 	config "github.com/spf13/viper"
 )
 
+func normalizeAddrs() ([]string, error) {
+
+	shost, sport, err := net.SplitHostPort(config.GetString("clientaddress"))
+	if err != nil {
+		return nil, err
+	}
+
+	if shost != "" {
+		return []string{config.GetString("clientaddress")}, nil
+	}
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+
+	var clientAddrs []string
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			if ipnet.IP.To4() != nil {
+				clientAddrs = append(clientAddrs, fmt.Sprintf("%s:%s", ipnet.IP.String(), sport))
+			}
+		}
+	}
+
+	return clientAddrs, nil
+}
+
 // AddSelfDetails results in the peer adding its own details into etcd
 func AddSelfDetails() error {
+	var err error
+
 	p := &Peer{
-		ID:        gdctx.MyUUID,
-		Name:      gdctx.HostName,
-		Addresses: []string{config.GetString("peeraddress")},
+		ID:            gdctx.MyUUID,
+		Name:          gdctx.HostName,
+		PeerAddresses: []string{config.GetString("peeraddress")},
+	}
+
+	p.ClientAddresses, err = normalizeAddrs()
+	if err != nil {
+		return err
 	}
 
 	return AddOrUpdatePeer(p)

--- a/glusterd2/peer/store-utils-mock.go
+++ b/glusterd2/peer/store-utils-mock.go
@@ -18,7 +18,7 @@ func GetPeerFMockGood(id string) (*Peer, error) {
 	var p Peer
 	p.Name = "test"
 	p.ID = uuid.NewRandom()
-	p.Addresses = []string{"test"}
+	p.PeerAddresses = []string{"test"}
 	return &p, nil
 }
 

--- a/glusterd2/peer/store-utils.go
+++ b/glusterd2/peer/store-utils.go
@@ -174,7 +174,7 @@ func GetPeerByAddr(addr string) (*Peer, error) {
 	}
 
 	for _, p := range peers {
-		for _, paddr := range p.Addresses {
+		for _, paddr := range p.PeerAddresses {
 			if utils.IsPeerAddressSame(addr, paddr) {
 				return p, nil
 			}
@@ -192,7 +192,7 @@ func GetPeerByAddrs(addrs []string) (*Peer, error) {
 	}
 	for _, a := range addrs {
 		for _, p := range peers {
-			for _, paddr := range p.Addresses {
+			for _, paddr := range p.PeerAddresses {
 				if utils.IsPeerAddressSame(a, paddr) {
 					return p, nil
 				}

--- a/glusterd2/transaction/rpc-client.go
+++ b/glusterd2/transaction/rpc-client.go
@@ -30,7 +30,7 @@ func RunStepOn(step string, node uuid.UUID, c TxnCtx) (TxnCtx, error) {
 
 	var conn *grpc.ClientConn
 
-	remote, err := utils.FormRemotePeerAddress(p.Addresses[0])
+	remote, err := utils.FormRemotePeerAddress(p.PeerAddresses[0])
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func RunStepOn(step string, node uuid.UUID, c TxnCtx) (TxnCtx, error) {
 	if conn == nil {
 		logger.WithFields(log.Fields{
 			"error":  err,
-			"remote": p.Addresses,
+			"remote": p.PeerAddresses[0],
 		}).Error("failed to grpc.Dial remote")
 		return nil, err
 	}

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -149,7 +149,7 @@ func NewBrickEntries(bricks []api.BrickReq, volName string, volID uuid.UUID) ([]
 
 		binfo.NodeID = u
 		// TODO: Have a better way to select peer address here
-		binfo.Hostname, _, _ = net.SplitHostPort(p.Addresses[0])
+		binfo.Hostname, _, _ = net.SplitHostPort(p.PeerAddresses[0])
 
 		binfo.Path, e = absFilePath(b.Path)
 		if e != nil {

--- a/pkg/api/peer_req_resp.go
+++ b/pkg/api/peer_req_resp.go
@@ -4,10 +4,11 @@ import "github.com/pborman/uuid"
 
 // Peer represents a peer in the glusterd2 cluster
 type Peer struct {
-	ID        uuid.UUID `json:"id"`
-	Name      string    `json:"name"`
-	Addresses []string  `json:"addresses"`
-	Online    bool      `json:"online"`
+	ID              uuid.UUID `json:"id"`
+	Name            string    `json:"name"`
+	PeerAddresses   []string  `json:"peer-addresses"`
+	ClientAddresses []string  `json:"client-addresses"`
+	Online          bool      `json:"online"`
 }
 
 // PeerAddReq represents an incoming request to add a peer to the cluster

--- a/pkg/restclient/peer.go
+++ b/pkg/restclient/peer.go
@@ -32,7 +32,7 @@ func (c *Client) PeerDetach(host string) error {
 
 	// Find Peer ID using available information
 	for _, p := range peers {
-		for _, h := range p.Addresses {
+		for _, h := range p.PeerAddresses {
 			if h == host {
 				peerID = p.ID.String()
 				break


### PR DESCRIPTION
Peer address is used by glusterd2 to communicate with each other. Client address is used by clients (CLI, mount, curl) to communicate with glusterd2. A single `Addresses` currently showed in response and CLI is unusable by clients as it's address used for internal communication

Signed-off-by: Prashanth Pai <ppai@redhat.com>