### PR TITLE
Quota: to set quota options

### DIFF
--- a/glusterd2/xlator/options/options.go
+++ b/glusterd2/xlator/options/options.go
@@ -336,10 +336,46 @@ func ValidateStr(o *Option, val string) error {
 
 // ValidateTime validates if the option is valid time format
 func ValidateTime(o *Option, val string) error {
-	if validate.IsTime(val, "hh:mm:ss") != true {
-		return ErrInvalidArg
+	var time int    // to convert given value from other formates to seconds
+	var tStr string // temp value which has the int without "min" ...
+	multiplier := 1
+	if strings.HasSuffix(val, "sec") {
+		tStr = strings.TrimSuffix(val, "sec")
+	} else if strings.HasSuffix(val, "s") {
+		tStr = strings.TrimSuffix(val, "s")
+	} else if strings.HasSuffix(val, "min") {
+		tStr = strings.TrimSuffix(val, "min")
+		multiplier = 60
+	} else if strings.HasSuffix(val, "m") {
+		tStr = strings.TrimSuffix(val, "m")
+		multiplier = 60
+	} else if strings.HasSuffix(val, "hr") {
+		tStr = strings.TrimSuffix(val, "hr")
+		multiplier = 60 * 60
+	} else if strings.HasSuffix(val, "h") {
+		tStr = strings.TrimSuffix(val, "h")
+		multiplier = 60 * 60
+	} else if strings.HasSuffix(val, "days") {
+		tStr = strings.TrimSuffix(val, "days")
+		multiplier = 60 * 60 * 24
+	} else if strings.HasSuffix(val, "d") {
+		tStr = strings.TrimSuffix(val, "d")
+		multiplier = 60 * 60 * 24
+	} else if strings.HasSuffix(val, "w") {
+		tStr = strings.TrimSuffix(val, "w")
+		multiplier = 60 * 60 * 24 * 7
+	} else if strings.HasSuffix(val, "wk") {
+		tStr = strings.TrimSuffix(val, "wk")
+		multiplier = 60 * 60 * 24 * 7
+	} else {
+		tStr = val
 	}
-	return nil
+	time, err := strconv.Atoi(tStr)
+	if err != nil {
+		return err
+	}
+	time = time * multiplier
+	return ValidateRange(o, strconv.Itoa(time))
 }
 
 // ValidateXlator validates if the option is a valid xlator

--- a/glusterd2/xlator/validation.go
+++ b/glusterd2/xlator/validation.go
@@ -52,6 +52,32 @@ func validateBitrot(v *volume.Volinfo, key string, value string) error {
 	return nil
 }
 
+func validateQuota(v *volume.Volinfo, key string, value string) error {
+
+	// Check if quota is already enabled
+	if volume.IsQuotaEnabled(v) == false {
+		err := fmt.Errorf("Quota not enabled to set this value: '%s'", key)
+		return err
+	}
+
+	switch key {
+	case "deem-statfs":
+		return nil
+	case "hard-timeout":
+		return nil
+	case "soft-timeout":
+		return nil
+	case "alert-time":
+		return nil
+	case "default-soft-limit":
+		return nil
+	default:
+		err := fmt.Errorf("'%s' is not a valid quota option", key)
+		return err
+	}
+	return nil
+}
+
 func registerValidation(xlator string, vf validationFunc) error {
 	xl, err := Find(xlator)
 	if err != nil {
@@ -65,5 +91,11 @@ func registerAllValidations() error {
 	if err := registerValidation("afr", validateReplica); err != nil {
 		return err
 	}
-	return registerValidation("bit-rot", validateBitrot)
+	if err := registerValidation("bit-rot", validateBitrot); err != nil {
+		return err
+	}
+	if err := registerValidation("quota", validateQuota); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Various quota options we set as quota set command in glusterd one.
From glusterd2 onwards they are maintained through volume set commands.
this patch enables setting quota options like soft and hard timeout,
deemstatfs, alert-time and default-soft-limit.

The parsing for time during volume set was bug, have changed it to
accomodate the backward compatiblity with glusterd1's validation.

Updates: #421
Signed-off-by: Hari Gowtham <hgowtham@redhat.com>