### PR TITLE
Fix few pending stuff in REST API doc generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+doc/endpoints.md linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GlusterD, while also becoming more modular and easing extensibility.
 * [Quick Start User Guide](doc/quick-start-user-guide.md)
 * [Development Guide](doc/development-guide.md)
 * [Coding Guidelines](doc/coding.md)
+* [REST API Reference](doc/endpoints.md)
 
 ## Architecture and Design
 Please refer to the [wiki](https://github.com/gluster/glusterd2/wiki/Design) for more information.

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -1,11 +1,20 @@
-# API Endpoints
+
+<!---
+This file is generated using commands described below. DO NOT EDIT.
+
+$ curl -o endpoints.json -s -X GET http://127.0.0.1:24007/endpoints
+$ go build pkg/tools/generate-doc.go
+$ ./generate-doc
+-->
+
+# REST API Endpoints Reference
 
 Name | Methods | Path | Request | Response
 --- | --- | --- | --- | ---
 GetVersion | GET | /version | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [VersionResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VersionResp)
 VolumeCreate | POST | /volumes | [VolCreateReq](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VolCreateReq) | [VolumeCreateResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VolumeCreateResp)
 VolumeExpand | POST | /volumes/{volname}/expand | [VolExpandReq](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VolExpandReq) | [VolumeExpandResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VolumeExpandResp)
-VolumeOptions | POST | /volumes/{volname}/options | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
+VolumeOptions | POST | /volumes/{volname}/options | [VolOptionReq](https://godoc.org/github.com/gluster/glusterd2/pkg/api#VolOptionReq) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 OptionGroupList | GET | /volumes/options-group | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [OptionGroupListResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#OptionGroupListResp)
 OptionGroupCreate | POST | /volumes/options-group | [OptionGroupReq](https://godoc.org/github.com/gluster/glusterd2/pkg/api#OptionGroupReq) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 OptionGroupDelete | DELETE | /volumes/options-group/{groupname} | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
@@ -18,10 +27,10 @@ VolumeStart | POST | /volumes/{volname}/start | [](https://godoc.org/github.com/
 VolumeStop | POST | /volumes/{volname}/stop | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 VolfilesGenerate | POST | /volfiles | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 VolfilesGet | GET | /volfiles | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
-GetPeer | GET | /peers/{peerid} | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
-GetPeers | GET | /peers | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
+GetPeer | GET | /peers/{peerid} | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [PeerGetResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#PeerGetResp)
+GetPeers | GET | /peers | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [PeerListResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#PeerListResp)
 DeletePeer | DELETE | /peers/{peerid} | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
-AddPeer | POST | /peers | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
+AddPeer | POST | /peers | [PeerAddReq](https://godoc.org/github.com/gluster/glusterd2/pkg/api#PeerAddReq) | [PeerAddResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#PeerAddResp)
 GeoreplicationCreate | POST | /geo-replication/{mastervolid}/{remotevolid} | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 GeoreplicationStart | POST | /geo-replication/{mastervolid}/{remotevolid}/start | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 GeoreplicationStop | POST | /geo-replication/{mastervolid}/{remotevolid}/stop | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
@@ -50,3 +59,5 @@ WebhookDelete | DELETE | /events/webhook | [](https://godoc.org/github.com/glust
 WebhookList | GET | /events/webhook | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 GlustershEnable | POST | /volumes/{name}/heal/enable | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
 GlustershDisable | POST | /volumes/{name}/heal/disable | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
+Statedump | GET | /statedump | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#)
+List Endpoints | GET | /endpoints | [](https://godoc.org/github.com/gluster/glusterd2/pkg/api#) | [ListEndpointsResp](https://godoc.org/github.com/gluster/glusterd2/pkg/api#ListEndpointsResp)

--- a/glusterd2/commands/peers/commands.go
+++ b/glusterd2/commands/peers/commands.go
@@ -3,6 +3,8 @@ package peercommands
 
 import (
 	"github.com/gluster/glusterd2/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/pkg/api"
+	"github.com/gluster/glusterd2/pkg/utils"
 )
 
 // Command is a holding struct used to implement the GlusterD Command interface
@@ -13,18 +15,20 @@ type Command struct {
 func (c *Command) Routes() route.Routes {
 	return route.Routes{
 		route.Route{
-			Name:        "GetPeer",
-			Method:      "GET",
-			Pattern:     "/peers/{peerid}",
-			Version:     1,
-			HandlerFunc: getPeerHandler,
+			Name:         "GetPeer",
+			Method:       "GET",
+			Pattern:      "/peers/{peerid}",
+			Version:      1,
+			ResponseType: utils.GetTypeString((*api.PeerGetResp)(nil)),
+			HandlerFunc:  getPeerHandler,
 		},
 		route.Route{
-			Name:        "GetPeers",
-			Method:      "GET",
-			Pattern:     "/peers",
-			Version:     1,
-			HandlerFunc: getPeersHandler,
+			Name:         "GetPeers",
+			Method:       "GET",
+			Pattern:      "/peers",
+			Version:      1,
+			ResponseType: utils.GetTypeString((*api.PeerListResp)(nil)),
+			HandlerFunc:  getPeersHandler,
 		},
 		route.Route{
 			Name:        "DeletePeer",
@@ -34,11 +38,13 @@ func (c *Command) Routes() route.Routes {
 			HandlerFunc: deletePeerHandler,
 		},
 		route.Route{
-			Name:        "AddPeer",
-			Method:      "POST",
-			Pattern:     "/peers",
-			Version:     1,
-			HandlerFunc: addPeerHandler,
+			Name:         "AddPeer",
+			Method:       "POST",
+			Pattern:      "/peers",
+			Version:      1,
+			RequestType:  utils.GetTypeString((*api.PeerAddReq)(nil)),
+			ResponseType: utils.GetTypeString((*api.PeerAddResp)(nil)),
+			HandlerFunc:  addPeerHandler,
 		},
 	}
 }

--- a/glusterd2/commands/volumes/commands.go
+++ b/glusterd2/commands/volumes/commands.go
@@ -37,6 +37,7 @@ func (c *Command) Routes() route.Routes {
 			Method:      "POST",
 			Pattern:     "/volumes/{volname}/options",
 			Version:     1,
+			RequestType: utils.GetTypeString((*api.VolOptionReq)(nil)),
 			HandlerFunc: volumeOptionsHandler},
 		route.Route{
 			Name:         "OptionGroupList",

--- a/glusterd2/servers/rest/rest.go
+++ b/glusterd2/servers/rest/rest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
-	"expvar"
 	"net"
 	"net/http"
 	"time"
@@ -74,13 +73,6 @@ func NewMuxed(m cmux.CMux) *GDRest {
 	}
 
 	rest.registerRoutes()
-
-	// Expose /statedump endpoint (uses expvar) if enabled
-	if ok := config.GetBool("statedump"); ok {
-		rest.Routes.Handle("/statedump", expvar.Handler()).Methods("GET").Name("Statedump")
-	}
-
-	rest.Routes.Handle("/endpoints", rest.listEndpointsHandler()).Methods("GET").Name("List Endpoints")
 
 	// Chain of ordered middlewares.
 	rest.server.Handler = alice.New(

--- a/pkg/tools/generate-doc.go
+++ b/pkg/tools/generate-doc.go
@@ -13,14 +13,28 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const endpointsTable = `# API Endpoints
+// TODO: Fix this template by making a sub-template and removing markdown
+// links if the strings are empty.
+
+const endpointsTable = `
+<!---
+This file is generated using commands described below. DO NOT EDIT.
+
+$ curl -o endpoints.json -s -X GET http://127.0.0.1:24007/endpoints
+$ go build pkg/tools/generate-doc.go
+$ ./generate-doc
+-->
+
+# REST API Endpoints Reference
 
 Name | Methods | Path | Request | Response
 --- | --- | --- | --- | ---{{range $index, $element := .}}
 {{.Name}} | {{.Method}} | {{.Path}} | [{{.RequestType}}](https://godoc.org/github.com/gluster/glusterd2/pkg/api#{{.RequestType}}) | [{{.ResponseType}}](https://godoc.org/github.com/gluster/glusterd2/pkg/api#{{.ResponseType}}){{end}}
 `
 
-const outFile = "endpoints.md"
+// TODO: Consider making this code comment instead of markdown in the
+// file pkg/api/doc.go to be rendered by godoc in HTML
+const outFile = "doc/endpoints.md"
 
 // Example:
 // 	$ curl -o endpoints.json -s -X GET http://127.0.0.1:24007/endpoints


### PR DESCRIPTION
* REST API doc now resides in `doc/` dir and is mentioned in `README.md`
* Added request and response structs to peer APIs
* The `/statedump` and `/endpoints` now follow the normal convention of registering a mux route.
* Added some useful comments about further pending TODOs
* Add generated doc to `.gitattributes` to suppress GitHub showing diff.