### PR TITLE
Refactor volume create and other minor fixes

### DIFF
--- a/glusterd2/commands/volumes/brickutils.go
+++ b/glusterd2/commands/volumes/brickutils.go
@@ -1,7 +1,7 @@
 package volumecommands
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/gluster/glusterd2/pkg/api"
 
@@ -9,15 +9,15 @@ import (
 )
 
 func nodesFromVolumeCreateReq(req *api.VolCreateReq) ([]uuid.UUID, error) {
-	var nodesMap = make(map[string]int)
+	var nodesMap = make(map[string]bool)
 	var nodes []uuid.UUID
 	for _, subvol := range req.Subvols {
 		for _, brick := range subvol.Bricks {
 			if _, ok := nodesMap[brick.NodeID]; !ok {
-				nodesMap[brick.NodeID] = 1
+				nodesMap[brick.NodeID] = true
 				u := uuid.Parse(brick.NodeID)
 				if u == nil {
-					return nil, errors.New("Unable to parse Node ID")
+					return nil, fmt.Errorf("Failed to parse peer ID: %s", brick.NodeID)
 				}
 				nodes = append(nodes, u)
 			}
@@ -27,14 +27,14 @@ func nodesFromVolumeCreateReq(req *api.VolCreateReq) ([]uuid.UUID, error) {
 }
 
 func nodesFromVolumeExpandReq(req *api.VolExpandReq) ([]uuid.UUID, error) {
-	var nodesMap = make(map[string]int)
+	var nodesMap = make(map[string]bool)
 	var nodes []uuid.UUID
 	for _, brick := range req.Bricks {
 		if _, ok := nodesMap[brick.NodeID]; !ok {
-			nodesMap[brick.NodeID] = 1
+			nodesMap[brick.NodeID] = true
 			u := uuid.Parse(brick.NodeID)
 			if u == nil {
-				return nil, errors.New("Unable to parse Node ID")
+				return nil, fmt.Errorf("Failed to parse peer ID: %s", brick.NodeID)
 			}
 			nodes = append(nodes, u)
 		}

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -68,7 +68,7 @@ func validateXlatorOptions(opts map[string]string, volinfo *volume.Volinfo) erro
 	return nil
 }
 
-func expandOptions(opts map[string]string) (map[string]string, error) {
+func expandGroupOptions(opts map[string]string) (map[string]string, error) {
 	resp, err := store.Store.Get(context.TODO(), "groupoptions")
 	if err != nil {
 		return nil, err

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -116,6 +116,7 @@ func notifyVolfileChange(c transaction.TxnCtx) error {
 	return nil
 }
 
+// This txn step is used in volume create and in volume expand
 func validateBricks(c transaction.TxnCtx) error {
 
 	var err error
@@ -145,6 +146,7 @@ func validateBricks(c transaction.TxnCtx) error {
 	return nil
 }
 
+// This txn step is used in volume create and in volume expand
 func initBricks(c transaction.TxnCtx) error {
 
 	var err error
@@ -190,6 +192,7 @@ func initBricks(c transaction.TxnCtx) error {
 	return nil
 }
 
+// This txn step is used in volume create and in volume expand
 func undoInitBricks(c transaction.TxnCtx) error {
 
 	var bricks []brick.Brickinfo

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -41,7 +41,7 @@ func validateOptions(opts map[string]string) error {
 		}
 
 		if err := o.Validate(v); err != nil {
-			return err
+			return fmt.Errorf("Failed to validate value(%s) for key(%s): %s", k, v, err.Error())
 		}
 		// TODO: Check op-version
 	}

--- a/glusterd2/commands/volumes/volume-create-disperse.go
+++ b/glusterd2/commands/volumes/volume-create-disperse.go
@@ -1,0 +1,68 @@
+package volumecommands
+
+import (
+	"errors"
+
+	"github.com/gluster/glusterd2/glusterd2/volume"
+	"github.com/gluster/glusterd2/pkg/api"
+)
+
+func getRedundancy(disperse uint) uint {
+	var temp, l, mask uint
+	temp = disperse
+	l = 0
+	for temp = temp >> 1; temp != 0; temp = temp >> 1 {
+		l = l + 1
+	}
+	mask = ^(1 << l)
+	if red := disperse & mask; red != 0 {
+		return red
+	}
+	return 1
+}
+
+func checkDisperseParams(req *api.SubvolReq, s *volume.Subvol) error {
+	count := len(req.Bricks)
+
+	if req.DisperseData > 0 {
+		if req.DisperseCount > 0 && req.DisperseRedundancy > 0 {
+			if req.DisperseCount != req.DisperseData+req.DisperseRedundancy {
+				return errors.New("Disperse count should be equal to sum of disperse-data and redundancy")
+			}
+		} else if req.DisperseRedundancy > 0 {
+			req.DisperseCount = req.DisperseData + req.DisperseRedundancy
+		} else if req.DisperseCount > 0 {
+			req.DisperseRedundancy = req.DisperseCount - req.DisperseData
+		} else {
+			if count-req.DisperseData >= req.DisperseData {
+				return errors.New("Need redundancy count along with disperse-data")
+			}
+			req.DisperseRedundancy = count - req.DisperseData
+			req.DisperseCount = count
+		}
+	}
+
+	if req.DisperseCount <= 0 {
+		if count < 3 {
+			return errors.New("Number of bricks must be greater than 2")
+		}
+		req.DisperseCount = count
+	}
+
+	if req.DisperseRedundancy <= 0 {
+		req.DisperseRedundancy = int(getRedundancy(uint(req.DisperseCount)))
+	}
+
+	if req.DisperseCount != count {
+		return errors.New("Disperse count and the number of bricks must be same for a pure disperse volume")
+	}
+
+	if 2*req.DisperseRedundancy >= req.DisperseCount {
+		return errors.New("Invalid redundancy value")
+	}
+
+	s.DisperseCount = req.DisperseCount
+	s.RedundancyCount = req.DisperseRedundancy
+
+	return nil
+}

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -1,0 +1,199 @@
+package volumecommands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gluster/glusterd2/glusterd2/brick"
+	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+	"github.com/gluster/glusterd2/pkg/api"
+	gderrors "github.com/gluster/glusterd2/pkg/errors"
+
+	"github.com/pborman/uuid"
+)
+
+func undoStoreVolumeOnCreate(c transaction.TxnCtx) error {
+
+	var volinfo volume.Volinfo
+	if err := c.Get("volinfo", &volinfo); err != nil {
+		c.Logger().WithError(err).WithField(
+			"key", "volinfo").Debug("Failed to get key from store")
+		return err
+	}
+
+	if err := deleteVolfiles(c); err != nil {
+		c.Logger().WithError(err).WithField(
+			"volume", volinfo.Name).Warn("Failed to delete volfiles")
+	}
+
+	if err := deleteVolume(c); err != nil {
+		c.Logger().WithError(err).WithField(
+			"volume", volinfo.Name).Warn("Failed to delete volinfo from store")
+	}
+
+	return nil
+}
+
+func voltypeFromSubvols(req *api.VolCreateReq) volume.VolType {
+	if len(req.Subvols) == 0 {
+		return volume.Distribute
+	}
+	numSubvols := len(req.Subvols)
+
+	// TODO: Don't know how to decide on Volume Type if each subvol is different
+	// For now just picking the first subvols Type, which satisfies
+	// most of today's needs
+	switch req.Subvols[0].Type {
+	case "replicate":
+		if numSubvols > 1 {
+			return volume.DistReplicate
+		}
+		return volume.Replicate
+	case "distribute":
+		return volume.Distribute
+	default:
+		return volume.Distribute
+	}
+}
+
+func populateSubvols(volinfo *volume.Volinfo, req *api.VolCreateReq) error {
+	var err error
+	for idx, subvolreq := range req.Subvols {
+		if subvolreq.ReplicaCount == 0 && subvolreq.Type == "replicate" {
+			return errors.New("Replica count not specified")
+		}
+
+		if subvolreq.ReplicaCount > 0 && subvolreq.ReplicaCount != len(subvolreq.Bricks) {
+			return errors.New("Invalid number of bricks")
+		}
+
+		name := fmt.Sprintf("%s-%s-%d", volinfo.Name, strings.ToLower(subvolreq.Type), idx)
+
+		ty := volume.SubvolDistribute
+		switch subvolreq.Type {
+		case "replicate":
+			ty = volume.SubvolReplicate
+		case "disperse":
+			ty = volume.SubvolDisperse
+		default:
+			ty = volume.SubvolDistribute
+		}
+
+		s := volume.Subvol{
+			Name: name,
+			ID:   uuid.NewRandom(),
+			Type: ty,
+		}
+
+		if subvolreq.ArbiterCount != 0 {
+			if subvolreq.ReplicaCount != 3 || subvolreq.ArbiterCount != 1 {
+				return errors.New("For arbiter configuration, replica count must be 3 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter")
+			}
+			s.ArbiterCount = 1
+		}
+
+		if subvolreq.ReplicaCount == 0 {
+			s.ReplicaCount = 1
+		} else {
+			s.ReplicaCount = subvolreq.ReplicaCount
+		}
+
+		if subvolreq.DisperseCount != 0 || subvolreq.DisperseData != 0 || subvolreq.DisperseRedundancy != 0 {
+			err = checkDisperseParams(&subvolreq, &s)
+			if err != nil {
+				return err
+			}
+		}
+		s.Bricks, err = volume.NewBrickEntriesFunc(subvolreq.Bricks, volinfo.Name, volinfo.ID)
+		if err != nil {
+			return err
+		}
+		volinfo.Subvols = append(volinfo.Subvols, s)
+	}
+
+	return nil
+}
+
+func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
+
+	volinfo := &volume.Volinfo{
+		ID:        uuid.NewRandom(),
+		Name:      req.Name,
+		State:     volume.VolCreated,
+		Type:      voltypeFromSubvols(req),
+		DistCount: len(req.Subvols),
+		Auth: volume.VolAuth{
+			Username: uuid.NewRandom().String(),
+			Password: uuid.NewRandom().String(),
+		},
+	}
+
+	if req.Options != nil {
+		volinfo.Options = req.Options
+	} else {
+		volinfo.Options = make(map[string]string)
+	}
+
+	if req.Transport != "" {
+		volinfo.Transport = req.Transport
+	} else {
+		volinfo.Transport = "tcp"
+	}
+
+	if err := populateSubvols(volinfo, req); err != nil {
+		return nil, err
+	}
+
+	return volinfo, nil
+}
+
+func createVolinfo(c transaction.TxnCtx) error {
+
+	// TODO: Reduce the number of txn.Set calls.
+
+	var req api.VolCreateReq
+	if err := c.Get("req", &req); err != nil {
+		return err
+	}
+
+	if volume.Exists(req.Name) {
+		return gderrors.ErrVolExists
+	}
+
+	volinfo, err := newVolinfo(&req)
+	if err != nil {
+		return err
+	}
+
+	if err := validateXlatorOptions(req.Options, volinfo); err != nil {
+		return err
+	}
+
+	if err := c.Set("volinfo", volinfo); err != nil {
+		return err
+	}
+
+	// TODO: Volinfo already has this info. Right now, the key "bricks"
+	// is set separately to reuse the same step function (validateBricks)
+	// later in volume expand. Consider duplicating that code if store
+	// access turns out to be expensive.
+	if err := c.Set("bricks", volinfo.GetBricks()); err != nil {
+		return err
+	}
+
+	// TODO: Expose this granularity in the volume create API.
+	var checks brick.InitChecks
+	if !req.Force {
+		checks.IsInUse = true
+		checks.IsMount = true
+		checks.IsOnRoot = true
+	}
+
+	if err := c.Set("brick-checks", &checks); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -2,11 +2,8 @@ package volumecommands
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 
-	"github.com/gluster/glusterd2/glusterd2/brick"
 	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
@@ -18,155 +15,24 @@ import (
 	"github.com/pborman/uuid"
 )
 
-func unmarshalVolCreateRequest(msg *api.VolCreateReq, r *http.Request) (int, error) {
-	if err := restutils.UnmarshalRequest(r, msg); err != nil {
-		return 422, gderrors.ErrJSONParsingFailed
+func validateVolCreateReq(req *api.VolCreateReq) error {
+
+	if req.Name == "" {
+		return gderrors.ErrEmptyVolName
 	}
 
-	if msg.Name == "" {
-		return http.StatusBadRequest, gderrors.ErrEmptyVolName
+	if req.Transport != "" && (req.Transport != "tcp" || req.Transport != "rdma") {
+		return errors.New("Invalid transport. Supported values: tcp or rdma")
 	}
 
-	if len(msg.Subvols) <= 0 {
-		return http.StatusBadRequest, gderrors.ErrEmptyBrickList
+	if len(req.Subvols) <= 0 {
+		return gderrors.ErrEmptyBrickList
 	}
 
-	for _, subvol := range msg.Subvols {
+	for _, subvol := range req.Subvols {
 		if len(subvol.Bricks) <= 0 {
-			return http.StatusBadRequest, gderrors.ErrEmptyBrickList
+			return gderrors.ErrEmptyBrickList
 		}
-	}
-	return 0, nil
-
-}
-
-func voltypeFromSubvols(req *api.VolCreateReq) volume.VolType {
-	if len(req.Subvols) == 0 {
-		return volume.Distribute
-	}
-	numSubvols := len(req.Subvols)
-
-	// TODO: Don't know how to decide on Volume Type if each subvol is different
-	// For now just picking the first subvols Type, which satisfies
-	// most of today's needs
-	switch req.Subvols[0].Type {
-	case "replicate":
-		if numSubvols > 1 {
-			return volume.DistReplicate
-		}
-		return volume.Replicate
-	case "distribute":
-		return volume.Distribute
-	default:
-		return volume.Distribute
-	}
-}
-
-func createVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
-
-	var err error
-
-	v := new(volume.Volinfo)
-	if req.Options != nil {
-		v.Options = req.Options
-	} else {
-		v.Options = make(map[string]string)
-	}
-	v.ID = uuid.NewRandom()
-	v.Name = req.Name
-
-	if len(req.Transport) > 0 {
-		v.Transport = req.Transport
-	} else {
-		v.Transport = "tcp"
-	}
-
-	v.DistCount = len(req.Subvols)
-
-	v.Type = voltypeFromSubvols(req)
-
-	for idx, subvolreq := range req.Subvols {
-		if subvolreq.ReplicaCount == 0 && subvolreq.Type == "replicate" {
-			return nil, errors.New("Replica count not specified")
-		}
-
-		if subvolreq.ReplicaCount > 0 && subvolreq.ReplicaCount != len(subvolreq.Bricks) {
-			return nil, errors.New("Invalid number of bricks")
-		}
-
-		name := fmt.Sprintf("%s-%s-%d", v.Name, strings.ToLower(subvolreq.Type), idx)
-
-		ty := volume.SubvolDistribute
-		switch subvolreq.Type {
-		case "replicate":
-			ty = volume.SubvolReplicate
-		case "disperse":
-			ty = volume.SubvolDisperse
-		default:
-			ty = volume.SubvolDistribute
-		}
-
-		s := volume.Subvol{
-			Name: name,
-			ID:   uuid.NewRandom(),
-			Type: ty,
-		}
-
-		if subvolreq.ArbiterCount != 0 {
-			if subvolreq.ReplicaCount != 3 || subvolreq.ArbiterCount != 1 {
-				return nil, errors.New("For arbiter configuration, replica count must be 3 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter")
-			}
-			s.ArbiterCount = 1
-		}
-
-		if subvolreq.ReplicaCount == 0 {
-			s.ReplicaCount = 1
-		} else {
-			s.ReplicaCount = subvolreq.ReplicaCount
-		}
-
-		if subvolreq.DisperseCount != 0 || subvolreq.DisperseData != 0 || subvolreq.DisperseRedundancy != 0 {
-			err = checkDisperseParams(&subvolreq, &s)
-			if err != nil {
-				return nil, err
-			}
-		}
-		s.Bricks, err = volume.NewBrickEntriesFunc(subvolreq.Bricks, v.Name, v.ID)
-		if err != nil {
-			return nil, err
-		}
-		v.Subvols = append(v.Subvols, s)
-
-	}
-
-	v.Auth = volume.VolAuth{
-		Username: uuid.NewRandom().String(),
-		Password: uuid.NewRandom().String(),
-	}
-
-	v.State = volume.VolCreated
-
-	return v, nil
-}
-
-// This undo is for storeVolume() used during volume create
-func undoStoreVolumeOnCreate(c transaction.TxnCtx) error {
-
-	var volinfo volume.Volinfo
-	if err := c.Get("volinfo", &volinfo); err != nil {
-		c.Logger().WithError(err).WithField(
-			"key", "volinfo").Debug("Failed to get key from store")
-		return err
-	}
-
-	if err := deleteVolfiles(c); err != nil {
-		c.Logger().WithError(err).WithField(
-			"volume", volinfo.Name).Warn("Failed to delete volfiles")
-	}
-
-	if err := deleteVolume(c); err != nil {
-		c.Logger().WithError(err).WithField(
-			"volume", volinfo.Name).Warn("Failed to delete volinfo from store")
 	}
 
 	return nil
@@ -177,6 +43,7 @@ func registerVolCreateStepFuncs() {
 		name string
 		sf   transaction.StepFunc
 	}{
+		{"vol-create.CreateVolinfo", createVolinfo},
 		{"vol-create.ValidateBricks", validateBricks},
 		{"vol-create.InitBricks", initBricks},
 		{"vol-create.UndoInitBricks", undoInitBricks},
@@ -192,36 +59,33 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
+	var err error
 
-	req := new(api.VolCreateReq)
-	httpStatus, err := unmarshalVolCreateRequest(req, r)
+	var req api.VolCreateReq
+	if err := restutils.UnmarshalRequest(r, &req); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	if err := validateVolCreateReq(&req); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	req.Options, err = expandGroupOptions(req.Options)
 	if err != nil {
-		logger.WithError(err).Error("Failed to unmarshal volume create request")
-		restutils.SendHTTPError(ctx, w, httpStatus, err)
-		return
-	}
-
-	if volume.ExistsFunc(req.Name) {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, gderrors.ErrVolExists)
-		return
-	}
-
-	nodes, err := nodesFromVolumeCreateReq(req)
-	if err != nil {
-		logger.WithError(err).Error("could not prepare node list")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
-	if req.Options, err = expandGroupOptions(req.Options); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := validateOptions(req.Options); err != nil {
-		logger.WithField("option", err.Error()).Error("invalid volume option specified")
-		msg := fmt.Sprintf("invalid volume option specified: %s", err.Error())
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, msg)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	nodes, err := nodesFromVolumeCreateReq(&req)
+	if err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -236,6 +100,10 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	txn.Steps = []*transaction.Step{
 		lock,
+		{
+			DoFunc: "vol-create.CreateVolinfo",
+			Nodes:  []uuid.UUID{gdctx.MyUUID},
+		},
 		{
 			DoFunc: "vol-create.ValidateBricks",
 			Nodes:  nodes,
@@ -253,51 +121,12 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		unlock,
 	}
 
-	vol, err := createVolinfo(req)
-	if err != nil {
-		logger.WithError(err).Error("failed to create volinfo")
+	if err := txn.Ctx.Set("req", &req); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
-	if err := validateXlatorOptions(req.Options, vol); err != nil {
-		logger.WithError(err).Error("validation failed")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, fmt.Sprintf("failed to set volume option: %s", err.Error()))
-		return
-	}
-
-	err = txn.Ctx.Set("bricks", vol.GetBricks())
-	if err != nil {
-		logger.WithError(err).WithField("key", "bricks").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
-	// TODO: Expose the granularity provided by InitChecks in the API.
-	var checks brick.InitChecks
-	if !req.Force {
-		checks.IsInUse = true
-		checks.IsMount = true
-		checks.IsOnRoot = true
-	}
-
-	err = txn.Ctx.Set("brick-checks", &checks)
-	if err != nil {
-		logger.WithError(err).WithField("key", "brick-checks").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
-	err = txn.Ctx.Set("volinfo", &vol)
-	if err != nil {
-		logger.WithError(err).WithField("key", "volinfo").Error("failed to set key in transaction context")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
-	err = txn.Do()
-	if err != nil {
-		logger.WithError(err).Error("volume create transaction failed")
+	if err := txn.Do(); err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -306,78 +135,22 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = txn.Ctx.Get("volinfo", &vol); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to get volinfo")
+	volinfo, err := volume.GetVolume(req.Name)
+	if err != nil {
+		// FIXME: If volume was created successfully in the txn above and
+		// then the store goes down by the time we reach here, what do
+		// we return to the client ?
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
-	txn.Ctx.Logger().WithField("volname", vol.Name).Info("new volume created")
-	events.Broadcast(newVolumeEvent(eventVolumeCreated, vol))
+	logger.WithField("volume-name", volinfo.Name).Info("new volume created")
+	events.Broadcast(newVolumeEvent(eventVolumeCreated, volinfo))
 
-	resp := createVolumeCreateResp(vol)
+	resp := createVolumeCreateResp(volinfo)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
 }
 
 func createVolumeCreateResp(v *volume.Volinfo) *api.VolumeCreateResp {
 	return (*api.VolumeCreateResp)(volume.CreateVolumeInfoResp(v))
-}
-
-func checkDisperseParams(req *api.SubvolReq, s *volume.Subvol) error {
-	count := len(req.Bricks)
-
-	if req.DisperseData > 0 {
-		if req.DisperseCount > 0 && req.DisperseRedundancy > 0 {
-			if req.DisperseCount != req.DisperseData+req.DisperseRedundancy {
-				return errors.New("Disperse count should be equal to sum of disperse-data and redundancy")
-			}
-		} else if req.DisperseRedundancy > 0 {
-			req.DisperseCount = req.DisperseData + req.DisperseRedundancy
-		} else if req.DisperseCount > 0 {
-			req.DisperseRedundancy = req.DisperseCount - req.DisperseData
-		} else {
-			if count-req.DisperseData >= req.DisperseData {
-				return errors.New("Need redundancy count along with disperse-data")
-			}
-			req.DisperseRedundancy = count - req.DisperseData
-			req.DisperseCount = count
-		}
-	}
-
-	if req.DisperseCount <= 0 {
-		if count < 3 {
-			return errors.New("Number of bricks must be greater than 2")
-		}
-		req.DisperseCount = count
-	}
-
-	if req.DisperseRedundancy <= 0 {
-		req.DisperseRedundancy = int(getRedundancy(uint(req.DisperseCount)))
-	}
-
-	if req.DisperseCount != count {
-		return errors.New("Disperse count and the number of bricks must be same for a pure disperse volume")
-	}
-
-	if 2*req.DisperseRedundancy >= req.DisperseCount {
-		return errors.New("Invalid redundancy value")
-	}
-
-	s.DisperseCount = req.DisperseCount
-	s.RedundancyCount = req.DisperseRedundancy
-
-	return nil
-}
-
-func getRedundancy(disperse uint) uint {
-	var temp, l, mask uint
-	temp = disperse
-	l = 0
-	for temp = temp >> 1; temp != 0; temp = temp >> 1 {
-		l = l + 1
-	}
-	mask = ^(1 << l)
-	if red := disperse & mask; red != 0 {
-		return red
-	}
-	return 1
 }

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -213,7 +213,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Options, err = expandOptions(req.Options); err != nil {
+	if req.Options, err = expandGroupOptions(req.Options); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}

--- a/glusterd2/commands/volumes/volume-create_test.go
+++ b/glusterd2/commands/volumes/volume-create_test.go
@@ -1,16 +1,13 @@
 package volumecommands
 
 import (
-	"bytes"
 	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/gluster/glusterd2/glusterd2/brick"
 	"github.com/gluster/glusterd2/glusterd2/peer"
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/api"
-	gderrors "github.com/gluster/glusterd2/pkg/errors"
 	"github.com/gluster/glusterd2/pkg/testutils"
 
 	"github.com/pborman/uuid"
@@ -21,36 +18,7 @@ var (
 	errBad = errors.New("bad")
 )
 
-//TestUnmarshalVolCreateRequest validates the JSON request of volume
-//create request
-func TestUnmarshalVolCreateRequest(t *testing.T) {
-	msg := new(api.VolCreateReq)
-	assert.NotNil(t, msg)
-
-	// Request with invalid JSON format
-	r, _ := http.NewRequest("POST", "/v1/volumes/", bytes.NewBuffer([]byte(`{"invalid_format"}`)))
-	_, e := unmarshalVolCreateRequest(msg, r)
-	assert.Equal(t, gderrors.ErrJSONParsingFailed, e)
-
-	// Request with empty volume name
-	r, _ = http.NewRequest("POST", "/v1/volumes/", bytes.NewBuffer([]byte(`{}`)))
-	_, e = unmarshalVolCreateRequest(msg, r)
-	assert.Equal(t, gderrors.ErrEmptyVolName, e)
-
-	// Request with empty bricks
-	r, _ = http.NewRequest("POST", "/v1/volumes/", bytes.NewBuffer([]byte(`{"name" : "vol"}`)))
-	_, e = unmarshalVolCreateRequest(msg, r)
-	assert.Equal(t, "vol", msg.Name)
-	assert.Equal(t, gderrors.ErrEmptyBrickList, e)
-
-	// Request with volume name & bricks
-	r, _ = http.NewRequest("POST", "/v1/volumes/", bytes.NewBuffer([]byte(`{"name" : "vol", "subvols": [{"bricks":[{"nodeid": "127.0.0.1", "path": "/tmp/b1"}]}]}`)))
-	_, e = unmarshalVolCreateRequest(msg, r)
-	assert.Nil(t, e)
-
-}
-
-// TestCreateVolinfo validates createVolinfo()
+// TestCreateVolinfo validates newVolinfo()
 func TestCreateVolinfo(t *testing.T) {
 	defer testutils.Patch(&peer.GetPeerIDByAddrF, peer.GetPeerIDByAddrMockGood).Restore()
 	defer testutils.Patch(&peer.GetPeerF, peer.GetPeerFMockGood).Restore()
@@ -62,7 +30,7 @@ func TestCreateVolinfo(t *testing.T) {
 		{NodeID: u.String(), Path: "/tmp/b1"},
 		{NodeID: u.String(), Path: "/tmp/b2"},
 	}}}
-	vol, e := createVolinfo(msg)
+	vol, e := newVolinfo(msg)
 	assert.Nil(t, e)
 	assert.NotNil(t, vol)
 
@@ -70,6 +38,6 @@ func TestCreateVolinfo(t *testing.T) {
 	defer testutils.Patch(&volume.NewBrickEntriesFunc, func(bricks []api.BrickReq, volName string, volID uuid.UUID) ([]brick.Brickinfo, error) {
 		return nil, errBad
 	}).Restore()
-	_, e = createVolinfo(msg)
+	_, e = newVolinfo(msg)
 	assert.Equal(t, errBad, e)
 }

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -48,7 +48,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var options map[string]string
-	if options, err = expandOptions(req.Options); err != nil {
+	if options, err = expandGroupOptions(req.Options); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -84,24 +84,18 @@ func (c *Tctx) WithPrefix(prefix string) *Tctx {
 // Set attaches the given key-value pair to the context.
 // If the key exists, the value will be updated.
 func (c *Tctx) Set(key string, value interface{}) error {
-	json, e := json.Marshal(value)
-	if e != nil {
-		c.log.WithFields(log.Fields{
-			"error": e,
-			"key":   key,
-		}).Error("failed to marshal value")
-		return e
+	json, err := json.Marshal(value)
+	if err != nil {
+		c.log.WithError(err).WithField("key", key).Error("failed to marshal value")
+		return err
 	}
 
 	storeKey := c.prefix + "/" + key
-	_, e = store.Store.Put(context.TODO(), storeKey, string(json))
-	if e != nil {
-		c.log.WithFields(log.Fields{
-			"error": e,
-			"key":   storeKey,
-		}).Error("failed to set value")
+	_, err = store.Store.Put(context.TODO(), storeKey, string(json))
+	if err != nil {
+		c.log.WithError(err).WithField("key", key).Error("failed to set key in transaction context")
 	}
-	return e
+	return err
 }
 
 // SetNodeResult is similar to Set but prefixes the key with the node UUID
@@ -119,7 +113,7 @@ func (c *Tctx) Get(key string, value interface{}) error {
 	storeKey := c.prefix + "/" + key
 	r, err := store.Store.Get(context.TODO(), storeKey)
 	if err != nil {
-		c.log.WithError(err).WithField("key", storeKey).Error("failed to get value from store")
+		c.log.WithError(err).WithField("key", storeKey).Error("failed to get value from transaction context")
 		return err
 	}
 

--- a/glusterd2/volume/store-utils.go
+++ b/glusterd2/volume/store-utils.go
@@ -17,8 +17,6 @@ const (
 )
 
 var (
-	//ExistsFunc check whether a given volume exist or not
-	ExistsFunc = Exists
 	// AddOrUpdateVolumeFunc marshals to volume object and passes to store to add/update
 	AddOrUpdateVolumeFunc = AddOrUpdateVolume
 )


### PR DESCRIPTION
* Move disperse related code and txn code to its own files.
* Move volume create validation and volinfo creation into a step func
  which will be executed under lock. Updated issue #510 
* Slightly simplify validation of incoming request.
* Log failures inside txn.Get and txn.Set
* Include more info in errors returned at some places