### PR TITLE
Error in Volume Status CLI Command Output.

### DIFF
--- a/glusterd2/commands/volumes/bricks-status.go
+++ b/glusterd2/commands/volumes/bricks-status.go
@@ -110,9 +110,9 @@ func volumeBricksStatusHandler(w http.ResponseWriter, r *http.Request) {
 func createBricksStatusResp(ctx transaction.TxnCtx, vol *volume.Volinfo) (*api.BricksStatusResp, error) {
 
 	// bmap is a map of brick statuses keyed by brick ID
-	bmap := make(map[string]*api.BrickStatus)
+	bmap := make(map[string]api.BrickStatus)
 	for _, b := range vol.GetBricks() {
-		bmap[b.ID.String()] = &api.BrickStatus{
+		bmap[b.ID.String()] = api.BrickStatus{
 			Info: brick.CreateBrickInfo(&b),
 		}
 	}
@@ -128,12 +128,12 @@ func createBricksStatusResp(ctx transaction.TxnCtx, vol *volume.Volinfo) (*api.B
 			continue
 		}
 		for _, b := range tmp {
-			bmap[b.Info.ID.String()] = &b
+			bmap[b.Info.ID.String()] = b
 		}
 	}
 
 	for _, v := range bmap {
-		resp = append(resp, *v)
+		resp = append(resp, v)
 	}
 
 	return &resp, nil


### PR DESCRIPTION
Currently there is an issue with the output of volume status CLI command.

Steps To Reproduce :- 
1- Create a volume using volume create API or CLI command
2- Start the volume using API or CLI
3- Run the command "glustercli volume status <volname>"

Lets say the above created volume has 2 bricks "/brickpath1/brick1" and "/brickpath2/brick2" 
Then the volume status command should display output in form of a table with bricks column as follows 

Expected Output - 

PATH
/brickpath1/brick1
/brickpath2/brick2

But currently the  Output is as follows -

PATH
/brickpath2/brick2
/brickpath2/brick2

This PR resolves the above issue.

Signed-off-by: Vishal Pandey <vpandey@redhat.com>