### PR TITLE
Simplify SendHTTPError()

### DIFF
--- a/glusterd2/commands/global/getglobaloptions.go
+++ b/glusterd2/commands/global/getglobaloptions.go
@@ -16,7 +16,7 @@ func getGlobalOptionsHandler(w http.ResponseWriter, r *http.Request) {
 	c, err := cluster.GetCluster()
 	// ErrClusterNotFound here implies that no global option has yet been explicitly set. Ignoring it.
 	if err != nil && err != errors.ErrClusterNotFound {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Problem retrieving cluster information from etcd store: %s", err.Error()), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Problem retrieving cluster information from etcd store: %s", err.Error()))
 		return
 	}
 

--- a/glusterd2/commands/global/setglobaloptions.go
+++ b/glusterd2/commands/global/setglobaloptions.go
@@ -15,14 +15,14 @@ func setGlobalOptionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.GlobalOptionReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
 	c, err := cluster.GetCluster()
 	// ErrClusterNotFound here implies that no global option has yet been explicitly set. Ignoring it.
 	if err != nil && err != errors.ErrClusterNotFound {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Problem retrieving cluster information from etcd store: %s", err.Error()), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Problem retrieving cluster information from etcd store: %s", err.Error()))
 		return
 	}
 
@@ -36,14 +36,14 @@ func setGlobalOptionsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			c.Options[k] = v
 		} else {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Invalid global option: %s", k), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, fmt.Sprintf("Invalid global option: %s", k))
 			continue
 		}
 	}
 
 	if err := cluster.UpdateCluster(c); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError,
-			fmt.Sprint("Failed to update store with cluster attributes %s", err.Error()), api.ErrCodeDefault)
+			fmt.Sprint("Failed to update store with cluster attributes %s", err.Error()))
 		return
 	}
 

--- a/glusterd2/commands/peers/addpeer.go
+++ b/glusterd2/commands/peers/addpeer.go
@@ -21,19 +21,19 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.PeerAddReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
 		return
 	}
 
 	if len(req.Addresses) < 1 {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrNoHostnamesPresent.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrNoHostnamesPresent)
 		return
 	}
 	logger.WithField("addresses", req.Addresses).Debug("received request to add new peer with given addresses")
 
 	p, _ := peer.GetPeerByAddrs(req.Addresses)
 	if p != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, fmt.Sprintf("Peer exists with given addresses (ID: %s)", p.ID.String()), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, fmt.Sprintf("Peer exists with given addresses (ID: %s)", p.ID.String()))
 		return
 	}
 
@@ -42,14 +42,14 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 	remotePeerAddress, err := utils.FormRemotePeerAddress(req.Addresses[0])
 	if err != nil {
 		logger.WithError(err).WithField("address", req.Addresses[0]).Error("failed to parse peer address")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "failed to parse remote address", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "failed to parse remote address")
 		return
 	}
 
 	// TODO: Try all addresses till the first one connects
 	client, err := getPeerServiceClient(remotePeerAddress)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	defer client.conn.Close()
@@ -62,12 +62,12 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 	rsp, err := client.JoinCluster(newconfig)
 	if err != nil {
 		logger.WithError(err).Error("sending Join request failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to send join cluster request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to send join cluster request")
 		return
 	} else if Error(rsp.Err) != ErrNone {
 		err = Error(rsp.Err)
 		logger.WithError(err).Error("join request failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	logger = logger.WithField("peerid", rsp.PeerID)
@@ -76,14 +76,14 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 	// Get the new peer information to reply back with
 	newpeer, err := peer.GetPeer(rsp.PeerID)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "new peer was added, but could not find peer in store. Try again later.", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "new peer was added, but could not find peer in store. Try again later.")
 		return
 	}
 
 	newpeer.MetaData = req.MetaData
 	err = peer.AddOrUpdatePeer(newpeer)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Fail to add metadata to peer", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Fail to add metadata to peer")
 	}
 	resp := createPeerAddResp(newpeer)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)

--- a/glusterd2/commands/peers/deletepeer.go
+++ b/glusterd2/commands/peers/deletepeer.go
@@ -9,7 +9,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/store"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/utils"
 
 	"github.com/gorilla/mux"
@@ -23,7 +22,7 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 
 	id := mux.Vars(r)["peerid"]
 	if id == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in the request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in the request")
 		return
 	}
 
