### PR TITLE
Default rundir to /var/run/gluster

### DIFF
--- a/e2e/config/1.toml
+++ b/e2e/config/1.toml
@@ -1,4 +1,5 @@
 workdir = "/tmp/gd2_func_test/w1"
+rundir = "/tmp/gd2_func_test/w1/run/gluster"
 logfile = "w1.log"
 peeraddress = "127.0.0.1:24008"
 clientaddress = "127.0.0.1:24007"

--- a/e2e/config/2.toml
+++ b/e2e/config/2.toml
@@ -1,4 +1,5 @@
 workdir = "/tmp/gd2_func_test/w2"
+rundir = "/tmp/gd2_func_test/w2/run/gluster"
 logfile = "w2.log"
 peeraddress = "127.0.0.1:23008"
 clientaddress = "127.0.0.1:23007"

--- a/e2e/config/3.toml
+++ b/e2e/config/3.toml
@@ -1,4 +1,5 @@
 workdir = "/tmp/gd2_func_test/w3"
+rundir = "/tmp/gd2_func_test/w3/run/gluster"
 logfile = "w3.log"
 peeraddress = "127.0.0.1:22008"
 clientaddress = "127.0.0.1:22007"

--- a/e2e/config/4.toml
+++ b/e2e/config/4.toml
@@ -1,4 +1,5 @@
 workdir = "/tmp/gd2_func_test/w4"
+rundir = "/tmp/gd2_func_test/w4/run/gluster"
 logfile = "w4.log"
 peeraddress = "127.0.0.1:21008"
 clientaddress = "127.0.0.1:21007"

--- a/glusterd2/brick/glusterfsd.go
+++ b/glusterd2/brick/glusterfsd.go
@@ -98,7 +98,7 @@ func (b *Glusterfsd) SocketFile() string {
 
 	// Then xxhash of the above path shall be the name of socket file.
 	// Example: /var/run/gluster/<xxhash-hash>.socket
-	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
+	glusterdSockDir := config.GetString("rundir")
 	b.socketfilepath = fmt.Sprintf("%s/%x.socket", glusterdSockDir, xxhash.Sum64String(fakeSockFilePath))
 
 	return b.socketfilepath
@@ -111,11 +111,10 @@ func (b *Glusterfsd) PidFile() string {
 		return b.pidfilepath
 	}
 
-	rundir := config.GetString("rundir")
 	brickPathWithoutSlashes := strings.Trim(strings.Replace(b.brickinfo.Path, "/", "-", -1), "-")
 	// FIXME: The brick can no longer clean this up on clean shut down
 	pidfilename := fmt.Sprintf("%s-%s.pid", b.brickinfo.NodeID.String(), brickPathWithoutSlashes)
-	b.pidfilepath = path.Join(rundir, "gluster", pidfilename)
+	b.pidfilepath = path.Join(config.GetString("rundir"), pidfilename)
 
 	return b.pidfilepath
 }

--- a/glusterd2/config.go
+++ b/glusterd2/config.go
@@ -26,8 +26,8 @@ const (
 	defaultLogLevel      = "debug"
 	defaultClientAddress = ":24007"
 	defaultPeerAddress   = ":24008"
-
-	defaultConfName = "glusterd2"
+	defaultConfName      = "glusterd2"
+	defaultRunDir        = "/var/run/gluster"
 )
 
 // Slices,Arrays cannot be constants :(
