### PR TITLE
volgen: decommissioned bricks details in Volfile

### DIFF
--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -17,13 +17,14 @@ const (
 
 // Brickinfo is the static information about the brick
 type Brickinfo struct {
-	ID         uuid.UUID
-	Hostname   string
-	NodeID     uuid.UUID
-	Path       string
-	VolumeName string
-	VolumeID   uuid.UUID
-	Type       Type
+	ID             uuid.UUID
+	Hostname       string
+	NodeID         uuid.UUID
+	Path           string
+	VolumeName     string
+	VolumeID       uuid.UUID
+	Type           Type
+	Decommissioned bool
 }
 
 func (b *Brickinfo) String() string {

--- a/glusterd2/volgen2/volfile_bitd.go
+++ b/glusterd2/volgen2/volfile_bitd.go
@@ -19,7 +19,7 @@ func generateBitdVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, nodeid
 		if exists && val == "on" {
 			name := fmt.Sprintf("%s-bit-rot-%d", vol.Name, volIdx)
 			bitdvol := bitd.Add("features/bit-rot", vol, nil).SetName(name).SetIgnoreOptions([]string{"scrubber"})
-			clusterGraph(bitdvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
+			clusterGraph(volfile, bitdvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
 		}
 	}
 }

--- a/glusterd2/volgen2/volfile_fuse.go
+++ b/glusterd2/volgen2/volfile_fuse.go
@@ -20,7 +20,7 @@ func generateTCPFuseVolfile(volfile *Volfile, vol *volume.Volinfo, nodeid uuid.U
 		Add("performance/write-behind", vol, nil).
 		Add("cluster/distribute", vol, nil)
 
-	clusterGraph(dht, vol, nodeid, nil)
+	clusterGraph(volfile, dht, vol, nodeid, nil)
 }
 
 func init() {

--- a/glusterd2/volgen2/volfile_gfproxy.go
+++ b/glusterd2/volgen2/volfile_gfproxy.go
@@ -28,7 +28,7 @@ func generateGfproxydVolfile(volfile *Volfile, vol *volume.Volinfo, nodeid uuid.
 		Add("performance/read-ahead", vol, nil).
 		Add("cluster/distribute", vol, nil)
 
-	clusterGraph(dht, vol, nodeid, nil)
+	clusterGraph(volfile, dht, vol, nodeid, nil)
 }
 
 func init() {

--- a/glusterd2/volgen2/volfile_quotad.go
+++ b/glusterd2/volgen2/volfile_quotad.go
@@ -19,7 +19,7 @@ func generateQuotadVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, node
 
 	for _, v := range clusterinfo {
 		dht := quota.Add("cluster/distribute", v, nil).SetName(v.Name)
-		clusterGraph(dht, v, nodeid, nil)
+		clusterGraph(volfile, dht, v, nodeid, nil)
 	}
 }
 

--- a/glusterd2/volgen2/volfile_rebalance.go
+++ b/glusterd2/volgen2/volfile_rebalance.go
@@ -12,7 +12,7 @@ func generateRebalanceVolfile(volfile *Volfile, vol *volume.Volinfo, nodeid uuid
 	dht := volfile.RootEntry.Add("debug/io-stats", vol, nil).SetName(vol.Name).
 		Add("cluster/distribute", vol, nil)
 
-	clusterGraph(dht, vol, nodeid, nil)
+	clusterGraph(volfile, dht, vol, nodeid, nil)
 }
 
 func init() {

--- a/glusterd2/volgen2/volfile_scrub.go
+++ b/glusterd2/volgen2/volfile_scrub.go
@@ -19,7 +19,7 @@ func generateScrubVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, nodei
 		if exists && val == "on" {
 			name := fmt.Sprintf("%s-bit-rot-%d", vol.Name, volIdx)
 			scrubvol := scrub.Add("features/bit-rot", vol, nil).SetName(name)
-			clusterGraph(scrubvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
+			clusterGraph(volfile, scrubvol, vol, nodeid, &clusterGraphFilters{onlyLocalBricks: true})
 		}
 	}
 }

--- a/glusterd2/volgen2/volfile_shd.go
+++ b/glusterd2/volgen2/volfile_shd.go
@@ -15,7 +15,7 @@ func generateShdVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, nodeid 
 			volume.SubvolReplicate,
 			volume.SubvolDisperse,
 		}}
-		clusterGraph(shd, vol, nodeid, &filters)
+		clusterGraph(volfile, shd, vol, nodeid, &filters)
 	}
 }
 


### PR DESCRIPTION
If Remove brick is started, rebalance volfile expects details
about the list of decommissioned bricks.

Example:

    option decommissioned-bricks testvol2-client-0

When remove brick starts, Set `brickinfo.Decommissioned=true`

Updates: #426
Signed-off-by: Aravinda VK <avishwan@redhat.com>