@@ -40,49 +39,49 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 	p, err := peer.GetPeerF(id)
 	if err != nil {
 		logger.WithError(err).Error("failed to get peer")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "could not validate delete request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "could not validate delete request")
 		return
 	} else if p == nil {
 		logger.Debug("request denied, received request to remove unknown peer")
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, "peer not found in cluster", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, "peer not found in cluster")
 		return
 	}
 
 	// You cannot remove yourself
 	if id == gdctx.MyUUID.String() {
 		logger.Debug("request denied, received request to delete self from cluster")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "removing self is disallowed.", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "removing self is disallowed.")
 		return
 	}
 
 	// Check if any volumes exist with bricks on this peer
 	if exists, err := bricksExist(id); err != nil {
 		logger.WithError(err).Error("failed to check if bricks exist on peer")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "could not validate delete request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "could not validate delete request")
 		return
 	} else if exists {
 		logger.Debug("request denied, peer has bricks")
-		restutils.SendHTTPError(ctx, w, http.StatusForbidden, "cannot delete peer, peer has bricks", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusForbidden, "cannot delete peer, peer has bricks")
 		return
 	}
 
 	// Remove the peer details from the store
 	if err := peer.DeletePeer(id); err != nil {
 		logger.WithError(err).WithField("peer", id).Error("failed to remove peer from the store")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	remotePeerAddress, err := utils.FormRemotePeerAddress(p.PeerAddresses[0])
 	if err != nil {
 		logger.WithError(err).WithField("address", p.PeerAddresses[0]).Error("failed to parse peer address")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "failed to parse remote address", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "failed to parse remote address")
 		return
 	}
 
 	client, err := getPeerServiceClient(remotePeerAddress)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	defer client.conn.Close()
@@ -93,12 +92,12 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 	rsp, err := client.LeaveCluster()
 	if err != nil {
 		logger.WithError(err).Error("sending Leave request failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to send leave cluster request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to send leave cluster request")
 		return
 	} else if Error(rsp.Err) != ErrNone {
 		err = Error(rsp.Err)
 		logger.WithError(err).Error("leave request failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	logger.Debug("peer left cluster")

--- a/glusterd2/commands/peers/getpeer.go
+++ b/glusterd2/commands/peers/getpeer.go
@@ -16,13 +16,13 @@ func getPeerHandler(w http.ResponseWriter, r *http.Request) {
 
 	id := mux.Vars(r)["peerid"]
 	if id == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in request")
 		return
 	}
 
 	peer, err := peer.GetPeerF(id)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err)
 	}
 
 	resp := createPeerGetResp(peer)

--- a/glusterd2/commands/peers/getpeers.go
+++ b/glusterd2/commands/peers/getpeers.go
@@ -15,7 +15,7 @@ func getPeersHandler(w http.ResponseWriter, r *http.Request) {
 
 	peers, err := peer.GetPeersF()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err)
 	}
 
 	resp := createPeerListResp(peers)

--- a/glusterd2/commands/volumes/bricks-status.go
+++ b/glusterd2/commands/volumes/bricks-status.go
@@ -71,7 +71,7 @@ func volumeBricksStatusHandler(w http.ResponseWriter, r *http.Request) {
 	volname := mux.Vars(r)["volname"]
 	vol, err := volume.GetVolume(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -92,7 +92,7 @@ func volumeBricksStatusHandler(w http.ResponseWriter, r *http.Request) {
 	err = txn.Do()
 	if err != nil {
 		logger.WithError(err).WithField("volume", volname).Error("Failed to get volume status")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -100,7 +100,7 @@ func volumeBricksStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := "Failed to aggregate brick status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("volumeStatusHandler:" + errMsg)
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, errMsg, api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, errMsg)
 		return
 	}
 

--- a/glusterd2/commands/volumes/optiongroup-create.go
+++ b/glusterd2/commands/volumes/optiongroup-create.go
@@ -29,24 +29,24 @@ func optionGroupCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.OptionGroupReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
 	if err := validateOptionSet(req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
 		return
 	}
 
 	resp, err := store.Store.Get(context.TODO(), "groupoptions")
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	var groupOptions map[string][]api.VolumeOption
 	if err := json.Unmarshal(resp.Kvs[0].Value, &groupOptions); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -58,11 +58,11 @@ func optionGroupCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	groupOptionsJSON, err := json.Marshal(groupOptions)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	if _, err := store.Store.Put(context.TODO(), "groupoptions", string(groupOptionsJSON)); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/glusterd2/commands/volumes/optiongroup-delete.go
+++ b/glusterd2/commands/volumes/optiongroup-delete.go
@@ -18,24 +18,24 @@ func optionGroupDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := store.Store.Get(context.TODO(), "groupoptions")
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	var groupOptions map[string][]api.VolumeOption
 	if err := json.Unmarshal(resp.Kvs[0].Value, &groupOptions); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	_, ok := groupOptions[groupName]
 	if !ok {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "invalid group name specified", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "invalid group name specified")
 		return
 	}
 
 	if _, ok := defaultGroupOptions[groupName]; ok {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "cannot delete builtin groups", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "cannot delete builtin groups")
 		return
 	}
 
