### PR TITLE
Handle peer connects/disconnects in store

### DIFF
--- a/glusterd2/events/events.go
+++ b/glusterd2/events/events.go
@@ -58,11 +58,13 @@ func Start() error {
 	StartGlobal()
 	startEventLogger()
 	registerGaneshaHandler()
+	startLivenessWatcher()
 	return nil
 }
 
 // Stop stops the events framework, events will no longer be broadcast
 func Stop() error {
+	stopLivenessWatcher()
 	stopEventLogger()
 	StopGlobal()
 	stopHandlers()

--- a/glusterd2/events/liveness.go
+++ b/glusterd2/events/liveness.go
@@ -1,0 +1,79 @@
+package events
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/gluster/glusterd2/glusterd2/store"
+
+	"github.com/coreos/etcd/clientv3"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	eventPeerDisconnectedStore = "peer.disconnected.store"
+	eventPeerConnectedStore    = "peer.connected.store"
+)
+
+type livenessWatcher struct {
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+var lWatcher *livenessWatcher
+
+// Watch watches the store for nodes that go down or come up and it
+// broadcasts this information locally.
+func (l *livenessWatcher) Watch() {
+	defer l.wg.Done()
+
+	wch := store.Store.Watch(store.Store.Ctx(), store.LivenessKeyPrefix,
+		clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	for {
+		select {
+		case resp := <-wch:
+			if resp.Canceled {
+				return
+			}
+			for _, sev := range resp.Events {
+
+				peerID := strings.TrimPrefix(
+					string(sev.Kv.Key),
+					store.LivenessKeyPrefix)
+
+				var evName string
+				switch sev.Type {
+				case clientv3.EventTypePut:
+					evName = eventPeerConnectedStore
+					log.WithField("id", peerID).Info("peer connected to store")
+				case clientv3.EventTypeDelete:
+					evName = eventPeerDisconnectedStore
+					log.WithField("id", peerID).Info("peer disconnected from store")
+				default:
+					continue
+				}
+
+				data := map[string]string{
+					"peer.id": peerID,
+				}
+
+				Broadcast(New(evName, data, false))
+			}
+		case <-l.stopCh:
+			return
+		}
+	}
+}
+
+func startLivenessWatcher() {
+	lWatcher = &livenessWatcher{
+		stopCh: make(chan struct{}, 0),
+	}
+	lWatcher.wg.Add(1)
+	go lWatcher.Watch()
+}
+
+func stopLivenessWatcher() {
+	close(lWatcher.stopCh)
+	lWatcher.wg.Wait()
+}

--- a/glusterd2/store/config.go
+++ b/glusterd2/store/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	noEmbedOpt       = "no-embed"
+	noEmbedOpt       = "noembed"
 	etcdEndpointsOpt = "etcdendpoints"
 	etcdCURLsOpt     = "etcdcurls"
 	etcdPURLsOpt     = "etcdpurls"

--- a/glusterd2/store/liveness.go
+++ b/glusterd2/store/liveness.go
@@ -11,7 +11,9 @@ import (
 )
 
 const (
-	livenessKeyPrefix = "alive/"
+	// LivenessKeyPrefix is the prefix in store where peers publish
+	// their liveness information.
+	LivenessKeyPrefix = "alive/"
 )
 
 // IsNodeAlive returns true if the node specified is alive as seen by the store
@@ -34,7 +36,7 @@ func (s *GDStore) IsNodeAlive(nodeID interface{}) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	key := livenessKeyPrefix + keySuffix
+	key := LivenessKeyPrefix + keySuffix
 	resp, err := s.Get(ctx, key)
 	if err != nil {
 		return false
@@ -45,7 +47,7 @@ func (s *GDStore) IsNodeAlive(nodeID interface{}) bool {
 
 func (s *GDStore) publishLiveness() error {
 	// publish liveness of this instance into the store
-	key := livenessKeyPrefix + gdctx.MyUUID.String()
+	key := LivenessKeyPrefix + gdctx.MyUUID.String()
 	_, err := s.Put(context.TODO(), key, "", clientv3.WithLease(s.Session.Lease()))
 
 	return err
@@ -53,7 +55,8 @@ func (s *GDStore) publishLiveness() error {
 
 func (s *GDStore) revokeLiveness() error {
 	// revoke liveness (to be invoked during graceful shutdowns)
-	key := livenessKeyPrefix + gdctx.MyUUID.String()
+	key := LivenessKeyPrefix + gdctx.MyUUID.String()
 	_, err := s.Delete(context.TODO(), key)
+
 	return err
 }

--- a/glusterd2/store/liveness.go
+++ b/glusterd2/store/liveness.go
@@ -50,3 +50,10 @@ func (s *GDStore) publishLiveness() error {
 
 	return err
 }
+
+func (s *GDStore) revokeLiveness() error {
+	// revoke liveness (to be invoked during graceful shutdowns)
+	key := livenessKeyPrefix + gdctx.MyUUID.String()
+	_, err := s.Delete(context.TODO(), key)
+	return err
+}

--- a/glusterd2/store/store.go
+++ b/glusterd2/store/store.go
@@ -108,6 +108,10 @@ func New(conf *Config) (*GDStore, error) {
 
 // Close closes the store connections
 func (s *GDStore) Close() {
+	if err := s.revokeLiveness(); err != nil {
+		log.WithError(err).Error("failed to revoke liveness")
+	}
+
 	if s.ee != nil {
 		s.closeEmbedStore()
 	} else {


### PR DESCRIPTION
**Watch for liveness of nodes in store:**
     Log and emit local event every time a node connects to or disconnects
     from the store.

**Explicitly delete liveness key when an instance shuts down:**
    The default etcd session TTL is 30 seconds which is quite high.
    When a glusterd2 instance is shutdown, it takes a while for other
    nodes to notice this as TTL for the liveness key should expire. When
    a glusterd2 instance is shutdown gracefully (SIGTERM), it can simply
    delete its liveness key from the store and hence other nodes can see
    this instantly.

