### PR TITLE
Using PeerID instead of NodeID

### DIFF
--- a/e2e/georep_test.go
+++ b/e2e/georep_test.go
@@ -68,7 +68,7 @@ func TestGeorepCreateDelete(t *testing.T) {
 		MasterVol: volname1,
 		RemoteVol: volname2,
 		RemoteHosts: []georepapi.GeorepRemoteHostReq{
-			{NodeID: gds[1].PeerID(), Hostname: gds[1].PeerAddress},
+			{PeerID: gds[1].PeerID(), Hostname: gds[1].PeerAddress},
 		},
 	}
 

--- a/glustercli/cmd/georep.go
+++ b/glustercli/cmd/georep.go
@@ -140,7 +140,7 @@ func getVolumeDetails(volname string, rclient *restclient.Client) (*volumeDetail
 			for _, brick := range subvol.Bricks {
 				if _, ok := nodes[brick.PeerID.String()]; !ok {
 					nodes[brick.PeerID.String()] = true
-					nodesdata = append(nodesdata, georepapi.GeorepRemoteHostReq{NodeID: brick.PeerID.String(), Hostname: brick.Hostname})
+					nodesdata = append(nodesdata, georepapi.GeorepRemoteHostReq{PeerID: brick.PeerID.String(), Hostname: brick.Hostname})
 				}
 			}
 		}

--- a/plugins/georeplication/api/req.go
+++ b/plugins/georeplication/api/req.go
@@ -2,7 +2,7 @@ package georeplication
 
 // GeorepRemoteHostReq represents Remote host ID and IP/Hostname
 type GeorepRemoteHostReq struct {
-	NodeID   string `json:"nodeid"`
+	PeerID   string `json:"peerid"`
 	Hostname string `json:"host"`
 }
 

--- a/plugins/georeplication/api/resp.go
+++ b/plugins/georeplication/api/resp.go
@@ -35,14 +35,14 @@ const (
 
 // GeorepRemoteHost represents Remote host UUID and Hostname
 type GeorepRemoteHost struct {
-	NodeID   uuid.UUID `json:"nodeid"`
+	PeerID   uuid.UUID `json:"nodeid"`
 	Hostname string    `json:"host"`
 }
 
 // GeorepWorker represents Geo-replication Worker
 type GeorepWorker struct {
 	MasterNode                 string `json:"master_node"`
-	MasterNodeID               string `json:"node_id"`
+	MasterPeerID               string `json:"peer_id"`
 	MasterBrickPath            string `json:"master_brick_path"`
 	MasterBrick                string `json:"master_brick"`
 	Status                     string `json:"worker_status"`
@@ -64,7 +64,7 @@ type GeorepWorker struct {
 
 // GeorepSSHPublicKey represents one nodes SSH Public key
 type GeorepSSHPublicKey struct {
-	NodeID    uuid.UUID `json:"nodeid"`
+	PeerID    uuid.UUID `json:"nodeid"`
 	GsyncdKey string    `json:"gsyncd"`
 	TarKey    string    `json:"tar"`
 }

--- a/plugins/georeplication/events.go
+++ b/plugins/georeplication/events.go
@@ -29,7 +29,7 @@ func newGeorepEvent(e georepEvent, session *georepapi.GeorepSession, extra *map[
 			"remote.name":   session.RemoteVol,
 			"remote.id":     session.RemoteID.String(),
 			"remote.host":   session.RemoteHosts[0].Hostname,
-			"remote.peerid": session.RemoteHosts[0].NodeID.String(),
+			"remote.peerid": session.RemoteHosts[0].PeerID.String(),
 			"remote.user":   session.RemoteUser,
 		}
 	}

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -32,7 +32,7 @@ func newGeorepSession(mastervolid uuid.UUID, remotevolid uuid.UUID, req georepap
 	}
 	remotehosts := make([]georepapi.GeorepRemoteHost, len(req.RemoteHosts))
 	for idx, s := range req.RemoteHosts {
-		remotehosts[idx].NodeID = uuid.Parse(s.NodeID)
+		remotehosts[idx].PeerID = uuid.Parse(s.PeerID)
 		remotehosts[idx].Hostname = s.Hostname
 	}
 
@@ -547,7 +547,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 		// status not available these default values will be sent back in response
 		geoSession.Workers = append(geoSession.Workers, georepapi.GeorepWorker{
 			MasterNode:                 b.Hostname,
-			MasterNodeID:               b.PeerID.String(),
+			MasterPeerID:               b.PeerID.String(),
 			MasterBrickPath:            b.Path,
 			MasterBrick:                b.PeerID.String() + ":" + b.Path,
 			Status:                     "Unknown",
@@ -572,7 +572,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 	// assignment. So that order of the workers will be maintained similar
 	// to order of bricks in Master Volume
 	for idx, w := range geoSession.Workers {
-		statusData := (*result)[w.MasterNodeID+":"+w.MasterBrickPath]
+		statusData := (*result)[w.MasterPeerID+":"+w.MasterBrickPath]
 		geoSession.Workers[idx].Status = statusData.Status
 		geoSession.Workers[idx].LastSyncedTime = statusData.LastSyncedTime
 		geoSession.Workers[idx].LastSyncedTimeUTC = statusData.LastSyncedTimeUTC

--- a/plugins/georeplication/store-utils.go
+++ b/plugins/georeplication/store-utils.go
@@ -98,7 +98,7 @@ func addOrUpdateSSHKey(volname string, sshkey georepapi.GeorepSSHPublicKey) erro
 		return e
 	}
 
-	_, e = store.Store.Put(context.TODO(), georepSSHKeysPrefix+volname+"/"+sshkey.NodeID.String(), string(json))
+	_, e = store.Store.Put(context.TODO(), georepSSHKeysPrefix+volname+"/"+sshkey.PeerID.String(), string(json))
 	if e != nil {
 		log.WithError(e).Error("Couldn't add SSH public key to Store")
 		return e

--- a/plugins/georeplication/transactions.go
+++ b/plugins/georeplication/transactions.go
@@ -257,7 +257,7 @@ func configFileGenerate(session *georepapi.GeorepSession) error {
 	// Remote host and UUID details
 	var remote []string
 	for _, sh := range session.RemoteHosts {
-		remote = append(remote, sh.NodeID.String()+":"+sh.Hostname)
+		remote = append(remote, sh.PeerID.String()+":"+sh.Hostname)
 	}
 	confdata = append(confdata,
 		fmt.Sprintf("slave-bricks=%s", strings.Join(remote, ",")),
@@ -367,7 +367,7 @@ func txnSSHKeysGenerate(c transaction.TxnCtx) error {
 		return err
 	}
 
-	sshkey := georepapi.GeorepSSHPublicKey{NodeID: gdctx.MyUUID}
+	sshkey := georepapi.GeorepSSHPublicKey{PeerID: gdctx.MyUUID}
 
 	// Generate secret.pem file if not available
 	if _, err := os.Stat(secretPemFile); os.IsNotExist(err) {


### PR DESCRIPTION
Made changes for GeorepRemoteHostReq, GeorepRemoteHost, GeorepWorker, GeorepSSHPublicKey