@@ -43,11 +43,11 @@ func optionGroupDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	groupOptionsJSON, err := json.Marshal(groupOptions)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	if _, err := store.Store.Put(context.TODO(), "groupoptions", string(groupOptionsJSON)); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/glusterd2/commands/volumes/optiongroup-list.go
+++ b/glusterd2/commands/volumes/optiongroup-list.go
@@ -15,13 +15,13 @@ func optionGroupListHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := store.Store.Get(context.TODO(), "groupoptions")
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	var groupOptions map[string][]api.VolumeOption
 	if err := json.Unmarshal(resp.Kvs[0].Value, &groupOptions); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volfiles.go
+++ b/glusterd2/commands/volumes/volfiles.go
@@ -5,7 +5,6 @@ import (
 
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	volgen "github.com/gluster/glusterd2/glusterd2/volgen2"
-	"github.com/gluster/glusterd2/pkg/api"
 )
 
 func volfilesGenerateHandler(w http.ResponseWriter, r *http.Request) {
@@ -13,12 +12,12 @@ func volfilesGenerateHandler(w http.ResponseWriter, r *http.Request) {
 
 	err := volgen.Generate()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to generate volfiles", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to generate volfiles")
 		return
 	}
 	volfiles, err := volgen.GetVolfiles()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to get list of volfiles", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to get list of volfiles")
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, volfiles)
@@ -29,7 +28,7 @@ func volfilesListHandler(w http.ResponseWriter, r *http.Request) {
 
 	volfiles, err := volgen.GetVolfiles()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to get list of volfiles", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "unable to get list of volfiles")
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, volfiles)

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -197,31 +197,31 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	httpStatus, err := unmarshalVolCreateRequest(req, r)
 	if err != nil {
 		logger.WithError(err).Error("Failed to unmarshal volume create request")
-		restutils.SendHTTPError(ctx, w, httpStatus, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, httpStatus, err)
 		return
 	}
 
 	if volume.ExistsFunc(req.Name) {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, gderrors.ErrVolExists.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, gderrors.ErrVolExists)
 		return
 	}
 
 	nodes, err := nodesFromVolumeCreateReq(req)
 	if err != nil {
 		logger.WithError(err).Error("could not prepare node list")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if req.Options, err = expandOptions(req.Options); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := validateOptions(req.Options); err != nil {
 		logger.WithField("option", err.Error()).Error("invalid volume option specified")
 		msg := fmt.Sprintf("invalid volume option specified: %s", err.Error())
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, msg, api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, msg)
 		return
 	}
 
@@ -230,7 +230,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	lock, unlock, err := transaction.CreateLockSteps(req.Name)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -256,20 +256,20 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	vol, err := createVolinfo(req)
 	if err != nil {
 		logger.WithError(err).Error("failed to create volinfo")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := validateXlatorOptions(req.Options, vol); err != nil {
 		logger.WithError(err).Error("validation failed")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, fmt.Sprintf("failed to set volume option: %s", err.Error()), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, fmt.Sprintf("failed to set volume option: %s", err.Error()))
 		return
 	}
 
 	err = txn.Ctx.Set("bricks", vol.GetBricks())
 	if err != nil {
 		logger.WithError(err).WithField("key", "bricks").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -284,14 +284,14 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	err = txn.Ctx.Set("brick-checks", &checks)
 	if err != nil {
 		logger.WithError(err).WithField("key", "brick-checks").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	err = txn.Ctx.Set("volinfo", &vol)
 	if err != nil {
 		logger.WithError(err).WithField("key", "volinfo").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -299,15 +299,15 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.WithError(err).Error("volume create transaction failed")
 		if err == transaction.ErrLockTimeout {
-			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		}
 		return
 	}
 
 	if err = txn.Ctx.Get("volinfo", &vol); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to get volinfo", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to get volinfo")
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volgen"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
@@ -68,12 +67,12 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	volname := mux.Vars(r)["volname"]
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err)
 		return
 	}
 
 	if volinfo.State == volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusForbidden, "volume is not stopped", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusForbidden, "volume is not stopped")
 		return
 	}
 
@@ -81,7 +80,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -103,9 +102,9 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		logger.WithError(err).WithField(
 			"volume", volname).Error("failed to delete the volume")
 		if err == transaction.ErrLockTimeout {
-			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		}
 		return
 	}

--- a/glusterd2/commands/volumes/volume-info.go
+++ b/glusterd2/commands/volumes/volume-info.go
@@ -18,7 +18,7 @@ func volumeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	volname := mux.Vars(r)["volname"]
 	v, err := volume.GetVolume(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-list.go
+++ b/glusterd2/commands/volumes/volume-list.go
@@ -14,7 +14,7 @@ func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 
 	volumes, err := volume.GetVolumes()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, err)
 	}
 
 	resp := createVolumeListResp(volumes)

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -8,7 +8,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/gorilla/mux"
@@ -89,11 +88,11 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	volname := mux.Vars(r)["volname"]
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 	if vol.State == volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStarted.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStarted)
 		return
 	}
 