@@ -43,7 +43,7 @@ var (
 func parseFlags() {
 	flag.String("workdir", "", "Working directory for GlusterD. (default: current directory)")
 	flag.String("localstatedir", "", "Directory to store local state information. (default: workdir)")
-	flag.String("rundir", "", "Directory to store runtime data. (default: workdir/run)")
+	flag.String("rundir", defaultRunDir, "Directory to store runtime data.")
 	flag.String("config", "", "Configuration file for GlusterD. By default looks for glusterd2.toml in [/usr/local]/etc/glusterd2 and current working directory.")
 
 	flag.String(logging.DirFlag, "", logging.DirHelp+" (default: workdir/log)")
@@ -81,10 +81,6 @@ func setDefaults() error {
 
 	if config.GetString("localstatedir") == "" {
 		config.SetDefault("localstatedir", wd)
-	}
-
-	if config.GetString("rundir") == "" {
-		config.SetDefault("rundir", path.Join(config.GetString("localstatedir"), "run"))
 	}
 
 	if config.GetString(logging.DirFlag) == "" {

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -159,7 +159,6 @@ func initGD2Supervisor() *suture.Supervisor {
 func createDirectories() error {
 	dirs := []string{config.GetString("localstatedir"),
 		config.GetString("rundir"), config.GetString("logdir"),
-		path.Join(config.GetString("rundir"), "gluster"),
 		path.Join(config.GetString("logdir"), "glusterfs/bricks"),
 		"/var/run/gluster", // issue #476
 	}

--- a/plugins/bitrot/bitd.go
+++ b/plugins/bitrot/bitd.go
@@ -48,7 +48,7 @@ func (b *Bitd) SocketFile() string {
 		return b.socketfilepath
 	}
 
-	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
+	glusterdSockDir := config.GetString("rundir")
 	b.socketfilepath = fmt.Sprintf("%s/bitd-%x.socket", glusterdSockDir, xxhash.Sum64String(gdctx.MyUUID.String()))
 
 	return b.socketfilepath

--- a/plugins/bitrot/scrubd.go
+++ b/plugins/bitrot/scrubd.go
@@ -48,7 +48,7 @@ func (s *Scrubd) SocketFile() string {
 		return s.socketfilepath
 	}
 
-	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
+	glusterdSockDir := config.GetString("rundir")
 	s.socketfilepath = fmt.Sprintf("%s/scrub-%x.socket", glusterdSockDir, xxhash.Sum64String(gdctx.MyUUID.String()))
 
 	return s.socketfilepath

--- a/plugins/georeplication/gsyncd.go
+++ b/plugins/georeplication/gsyncd.go
@@ -78,9 +78,8 @@ func (g *Gsyncd) PidFile() string {
 		return g.pidfilepath
 	}
 
-	rundir := config.GetString("rundir")
 	pidfilename := fmt.Sprintf("gsyncd-%s-%s-%s.pid", g.sessioninfo.MasterVol, g.sessioninfo.RemoteHosts[0].Hostname, g.sessioninfo.RemoteVol)
-	g.pidfilepath = path.Join(rundir, "gluster", pidfilename)
+	g.pidfilepath = path.Join(config.GetString("rundir"), pidfilename)
 	return g.pidfilepath
 }
 

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -147,7 +147,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 		geoSession = newGeorepSession(masterid, remoteid, req)
 
 		// Set Required Geo-rep Configurations
-		geoSession.Options["gluster-rundir"] = path.Join(config.GetString("rundir"), "gluster")
+		geoSession.Options["gluster-rundir"] = config.GetString("rundir")
 		geoSession.Options["glusterd-workdir"] = config.GetString("localstatedir")
 		geoSession.Options["gluster-logdir"] = path.Join(config.GetString("logdir"), "glusterfs")
 	}

--- a/plugins/glustershd/glustershd.go
+++ b/plugins/glustershd/glustershd.go
@@ -45,7 +45,7 @@ func (shd *Glustershd) Args() string {
 	volFileID := "gluster/glustershd"
 
 	logFile := path.Join(config.GetString("logdir"), "glusterfs", "glustershd.log")
-	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
+	glusterdSockDir := config.GetString("rundir")
 	socketfilepath := fmt.Sprintf("%s/%x.socket", glusterdSockDir, xxhash.Sum64String(gdctx.MyUUID.String()))
 
 	var buffer bytes.Buffer
@@ -72,8 +72,7 @@ func (shd *Glustershd) PidFile() string {
 		return shd.pidfilepath
 	}
 
-	rundir := config.GetString("rundir")
-	shd.pidfilepath = path.Join(rundir, "gluster", "glustershd.pid")
+	shd.pidfilepath = path.Join(config.GetString("rundir"), "glustershd.pid")
 
 	return shd.pidfilepath
 }

--- a/plugins/quota/quotad.go
+++ b/plugins/quota/quotad.go
@@ -71,7 +71,7 @@ func (q *Quotad) SocketFile() string {
 		return q.socketfilepath
 	}
 
-	glusterdSockDir := path.Join(config.GetString("rundir"), "gluster")
+	glusterdSockDir := config.GetString("rundir")
 	q.socketfilepath = fmt.Sprintf("%s/quotad-%x.socket", glusterdSockDir,
 		xxhash.Sum64String(gdctx.MyUUID.String()))
 
@@ -90,9 +90,7 @@ func NewQuotad() (*Quotad, error) {
 		return nil, e
 	}
 	pidfilepath := path.Join(
-		config.GetString("rundir"),
-		"quotad", "quotad.pid",
-	)
+		config.GetString("rundir"), "quotad.pid")
 	logfilepath := path.Join(
 		config.GetString("logdir"), "glusterfs",
 		"quotad", "quotad.log",


### PR DESCRIPTION
...except for the tests.

Rundir should be in a place like /var/run which doesn't persist across
reboots. Further some socket files and pid files were in '/var/run' and
few others in '/var/run/gluster'. With this change, everything goes into
the same rundir.

See this bug and fix for some historical context:
https://bugzilla.redhat.com/show_bug.cgi?id=1258561

Reference:
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

Signed-off-by: Prashanth Pai <ppai@redhat.com>