### PR TITLE
cli: Support for external sub commands

### DIFF
--- a/glustercli/cmd/common.go
+++ b/glustercli/cmd/common.go
@@ -41,13 +41,13 @@ func handleGlusterdConnectFailure(msg string, err error, https bool, host string
 			scheme = "https"
 		}
 		os.Stderr.WriteString(msg + "\n\n")
-		os.Stderr.WriteString(fmt.Sprintf(errFailedToConnectToGlusterd, scheme, flagHostname, flagPort))
+		os.Stderr.WriteString(fmt.Sprintf(errFailedToConnectToGlusterd, scheme, FlagHostname, FlagPort))
 		os.Exit(errcode)
 	}
 }
 
 func failure(msg string, err error, errcode int) {
-	handleGlusterdConnectFailure(msg, err, flagHTTPS, flagHostname, flagPort, errcode)
+	handleGlusterdConnectFailure(msg, err, FlagHTTPS, FlagHostname, FlagPort, errcode)
 
 	// If different error
 	os.Stderr.WriteString(msg + "\n")

--- a/glustercli/cmd/root.go
+++ b/glustercli/cmd/root.go
@@ -13,30 +13,40 @@ var RootCmd = &cobra.Command{
 	Use:   "glustercli",
 	Short: "Gluster Console Manager (command line utility)",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		err := logging.Init(flagLogDir, flagLogFile, flagLogLevel, false)
+		err := logging.Init(FlagLogDir, FlagLogFile, FlagLogLevel, false)
 		if err != nil {
 			fmt.Println("Error initializing log file ", err)
 		}
 		scheme := "http"
-		if flagHTTPS {
+		if FlagHTTPS {
 			scheme = "https"
 		}
-		hostname := fmt.Sprintf("%s://%s:%d", scheme, flagHostname, flagPort)
-		initRESTClient(hostname, flagCacert, flagInsecure)
+		hostname := fmt.Sprintf("%s://%s:%d", scheme, FlagHostname, FlagPort)
+		initRESTClient(hostname, FlagCacert, FlagInsecure)
 	},
 }
 
 var (
-	flagXMLOutput  bool
-	flagJSONOutput bool
-	flagHostname   string
-	flagHTTPS      bool
-	flagPort       int
-	flagCacert     string
-	flagInsecure   bool
-	flagLogDir     string
-	flagLogFile    string
-	flagLogLevel   string
+	// FlagXMLOutput to display the output in XML format
+	FlagXMLOutput bool
+	// FlagJSONOutput to display the output in JSON format
+	FlagJSONOutput bool
+	// FlagHostname to represents Glusterd Hostname
+	FlagHostname string
+	// FlagHTTPS represents HTTPs connection to Glusterd
+	FlagHTTPS bool
+	// FlagPort represents Glusterd port
+	FlagPort int
+	// FlagCacert represents CA cert path to connect to Glusterd
+	FlagCacert string
+	// FlagInsecure represents ignore HTTPs certificate
+	FlagInsecure bool
+	// FlagLogDir represents Log directory
+	FlagLogDir string
+	// FlagLogFile represents Log file
+	FlagLogFile string
+	// FlagLogLevel represents Log level
+	FlagLogLevel string
 )
 
 const (
@@ -47,19 +57,19 @@ const (
 
 func init() {
 	// Global flags, applicable for all sub commands
-	RootCmd.PersistentFlags().BoolVarP(&flagXMLOutput, "xml", "", false, "XML Output")
-	RootCmd.PersistentFlags().BoolVarP(&flagJSONOutput, "json", "", false, "JSON Output")
-	RootCmd.PersistentFlags().StringVarP(&flagHostname, "glusterd-host", "", "localhost", "Glusterd Host")
-	RootCmd.PersistentFlags().BoolVarP(&flagHTTPS, "glusterd-https", "", false, "Use HTTPS while connecting to Glusterd")
-	RootCmd.PersistentFlags().IntVarP(&flagPort, "glusterd-port", "", 24007, "Glusterd Port")
+	RootCmd.PersistentFlags().BoolVarP(&FlagXMLOutput, "xml", "", false, "XML Output")
+	RootCmd.PersistentFlags().BoolVarP(&FlagJSONOutput, "json", "", false, "JSON Output")
+	RootCmd.PersistentFlags().StringVarP(&FlagHostname, "glusterd-host", "", "localhost", "Glusterd Host")
+	RootCmd.PersistentFlags().BoolVarP(&FlagHTTPS, "glusterd-https", "", false, "Use HTTPS while connecting to Glusterd")
+	RootCmd.PersistentFlags().IntVarP(&FlagPort, "glusterd-port", "", 24007, "Glusterd Port")
 
 	// Log options
-	RootCmd.PersistentFlags().StringVarP(&flagLogDir, logging.DirFlag, "", defaultLogDir, logging.DirHelp)
-	RootCmd.PersistentFlags().StringVarP(&flagLogFile, logging.FileFlag, "", defaultLogFile, logging.FileHelp)
-	RootCmd.PersistentFlags().StringVarP(&flagLogLevel, logging.LevelFlag, "", defaultLogLevel, logging.LevelHelp)
+	RootCmd.PersistentFlags().StringVarP(&FlagLogDir, logging.DirFlag, "", defaultLogDir, logging.DirHelp)
+	RootCmd.PersistentFlags().StringVarP(&FlagLogFile, logging.FileFlag, "", defaultLogFile, logging.FileHelp)
+	RootCmd.PersistentFlags().StringVarP(&FlagLogLevel, logging.LevelFlag, "", defaultLogLevel, logging.LevelHelp)
 
 	// SSL/TLS options
-	RootCmd.PersistentFlags().StringVarP(&flagCacert, "cacert", "", "", "Path to CA certificate")
-	RootCmd.PersistentFlags().BoolVarP(&flagInsecure, "insecure", "", false,
+	RootCmd.PersistentFlags().StringVarP(&FlagCacert, "cacert", "", "", "Path to CA certificate")
+	RootCmd.PersistentFlags().BoolVarP(&FlagInsecure, "insecure", "", false,
 		"Accepts any certificate presented by the server and any host name in that certificate.")
 }

--- a/glustercli/main.go
+++ b/glustercli/main.go
@@ -3,16 +3,79 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"regexp"
+	"syscall"
 
 	"github.com/gluster/glusterd2/glustercli/cmd"
+	"github.com/gluster/glusterd2/pkg/logging"
 )
+
+var unknownCommandExp = regexp.MustCompile(`unknown command "([^"]+)" `)
+
+func getUnknownCommandName(err error) string {
+	m := unknownCommandExp.FindStringSubmatch(err.Error())
+	if len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
 
 func main() {
 	// Migrate old format Args into new Format. Modifies os.Args[]
 	argsMigrate()
 
+	cmd.RootCmd.SilenceErrors = true
+
 	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		unknownCmd := getUnknownCommandName(err)
+		if unknownCmd != "" {
+			// May be external sub Command
+			cmdPath, err := exec.LookPath(cmd.RootCmd.Use + "-" + unknownCmd)
+			if err == nil {
+				cmdArgs := []string{}
+				err = cmd.RootCmd.ParseFlags(os.Args[1:])
+				if err == nil {
+					if cmd.FlagXMLOutput {
+						cmdArgs = append(cmdArgs, "--xml")
+					}
+
+					if cmd.FlagJSONOutput {
+						cmdArgs = append(cmdArgs, "--json")
+					}
+					cmdArgs = append(cmdArgs, "--glusterd-host", cmd.FlagHostname)
+					if cmd.FlagHTTPS {
+						cmdArgs = append(cmdArgs, "--glusterd-https")
+					}
+					cmdArgs = append(cmdArgs, "--glusterd-port", fmt.Sprintf("%d", cmd.FlagPort))
+					cmdArgs = append(cmdArgs, "--"+logging.DirFlag, cmd.FlagLogDir)
+					cmdArgs = append(cmdArgs, "--"+logging.FileFlag, cmd.FlagLogFile)
+					cmdArgs = append(cmdArgs, "--"+logging.LevelFlag, cmd.FlagLogLevel)
+					cmdArgs = append(cmdArgs, "--cacert", cmd.FlagCacert)
+					if cmd.FlagInsecure {
+						cmdArgs = append(cmdArgs, "--insecure")
+					}
+				}
+
+				command := exec.Command(cmdPath, cmdArgs...)
+				command.Stdout = os.Stdout
+				command.Stderr = os.Stderr
+
+				// If Return code is accessible
+				if err = command.Run(); err != nil {
+					if exiterr, ok := err.(*exec.ExitError); ok {
+						if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+							os.Exit(status.ExitStatus())
+						}
+					}
+					os.Exit(1)
+				}
+				return
+			}
+		}
+
+		// If Known command error or no external command available
+		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Added support for external sub commands to Gluster CLI.(Similar to
`git` external sub command support)

If any executable available in `PATH` with name `glustercli-<cmd>` then
it will be available as `glustercli <cmd>`. External sub command can be
written in any programming language.

All the known commands will get precedence over external commands.

Following arguments will be included while executing external commands.

    --xml
    --json
    --glusterd-host <host>
    --glusterd-https
    --glusterd-port <port>
    --logdir <path>
    --logfile <name>
    --loglevel <level>
    --cacert <path>
    --insecure

Example of simple external plugin/command, which connects to Glusterd
and just displays Volume name and State. (File name
`/usr/local/bin/glustercli-volinfo2` with executable permission)

    #!/usr/bin/env python
    from argparse import ArgumentParser
    import sys
    import json

    import requests

    if __name__ == "__main__":
        parser = ArgumentParser()
        parser.add_argument("--xml", action="store_true")
        parser.add_argument("--json", action="store_true")
        parser.add_argument("--glusterd-host", default="localhost")
        parser.add_argument("--glusterd-https", action="store_true")
        parser.add_argument("--glusterd-port", default=24007, type=int)
        parser.add_argument("--logdir")
        parser.add_argument("--logfile")
        parser.add_argument("--loglevel")
        parser.add_argument("--cacert")
        parser.add_argument("--insecure", action="store_true")

        parser.add_argument("--volume")

        args = parser.parse_args()
        url = "https://" if args.glusterd_https else "http://"
        url += "%s:%d/v1/volumes" % (args.glusterd_host, args.glusterd_port)
        if args.volume:
            url += "/" + args.volume

        resp = requests.get(url)

        if resp.status_code != 200:
            print("Unable to get Volume Info")
            sys.exit(1)

        for v in json.loads(resp.content):
            print("%15s %s" % (v["name"], v["state"]))

Fixes: #594
Signed-off-by: Aravinda VK <avishwan@redhat.com>