@@ -102,7 +101,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -123,7 +122,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 			"error":  err.Error(),
 			"volume": volname,
 		}).Error("failed to start volume")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -131,7 +130,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 
 	e = volume.AddOrUpdateVolumeFunc(vol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-status.go
+++ b/glusterd2/commands/volumes/volume-status.go
@@ -19,19 +19,19 @@ func volumeStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	v, err := volume.GetVolume(mux.Vars(r)["volname"])
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	if v.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted)
 		return
 	}
 
 	s, err := volume.UsageInfo(v.Name)
 	if err != nil {
 		logger.WithError(err).WithField("volume", v.Name).Error("Failed to get volume size info")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Failed to get Volume size info", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Failed to get Volume size info")
 		return
 
 	}

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -10,7 +10,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/gorilla/mux"
@@ -86,11 +85,11 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	volname := mux.Vars(r)["volname"]
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 	if vol.State == volume.VolStopped {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStopped.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStopped)
 		return
 	}
 
@@ -99,7 +98,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	defer txn.Cleanup()
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	txn.Steps = []*transaction.Step{
@@ -116,9 +115,9 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		logger.WithError(err).WithField(
 			"volume", volname).Error("failed to stop volume")
 		if err == transaction.ErrLockTimeout {
-			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		}
 		return
 	}
