### PR TITLE
re-initialize logging after parsing config file

### DIFF
--- a/glusterd2/config.go
+++ b/glusterd2/config.go
@@ -123,6 +123,7 @@ func (v valueType) String() string {
 }
 
 func dumpConfigToLog() {
+	log.WithField("file", config.ConfigFileUsed()).Info("loaded configuration from file")
 	l := log.NewEntry(log.StandardLogger())
 
 	for k, v := range config.AllSettings() {
@@ -162,8 +163,6 @@ func initConfig(confFile string) error {
 				"failed to read given config file")
 			return err
 		}
-	} else {
-		log.WithField("file", config.ConfigFileUsed()).Info("loaded configuration from file")
 	}
 
 	// Use config given by flags
@@ -174,6 +173,5 @@ func initConfig(confFile string) error {
 		return err
 	}
 
-	dumpConfigToLog()
 	return nil
 }

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -50,16 +50,28 @@ func main() {
 		log.WithError(err).Fatal("Failed to initialize logging")
 	}
 
-	log.WithFields(log.Fields{
-		"pid":     os.Getpid(),
-		"version": version.GlusterdVersion,
-	}).Debug("Starting GlusterD")
-
 	// Read config file
 	confFile, _ := flag.CommandLine.GetString("config")
 	if err := initConfig(confFile); err != nil {
 		log.WithError(err).Fatal("Failed to initialize config")
 	}
+
+	logLevel2 := config.GetString("loglevel")
+	logdir2 := config.GetString("logdir")
+	logFileName2 := config.GetString("logfile")
+
+	if logLevel != logLevel2 || logdir != logdir2 || logFileName != logFileName2 {
+		if err := logging.Init(logdir2, logFileName2, logLevel2, true); err != nil {
+			log.WithError(err).Fatal("Failed to re-initialize logging")
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"pid":     os.Getpid(),
+		"version": version.GlusterdVersion,
+	}).Debug("Starting GlusterD")
+
+	dumpConfigToLog()
 
 	workdir := config.GetString("workdir")
 	if err := os.Chdir(workdir); err != nil {
@@ -141,9 +153,9 @@ func main() {
 		case unix.SIGHUP:
 			// Logrotate case, when Log rotated, Reopen the log file and
 			// re-initiate the logger instance.
-			if strings.ToLower(logFileName) != "stderr" && strings.ToLower(logFileName) != "stdout" && logFileName != "-" {
+			if strings.ToLower(logFileName2) != "stderr" && strings.ToLower(logFileName2) != "stdout" && logFileName2 != "-" {
 				log.Info("Received SIGHUP, Reloading log file")
-				if err := logging.Init(logdir, logFileName, logLevel, true); err != nil {
+				if err := logging.Init(logdir2, logFileName2, logLevel2, true); err != nil {
 					log.WithError(err).Fatal("Could not re-initialize logging")
 				}
 			}


### PR DESCRIPTION
Based on Kaushal's comment
https://github.com/gluster/glusterd2/issues/586#issuecomment-372268063
logging is reinitialized if it is different than command line arguments.

Fixes: #586
Signed-off-by: Aravinda VK <avishwan@redhat.com>