### PR TITLE
xlator: report proper error message when xlator dir is empty

### DIFF
--- a/glusterd2/xlator/load.go
+++ b/glusterd2/xlator/load.go
@@ -147,6 +147,11 @@ func getXlatorsDir() string {
 func loadAllXlators() (map[string]*Xlator, error) {
 
 	xlatorsDir := getXlatorsDir()
+
+	if xlatorsDir == "" {
+		return nil, fmt.Errorf("No xlators dir found")
+	}
+
 	s, err := os.Stat(xlatorsDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before

> Failed to load xlator options error=stat : no such file or directory

After:

> Failed to load xlator options error=No xlators dir foun