@@ -127,7 +126,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 
 	e = volume.AddOrUpdateVolumeFunc(vol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 	events.Broadcast(newVolumeEvent(eventVolumeStopped, vol))

--- a/glusterd2/servers/rest/utils/utils.go
+++ b/glusterd2/servers/rest/utils/utils.go
@@ -41,7 +41,10 @@ func SendHTTPResponse(ctx context.Context, w http.ResponseWriter, statusCode int
 
 // SendHTTPError sends an error response to the client. The caller of this
 // function can pass either the error or one or more error code(s) exported by
-// api package.
+// api package. Example usage:
+// SendHTTPError(ctx, http.StatusBadRequest, err) // Pass error as is
+// SendHTTPError(ctx, http.StatusBadRequest, "", api.ErrorCode) // Specify error code
+// SendHTTPError(ctx, http.StatusBadRequest, "custom error") // Pass specific error string
 func SendHTTPError(ctx context.Context, w http.ResponseWriter, statusCode int,
 	err interface{}, errCodes ...api.ErrorCode) {
 
@@ -53,7 +56,7 @@ func SendHTTPError(ctx context.Context, w http.ResponseWriter, statusCode int,
 
 	var resp api.ErrorResp
 	errMsg := fmt.Sprint(err)
-	if errMsg != "" || len(errCodes) == 0 {
+	if errMsg != "" || errMsg != "<nil>" || len(errCodes) == 0 {
 		resp.Errors = append(resp.Errors, api.HTTPError{
 			Code:    int(api.ErrCodeGeneric),
 			Message: errMsg})

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -17,7 +17,7 @@ type ErrorCode uint16
 
 const (
 	// ErrCodeGeneric represents generic error code for API responses
-	ErrCodeGeneric ErrorCode = iota
+	ErrCodeGeneric ErrorCode = iota + 1
 )
 
 // ErrorCodeMap maps error code to it's textual message

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,14 +1,26 @@
 package api
 
-// HTTPError represents HTTP error returned by glusterd2
+// HTTPError contains an error code and corresponding text which briefly
+// describes the error in short.
 type HTTPError struct {
-	Error string `json:"Error"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ErrorResp is an error response which may contain one or more error responses
+type ErrorResp struct {
+	Errors []HTTPError `json:"errors"`
 }
 
 // ErrorCode represents API Error code Type
 type ErrorCode uint16
 
 const (
-	// ErrCodeDefault represents default error code for API responses
-	ErrCodeDefault ErrorCode = iota + 1
+	// ErrCodeGeneric represents generic error code for API responses
+	ErrCodeGeneric ErrorCode = iota
 )
+
+// ErrorCodeMap maps error code to it's textual message
+var ErrorCodeMap = map[ErrorCode]string{
+	ErrCodeGeneric: "generic error",
+}

--- a/pkg/restclient/common.go
+++ b/pkg/restclient/common.go
@@ -35,12 +35,13 @@ func New(baseURL string, username string, password string, cacert string, insecu
 }
 
 func parseHTTPError(jsonData []byte) string {
-	var errstr api.HTTPError
+	var errstr api.ErrorResp
 	err := json.Unmarshal(jsonData, &errstr)
 	if err != nil {
 		return ""
 	}
-	return errstr.Error
+	// There's only a single error most of the times
+	return errstr.Errors[0].Message
 }
 
 func getAuthToken(username string, password string) string {

--- a/plugins/bitrot/rest.go
+++ b/plugins/bitrot/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/glusterd2/xlator"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 	bitrotapi "github.com/gluster/glusterd2/plugins/bitrot/api"
 	"github.com/gorilla/mux"
@@ -29,19 +28,19 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if volume is started
 	if volinfo.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted)
 		return
 	}
 
 	// Check if bitrot is already enabled
 	if volume.IsBitrotEnabled(volinfo) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotAlreadyEnabled.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotAlreadyEnabled)
 		return
 	}
 
@@ -58,14 +57,14 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -99,7 +98,7 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volName,
 		}).Error("failed to enable bitrot")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, "Bitrot enabled successfully")
@@ -116,13 +115,13 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if bitrot is already disabled
 	if !volume.IsBitrotEnabled(volinfo) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotAlreadyDisabled.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotAlreadyDisabled)
 		return
 	}
 
@@ -137,14 +136,14 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -174,7 +173,7 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volName,
 		}).Error("failed to disable bitrot")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -192,19 +191,19 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if volume is started
 	if volinfo.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted)
 		return
 	}
 
 	// Check if bitrot is disabled
 	if !volume.IsBitrotEnabled(volinfo) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotNotEnabled.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotNotEnabled)
 		return
 	}
 
@@ -215,7 +214,7 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -236,7 +235,7 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volName,
 		}).Error("failed to start scrubber")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, "Scrubber started successfully")
@@ -254,21 +253,21 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusNotFound,
-			errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+			errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if volume is started
 	if volinfo.State != volume.VolStarted {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest,
-			errors.ErrVolNotStarted.Error(), api.ErrCodeDefault)
+			errors.ErrVolNotStarted)
 		return
 	}
 
 	// Check if bitrot is disabled
 	if !volume.IsBitrotEnabled(volinfo) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest,
-			errors.ErrBitrotNotEnabled.Error(), api.ErrCodeDefault)
+			errors.ErrBitrotNotEnabled)
 		return
 	}
 
@@ -280,7 +279,7 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 	lock, unlock, err := transaction.CreateLockSteps(volName)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError,
-			err.Error(), api.ErrCodeDefault)
+			err)
 		return
 	}
 
@@ -306,7 +305,7 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 			"volname": volName,
 		}).Error("failed to get scrubber status")
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError,
-			err.Error(), api.ErrCodeDefault)
+			err)
 		return
 	}
 
@@ -315,7 +314,7 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 		errMsg := "Failed to aggregate scrub status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("bitrotScrubStatusHandler:" + errMsg)
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError,
-			errMsg, api.ErrCodeDefault)
+			errMsg)
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, result)

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/peer"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
-	"github.com/gluster/glusterd2/pkg/api"
 	deviceapi "github.com/gluster/glusterd2/plugins/device/api"
 
 	"github.com/gorilla/mux"
@@ -22,18 +21,18 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 	req := new(deviceapi.AddDeviceReq)
 	if err := restutils.UnmarshalRequest(r, req); err != nil {
 		logger.WithError(err).Error("Failed to Unmarshal request")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Unable to marshal request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Unable to marshal request")
 		return
 	}
 	peerID := mux.Vars(r)["peerid"]
 	if peerID == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in request", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "peerid not present in request")
 		return
 	}
 	peerInfo, err := peer.GetPeer(peerID)
 	if err != nil {
 		logger.WithError(err).WithField("peerid", peerID).Error("Peer ID not found in store")
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, "Peer Id not found in store", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, "Peer Id not found in store")
 		return
 	}
 	txn := transaction.NewTxn(ctx)
@@ -51,25 +50,25 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 	err = txn.Ctx.Set("peerid", peerID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to set data for transaction")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	err = txn.Ctx.Set("req", req)
 	if err != nil {
 		logger.WithError(err).Error("Failed to set data for transaction")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	err = txn.Do()
 	if err != nil {
 		logger.WithError(err).Error("Transaction to prepare device failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Transaction to prepare device failed", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Transaction to prepare device failed")
 		return
 	}
 	peerInfo, err = peer.GetPeer(peerID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get peer from store")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Failed to get peer from store", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Failed to get peer from store")
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, peerInfo)

--- a/plugins/events/rest.go
+++ b/plugins/events/rest.go
@@ -1,11 +1,11 @@
 package events
 
 import (
-	"github.com/gluster/glusterd2/pkg/errors"
 	"net/http"
 
+	"github.com/gluster/glusterd2/pkg/errors"
+
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
-	"github.com/gluster/glusterd2/pkg/api"
 	eventsapi "github.com/gluster/glusterd2/plugins/events/api"
 )
 
@@ -20,12 +20,12 @@ func webhookAddHandler(w http.ResponseWriter, r *http.Request) {
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusUnprocessableEntity,
-			errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+			errors.ErrJSONParsingFailed)
 		return
 	}
 
 	if req.URL == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Webhook Url is required field", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Webhook Url is required field")
 		return
 	}
 
@@ -34,18 +34,18 @@ func webhookAddHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusInternalServerError,
-			"Could not check if webhook already exists", api.ErrCodeDefault)
+			"Could not check if webhook already exists")
 		return
 	}
 	if exists {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "Webhook already exists", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "Webhook already exists")
 		return
 	}
 
 	if err := addWebhook(req); err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusInternalServerError,
-			"Could not add webhook", api.ErrCodeDefault)
+			"Could not add webhook")
 		return
 	}
 
@@ -58,12 +58,12 @@ func webhookDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	var req eventsapi.Webhook
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity,
-			errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+			errors.ErrJSONParsingFailed)
 		return
 	}
 
 	if req.URL == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Webhook Url is required field", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Webhook Url is required field")
 		return
 	}
 
@@ -72,20 +72,18 @@ func webhookDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusInternalServerError,
-			"Could not check if webhook already exists",
-			api.ErrCodeDefault)
+			"Could not check if webhook already exists")
 		return
 	}
 	if !exists {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "Webhook does not exist", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "Webhook does not exist")
 		return
 	}
 
 	if err := deleteWebhook(req); err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusInternalServerError,
-			"Could not delete webhook",
-			api.ErrCodeDefault)
+			"Could not delete webhook")
 		return
 	}
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, "Webhook Deleted")
@@ -98,8 +96,7 @@ func webhookListHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		restutils.SendHTTPError(
 			ctx, w, http.StatusInternalServerError,
-			"Could not retrive webhook list",
-			api.ErrCodeDefault)
+			"Could not retrive webhook list")
 		return
 	}
 

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -13,7 +13,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 	georepapi "github.com/gluster/glusterd2/plugins/georeplication/api"
 
@@ -52,14 +51,14 @@ func validateMasterAndRemoteIDFormat(ctx context.Context, w http.ResponseWriter,
 	// Validate UUID format of Master and Remote Volume ID
 	masterid := uuid.Parse(masteridRaw)
 	if masterid == nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Master Volume ID", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Master Volume ID")
 		return nil, nil, errs.New("Invalid Master Volume ID")
 	}
 
 	// Validate UUID format of Remote Volume ID
 	remoteid := uuid.Parse(remoteidRaw)
 	if remoteid == nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Remote Volume ID", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Remote Volume ID")
 		return nil, nil, errs.New("Invalid Remote Volume ID")
 	}
 
@@ -82,43 +81,43 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if uuid.Equal(masterid, remoteid) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master and Remote Volume can't be same", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master and Remote Volume can't be same")
 		return
 	}
 
 	// Parse the JSON body to get additional details of request
 	var req georepapi.GeorepCreateReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
 	// Required fields are MasterVol, RemoteHosts and RemoteVol
 	if req.MasterVol == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master volume name is required field", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master volume name is required field")
 		return
 	}
 
 	if len(req.RemoteHosts) == 0 {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Atleast one Remote host is required", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Atleast one Remote host is required")
 		return
 	}
 
 	if req.RemoteVol == "" {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Remote volume name is required field", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Remote volume name is required field")
 		return
 	}
 
 	// Check if Master volume exists and Matches with passed Volume ID
 	vol, e := volume.GetVolume(req.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if Master Volume ID from store matches the input Master Volume ID
 	if !uuid.Equal(vol.ID, masterid) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master volume ID doesn't match", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Master volume ID doesn't match")
 		return
 	}
 
@@ -129,7 +128,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		sessionExists = true
 		if !req.Force {
-			restutils.SendHTTPError(ctx, w, http.StatusConflict, "Session already exists", api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, "Session already exists")
 			return
 		}
 	}
@@ -138,7 +137,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// error while fetching from store or JSON marshal errors
 	if err != nil {
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
 	}
@@ -160,7 +159,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -192,12 +191,12 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("geosession", geoSession); err != nil {
 		logger.WithError(err).Error("failed to set geosession in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 	if err = txn.Ctx.Set("volinfo", vol); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -208,7 +207,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to create geo-replication session")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -233,7 +232,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	// Parse the JSON body to get additional details of request
 	var req georepapi.GeorepCommandsReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -241,42 +240,42 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	geoSession, err := getSession(masterid.String(), remoteid.String())
 	if err != nil {
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found")
 		return
 	}
 
 	if action == actionStart && geoSession.Status == georepapi.GeorepStatusStarted && !req.Force {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session already started", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session already started")
 		return
 	}
 
 	if action == actionStop && geoSession.Status == georepapi.GeorepStatusStopped && !req.Force {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session already stopped", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session already stopped")
 		return
 	}
 
 	if action == actionPause && geoSession.Status != georepapi.GeorepStatusStarted && !req.Force {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session is not in started state", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session is not in started state")
 		return
 	}
 
 	if action == actionResume && geoSession.Status != georepapi.GeorepStatusPaused && !req.Force {
-		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session not in paused state", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusConflict, "session not in paused state")
 		return
 	}
 
 	// Fetch Volume details and check if Volume is in started state
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	if action == actionStart && vol.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "master volume not started", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "master volume not started")
 		return
 	}
 
@@ -285,7 +284,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -305,7 +304,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 		doFunc = "georeplication-stop.Commit"
 		stateToSet = georepapi.GeorepStatusStopped
 	default:
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Unknown action", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "Unknown action")
 		return
 	}
 
@@ -320,13 +319,13 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
 		logger.WithError(err).Error("failed to set mastervolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("remotevolid", remoteid.String()); err != nil {
 		logger.WithError(err).Error("failed to set remotevolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -337,7 +336,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to " + action.String() + " geo-replication session")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -345,7 +344,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 
 	e = addOrUpdateSession(geoSession)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -387,17 +386,17 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	geoSession, err := getSession(masterid.String(), remoteid.String())
 	if err != nil {
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found")
 		return
 	}
 
 	// Fetch Volume details and check if Volume exists
 	_, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -406,7 +405,7 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -422,13 +421,13 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
 		logger.WithError(err).Error("failed to set mastervolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("remotevolid", remoteid.String()); err != nil {
 		logger.WithError(err).Error("failed to set remotevolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -439,7 +438,7 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to delete geo-replication session")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -464,7 +463,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 	geoSession, err := getSession(masterid.String(), remoteid.String())
 	if err != nil {
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
 		restutils.SendHTTPResponse(ctx, w, http.StatusOK, []georepapi.GeorepSession{})
@@ -481,7 +480,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// Get Volume info, which is required to get the Bricks list
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -499,13 +498,13 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
 		logger.WithError(err).Error("failed to set mastervolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("remotevolid", remoteid.String()); err != nil {
 		logger.WithError(err).Error("failed to set remotevolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -518,7 +517,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to get status of geo-replication session")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -527,7 +526,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errMsg := "Failed to aggregate gsyncd status results from multiple nodes."
 		logger.WithField("error", err.Error()).Error("gsyncdStatusHandler:" + errMsg)
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, errMsg, api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, errMsg)
 		return
 	}
 
@@ -619,10 +618,10 @@ func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
 	geoSession, err := getSession(masterid.String(), remoteid.String())
 	if err != nil {
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found")
 		return
 	}
 
@@ -641,7 +640,7 @@ func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to get session configurations")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Failed to get session configurations", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Failed to get session configurations")
 		return
 	}
 
@@ -652,7 +651,7 @@ func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to parse configurations")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Failed to parse configurations", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Failed to parse configurations")
 		return
 	}
 
@@ -698,7 +697,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var req map[string]string
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -708,10 +707,10 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 		// Continue only if NotFound error, return if other errors like
 		// error while fetching from store or JSON marshal errors
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found")
 		return
 	}
 
@@ -724,7 +723,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 			configWillChange = true
 			err = checkConfig(k, v)
 			if err != nil {
-				restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Config Name/Value", api.ErrCodeDefault)
+				restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Invalid Config Name/Value")
 				return
 			}
 
@@ -734,7 +733,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -758,7 +757,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: change the lock key
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -778,25 +777,25 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
 		logger.WithError(err).Error("failed to set mastervolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("remotevolid", remoteid.String()); err != nil {
 		logger.WithError(err).Error("failed to set remotevolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("session", geoSession); err != nil {
 		logger.WithError(err).Error("failed to set geosession in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("restartRequired", restartRequired); err != nil {
 		logger.WithError(err).Error("failed to set restartrequired in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -807,7 +806,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to update geo-replication session config")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -831,7 +830,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var req []string
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -841,10 +840,10 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 		// Continue only if NotFound error, return if other errors like
 		// error while fetching from store or JSON marshal errors
 		if _, ok := err.(*ErrGeorepSessionNotFound); !ok {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 			return
 		}
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "geo-replication session not found")
 		return
 	}
 
@@ -873,7 +872,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -886,7 +885,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: change the lock key
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -906,25 +905,25 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
 		logger.WithError(err).Error("failed to set mastervolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("remotevolid", remoteid.String()); err != nil {
 		logger.WithError(err).Error("failed to set remotevolid in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("session", geoSession); err != nil {
 		logger.WithError(err).Error("failed to set geosession in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("restartRequired", restartRequired); err != nil {
 		logger.WithError(err).Error("failed to set restartrequired in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -935,7 +934,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 			"mastervolid": masterid,
 			"remotevolid": remoteid,
 		}).Error("failed to update geo-replication session config")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 
@@ -947,7 +946,7 @@ func georepStatusListHandler(w http.ResponseWriter, r *http.Request) {
 
 	sessions, err := getSessionList()
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -965,7 +964,7 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if Volume exists
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
@@ -976,7 +975,7 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -992,7 +991,7 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("volname", volname); err != nil {
 		logger.WithError(err).Error("failed to set volname in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1002,13 +1001,13 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volname,
 		}).Error("failed to generate SSH Keys")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	sshkeys, err := getSSHPublicKeys(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1029,7 +1028,7 @@ func georepSSHKeyGetHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volname,
 		}).Error("failed to get SSH public Keys")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1050,14 +1049,14 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if Volume exists
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Parse the JSON body to get additional details of request
 	var sshkeys []georepapi.GeorepSSHPublicKey
 	if err := restutils.UnmarshalRequest(r, &sshkeys); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -1068,7 +1067,7 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1084,13 +1083,13 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err = txn.Ctx.Set("sshkeys", sshkeys); err != nil {
 		logger.WithError(err).Error("failed to set sshkeys in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err = txn.Ctx.Set("user", user); err != nil {
 		logger.WithError(err).Error("failed to set user in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1100,7 +1099,7 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   e.Error(),
 			"volname": volname,
 		}).Error("failed to push SSH Keys")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, e)
 		return
 	}
 

--- a/plugins/glustershd/rest.go
+++ b/plugins/glustershd/rest.go
@@ -7,7 +7,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/gorilla/mux"
@@ -34,7 +33,7 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 	//validate volume name
 	v, err := volume.GetVolume(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 	// Store initial volinfo before changing the HealFlag
@@ -43,12 +42,12 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	// validate volume type
 	if !isVolReplicate(v.Type) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume Type not supported", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume Type not supported")
 		return
 	}
 
 	if v.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume should be in started state.", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume should be in started state.")
 		return
 
 	}
@@ -60,7 +59,7 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -87,20 +86,20 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := txn.Ctx.Set("volinfo", v); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := txn.Ctx.Set("oldvolinfo", oldvolinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	err = txn.Do()
 	if err != nil {
 		logger.WithError(err).Error("failed to start self heal daemon")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -117,7 +116,7 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 	//validate volume name
 	v, err := volume.GetVolume(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 	// Store initial volinfo before changing the HealFlag
@@ -126,7 +125,7 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 
 	// validate volume type
 	if !isVolReplicate(v.Type) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume Type not supported", api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Volume Type not supported")
 		return
 	}
 
@@ -138,7 +137,7 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 	// Lock on volume name.
 	lock, unlock, err := transaction.CreateLockSteps(volname)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -166,13 +165,13 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := txn.Ctx.Set("volinfo", v); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := txn.Ctx.Set("oldvolinfo", oldvolinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -182,7 +181,7 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 			"error":   err.Error(),
 			"volname": volname,
 		}).Error("failed to stop self heal daemon")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/plugins/quota/rest.go
+++ b/plugins/quota/rest.go
@@ -10,7 +10,6 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/glusterd2/volume"
-	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
@@ -51,19 +50,19 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 	// Validate volume existence
 	vol, err := volume.GetVolume(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusNotFound, errors.ErrVolNotFound)
 		return
 	}
 
 	// Check if volume is started
 	if vol.State != volume.VolStarted {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolNotStarted)
 		return
 	}
 
 	// Check if quota is already enabled
 	if volume.IsQuotaEnabled(vol) {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrProcessAlreadyRunning.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrProcessAlreadyRunning)
 		return
 	}
 
@@ -75,13 +74,13 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := txn.Ctx.Set("volinfo", vol); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	lock, unlock, err := transaction.CreateLockSteps(volName)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -102,9 +101,9 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.WithError(err).Error("quota enable transaction failed")
 		if err == transaction.ErrLockTimeout {
-			restutils.SendHTTPError(ctx, w, http.StatusConflict, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
-			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err.Error(), api.ErrCodeDefault)
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		}
 		return
 	}


### PR DESCRIPTION
* Remove having to specify default error code. It is made implicit
  instead. This removes some of the code clutter.
* Support returning multiple errors in a single API response.
  Although this will be rarely used, introducing the provision in API
  right now is better than later.
* Allow callers to pass both string and error types.
* Introduce a error code map which maps error codes (integers) to their
  brief textual description.

Signed-off-by: Prashanth Pai <ppai@redhat.com>