### PR TITLE
Intelligent Volume Provisioning

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -33,6 +33,9 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	// Cleanup leftover devices from previous test runs
+	loopDevicesCleanup(nil)
+
 	// Cleanup leftovers from previous test runs. But don't cleanup after.
 	os.RemoveAll(baseWorkdir)
 

--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -1,0 +1,258 @@
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"syscall"
+	"testing"
+
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func brickSizeTest(brickpath string, min uint64, max uint64) error {
+	var fstat syscall.Statfs_t
+	if err := syscall.Statfs(brickpath, &fstat); err != nil {
+		return fmt.Errorf("Unable to get size info of Brick(%s) %v", brickpath, err)
+	}
+
+	if &fstat != nil {
+		value := uint64((fstat.Blocks * uint64(fstat.Bsize)) / (1024 * 1024))
+		if value < min || value > max {
+			return fmt.Errorf("Brick(%s) size mismatch, Expected: %d-%d, got: %d", brickpath, min, max, value)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("Unable to get size info of Brick(%s)", brickpath)
+}
+
+func testSmartVolumeDistribute(t *testing.T) {
+	r := require.New(t)
+	smartvolname := "sv1"
+	// create Distribute 3 Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:            smartvolname,
+		Size:            60,
+		DistributeCount: 3,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 3)
+	r.Equal("Distribute", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 1)
+	r.Len(volinfo.Subvols[1].Bricks, 1)
+	r.Len(volinfo.Subvols[2].Bricks, 1)
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[2].Bricks[0].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeReplicate2(t *testing.T) {
+	r := require.New(t)
+	smartvolname := "sv2"
+	// create Replica 2 Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:         smartvolname,
+		Size:         20,
+		ReplicaCount: 2,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 1)
+	r.Equal("Replicate", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 2)
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeReplicate3(t *testing.T) {
+	r := require.New(t)
+
+	smartvolname := "sv3"
+	// create Replica 3 Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:         smartvolname,
+		Size:         20,
+		ReplicaCount: 3,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 1)
+	r.Equal("Replicate", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 3)
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeArbiter(t *testing.T) {
+	r := require.New(t)
+
+	smartvolname := "sv4"
+	// create Replica 3 Arbiter Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:         smartvolname,
+		Size:         20,
+		ReplicaCount: 3,
+		ArbiterCount: 1,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 1)
+	r.Equal("Replicate", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 3)
+	r.Equal("Arbiter", volinfo.Subvols[0].Bricks[2].Type.String())
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+
+	// TODO: Change this after arbiter calculation fix
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeDisperse(t *testing.T) {
+	r := require.New(t)
+
+	smartvolname := "sv5"
+
+	// create Disperse Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:          smartvolname,
+		Size:          40,
+		DisperseCount: 3,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 1)
+	r.Equal("Disperse", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 3)
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeDistributeReplicate(t *testing.T) {
+	r := require.New(t)
+
+	smartvolname := "sv6"
+
+	// create Distribute Replicate(2x3) Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:               smartvolname,
+		Size:               40,
+		DistributeCount:    2,
+		ReplicaCount:       3,
+		SubvolZonesOverlap: true,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 2)
+	r.Equal("Distributed-Replicate", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 3)
+	r.Len(volinfo.Subvols[1].Bricks, 3)
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[2].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+func testSmartVolumeDistributeDisperse(t *testing.T) {
+	r := require.New(t)
+
+	smartvolname := "sv7"
+
+	// create Distribute Disperse(2x3) Volume
+	createReq := smartvolapi.VolCreateReq{
+		Name:               smartvolname,
+		Size:               80,
+		DistributeCount:    2,
+		DisperseCount:      3,
+		SubvolZonesOverlap: true,
+	}
+	volinfo, err := client.SmartVolumeCreate(createReq)
+	r.Nil(err)
+
+	r.Len(volinfo.Subvols, 2)
+	r.Equal("Distributed-Disperse", volinfo.Type.String())
+	r.Len(volinfo.Subvols[0].Bricks, 3)
+	r.Len(volinfo.Subvols[1].Bricks, 3)
+
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[0].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[1].Path, 16, 21))
+	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[2].Path, 16, 21))
+
+	r.Nil(client.VolumeDelete(smartvolname))
+}
+
+// TestSmartVolume creates a volume and starts it, runs further tests on it and
+// finally deletes the volume
+func TestSmartVolume(t *testing.T) {
+	var err error
+
+	r := require.New(t)
+
+	gds, err = setupCluster("./config/1.toml", "./config/2.toml", "./config/3.toml")
+	r.Nil(err)
+	defer teardownCluster(gds)
+
+	client = initRestclient(gds[0].ClientAddress)
+
+	tmpDir, err = ioutil.TempDir("", t.Name())
+	r.Nil(err)
+	t.Logf("Using temp dir: %s", tmpDir)
+
+	// Device Setup
+	// Around 150MB will be reserved during pv/vg creation, create device with more size
+	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev1.img", "1", "400M"))
+	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev2.img", "2", "400M"))
+	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev3.img", "3", "400M"))
+
+	_, err = client.DeviceAdd(gds[0].PeerID(), "/dev/gluster_loop1")
+	r.Nil(err)
+
+	_, err = client.DeviceAdd(gds[1].PeerID(), "/dev/gluster_loop2")
+	r.Nil(err)
+
+	_, err = client.DeviceAdd(gds[2].PeerID(), "/dev/gluster_loop3")
+	r.Nil(err)
+
+	t.Run("Smartvol Distributed Volume", testSmartVolumeDistribute)
+	t.Run("Smartvol Replicate 2 Volume", testSmartVolumeReplicate2)
+	t.Run("Smartvol Replicate 3 Volume", testSmartVolumeReplicate3)
+	t.Run("Smartvol Arbiter Volume", testSmartVolumeArbiter)
+	t.Run("Smartvol Disperse Volume", testSmartVolumeDisperse)
+	t.Run("Smartvol Distributed-Replicate Volume", testSmartVolumeDistributeReplicate)
+	t.Run("Smartvol Distributed-Disperse Volume", testSmartVolumeDistributeDisperse)
+
+	// // Device Cleanup
+	r.Nil(loopDevicesCleanup(t))
+}

--- a/glustercli/cmd/utils.go
+++ b/glustercli/cmd/utils.go
@@ -1,8 +1,49 @@
 package cmd
 
+import (
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+var (
+	validSizeFormat = regexp.MustCompile(`^([0-9]+)([GMKT])?$`)
+)
+
 func formatBoolYesNo(value bool) string {
 	if value == true {
 		return "yes"
 	}
 	return "no"
+}
+
+func sizeToMb(value string) (uint64, error) {
+	sizeParts := validSizeFormat.FindStringSubmatch(value)
+	if len(sizeParts) == 0 {
+		return 0, errors.New("Invalid size format")
+	}
+
+	// If Size unit is specified as M/K/G/T, Default Size unit is M
+	sizeUnit := "M"
+	if len(sizeParts) == 3 {
+		sizeUnit = sizeParts[2]
+	}
+
+	sizeValue, err := strconv.ParseUint(sizeParts[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	var size uint64
+	switch sizeUnit {
+	case "K":
+		size = sizeValue / 1024
+	case "G":
+		size = sizeValue * 1024
+	case "T":
+		size = sizeValue * 1024 * 1024
+	default:
+		size = sizeValue
+	}
+	return size, nil
 }

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"path/filepath"
-	"regexp"
 
 	"github.com/gluster/glusterd2/glusterd2/events"
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
@@ -17,19 +16,12 @@ import (
 	"github.com/pborman/uuid"
 )
 
-var (
-	reg = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
-)
-
 const (
 	maxMetadataSizeLimit = 4096
 )
 
 func validateVolCreateReq(req *api.VolCreateReq) error {
-
-	valid := reg.MatchString(req.Name)
-
-	if !valid {
+	if !volume.IsValidName(req.Name) {
 		return gderrors.ErrInvalidVolName
 	}
 

--- a/glusterd2/plugin/plugins.go
+++ b/glusterd2/plugin/plugins.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gluster/glusterd2/plugins/glustershd"
 	"github.com/gluster/glusterd2/plugins/quota"
 	"github.com/gluster/glusterd2/plugins/rebalance"
+	"github.com/gluster/glusterd2/plugins/smartvol"
 
 	// ensure init() of non-plugins also gets executed
 	_ "github.com/gluster/glusterd2/plugins/afr"
@@ -25,4 +26,5 @@ var PluginsList = []GlusterdPlugin{
 	&glustershd.Plugin{},
 	&device.Plugin{},
 	&rebalance.Plugin{},
+	&smartvol.Plugin{},
 }

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"syscall"
 
@@ -16,6 +17,15 @@ import (
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
+
+var (
+	volumeNameRE = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+)
+
+// IsValidName validates Volume name
+func IsValidName(name string) bool {
+	return volumeNameRE.MatchString(name)
+}
 
 // GetRedundancy calculates redundancy count based on disperse count
 func GetRedundancy(disperse uint) int {

--- a/pkg/api/bricktype.go
+++ b/pkg/api/bricktype.go
@@ -10,3 +10,14 @@ const (
 	// Arbiter represents Arbiter brick type
 	Arbiter
 )
+
+func (t BrickType) String() string {
+	switch t {
+	case Brick:
+		return "Brick"
+	case Arbiter:
+		return "Arbiter"
+	default:
+		return "invalid BrickType"
+	}
+}

--- a/pkg/restclient/volume.go
+++ b/pkg/restclient/volume.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/gluster/glusterd2/pkg/api"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
 )
 
 // metadataFilter is a filter type
@@ -18,6 +19,13 @@ const (
 	onlyValue
 	keyAndValue
 )
+
+// SmartVolumeCreate creates Gluster Volume based on given size
+func (c *Client) SmartVolumeCreate(req smartvolapi.VolCreateReq) (api.VolumeCreateResp, error) {
+	var vol api.VolumeCreateResp
+	err := c.post("/v1/smartvol", req, http.StatusCreated, &vol)
+	return vol, err
+}
 
 // VolumeCreate creates Gluster Volume
 func (c *Client) VolumeCreate(req api.VolCreateReq) (api.VolumeCreateResp, error) {

--- a/plugins/device/transaction.go
+++ b/plugins/device/transaction.go
@@ -50,6 +50,7 @@ func txnPrepareDevice(c transaction.TxnCtx) error {
 		AvailableSize: availableSize,
 		ExtentSize:    extentSize,
 		PeerID:        peerID,
+		VgName:        vgName,
 	}
 
 	err = deviceutils.AddDevice(deviceInfo)

--- a/plugins/smartvol/api/req_resp.go
+++ b/plugins/smartvol/api/req_resp.go
@@ -1,0 +1,71 @@
+package api
+
+// VolCreateReq represents a Volume Create Request
+type VolCreateReq struct {
+	Name                    string   `json:"name"`
+	Transport               string   `json:"transport,omitempty"`
+	Force                   bool     `json:"force,omitempty"`
+	Size                    uint64   `json:"size"`
+	DistributeCount         int      `json:"distribute"`
+	ReplicaCount            int      `json:"replica"`
+	ArbiterCount            int      `json:"arbiter"`
+	DisperseCount           int      `json:"disperse"`
+	DisperseRedundancyCount int      `json:"disperse-redundancy"`
+	DisperseDataCount       int      `json:"disperse-data"`
+	SnapshotEnabled         bool     `json:"snapshot"`
+	SnapshotReserveFactor   float64  `json:"snapshot-reserve-factor"`
+	LimitPeers              []string `json:"limit-peers"`
+	LimitZones              []string `json:"limit-zones"`
+	ExcludePeers            []string `json:"exclude-peers"`
+	ExcludeZones            []string `json:"exclude-zones"`
+	SubvolZonesOverlap      bool     `json:"subvolume-zones-overlap"`
+}
+
+// Brick represents Brick Request
+type Brick struct {
+	Type           string `json:"type"`
+	PeerID         string `json:"peerid"`
+	Path           string `json:"path"`
+	TpMetadataSize uint64 `json:"metadata-size"`
+	TpSize         uint64 `json:"thinkpool-size"`
+	VgName         string `json:"vg-name"`
+	TpName         string `json:"thinpool-name"`
+	LvName         string `json:"logical-volume"`
+	Size           uint64 `json:"size"`
+	VgID           string `json:"vg-id"`
+}
+
+// Subvol represents Sub volume Request
+type Subvol struct {
+	Type                    string   `json:"type"`
+	Bricks                  []Brick  `json:"bricks"`
+	Subvols                 []Subvol `json:"subvols"`
+	ReplicaCount            int      `json:"replica"`
+	ArbiterCount            int      `json:"arbiter"`
+	DisperseCount           int      `json:"disperse-count,omitempty"`
+	DisperseDataCount       int      `json:"disperse-data,omitempty"`
+	DisperseRedundancyCount int      `json:"disperse-redundancy,omitempty"`
+}
+
+// Volume represents a Volume Create Request
+type Volume struct {
+	Name                    string   `json:"name"`
+	Transport               string   `json:"transport,omitempty"`
+	Force                   bool     `json:"force,omitempty"`
+	Size                    uint64   `json:"size"`
+	DistributeCount         int      `json:"distribute"`
+	ReplicaCount            int      `json:"replica"`
+	ArbiterCount            int      `json:"arbiter"`
+	DisperseCount           int      `json:"disperse"`
+	DisperseDataCount       int      `json:"disperse-data"`
+	DisperseRedundancyCount int      `json:"disperse-redundancy"`
+	SnapshotEnabled         bool     `json:"snapshot"`
+	SnapshotReserveFactor   float64  `json:"snapshot-reserve-factor"`
+	LimitPeers              []string `json:"limit-peers"`
+	LimitZones              []string `json:"limit-zones"`
+	ExcludePeers            []string `json:"exclude-peers"`
+	ExcludeZones            []string `json:"exclude-zones"`
+	SubvolZonesOverlap      bool     `json:"subvolume-zones-overlap"`
+	Subvols                 []Subvol `json:"subvols"`
+	SubvolType              string   `json:"subvolume-type"`
+}

--- a/plugins/smartvol/bricksplanner/planner.go
+++ b/plugins/smartvol/bricksplanner/planner.go
@@ -1,0 +1,235 @@
+package bricksplanner
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/gluster/glusterd2/glusterd2/volume"
+	"github.com/gluster/glusterd2/plugins/device/deviceutils"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+
+	config "github.com/spf13/viper"
+)
+
+func handleReplicaSubvolReq(req *smartvolapi.Volume) error {
+	if req.ReplicaCount < 2 {
+		return nil
+	}
+
+	if req.ReplicaCount > 3 {
+		return errors.New("Invalid Replica Count")
+	}
+	req.SubvolType = "replicate"
+	if req.ArbiterCount > 1 {
+		return errors.New("Invalid Arbiter Count")
+	}
+
+	return nil
+}
+
+func handleDisperseSubvolReq(req *smartvolapi.Volume) error {
+	if req.DisperseCount == 0 && req.DisperseDataCount == 0 && req.DisperseRedundancyCount == 0 {
+		return nil
+	}
+
+	req.SubvolType = "disperse"
+
+	if req.DisperseDataCount > 0 && req.DisperseRedundancyCount <= 0 {
+		return errors.New("Disperse redundancy count is required")
+	}
+
+	if req.DisperseDataCount > 0 {
+		req.DisperseCount = req.DisperseDataCount + req.DisperseRedundancyCount
+	}
+
+	// Calculate Redundancy Value
+	if req.DisperseRedundancyCount <= 0 {
+		req.DisperseRedundancyCount = volume.GetRedundancy(uint(req.DisperseCount))
+	}
+
+	if req.DisperseDataCount <= 0 {
+		req.DisperseDataCount = req.DisperseCount - req.DisperseRedundancyCount
+	}
+
+	if 2*req.DisperseRedundancyCount >= req.DisperseCount {
+		return errors.New("Invalid redundancy count")
+	}
+
+	return nil
+}
+
+// Based on the provided values like replica count, distribute count etc,
+// brick layout will be created. Peer and device information for bricks are
+// not available with the layout
+func getBricksLayout(req *smartvolapi.Volume) ([]smartvolapi.Subvol, error) {
+	var err error
+	bricksMountRoot := config.GetString("bricksmountroot")
+	if bricksMountRoot == "" {
+		bricksMountRoot, err = filepath.Abs(config.GetString("localstatedir") + "/mounts")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// If Distribute count is zero then automatically decide
+	// the distribute count based on available size in each device
+	// TODO: Auto find the distribute count
+	numSubvols := 1
+	if req.DistributeCount > 0 {
+		numSubvols = req.DistributeCount
+	}
+
+	// User input will be in MBs, convert to KBs for all
+	// internal usage
+	subvolSize := deviceutils.MbToKb(req.Size)
+	if numSubvols > 1 {
+		subvolSize = subvolSize / uint64(numSubvols)
+	}
+
+	if req.SnapshotReserveFactor < 1 {
+		return nil, errors.New("Invalid Snapshot Reserve Factor")
+	}
+
+	// Default Subvol Type
+	req.SubvolType = "distribute"
+
+	// Validations if replica and arbiter sub volume
+	err = handleReplicaSubvolReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validations if disperse sub volume
+	err = handleDisperseSubvolReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	subvolplanner, exists := subvolPlanners[req.SubvolType]
+	if !exists {
+		return nil, errors.New("Sub volume type not supported")
+	}
+
+	// Initialize the planner
+	subvolplanner.Init(req, subvolSize)
+
+	var subvols []smartvolapi.Subvol
+
+	// Create a Bricks layout based on replica count and
+	// other details. Brick Path, PeerID information will
+	// be added later.
+	for i := 0; i < numSubvols; i++ {
+		var bricks []smartvolapi.Brick
+		for j := 0; j < subvolplanner.BricksCount(); j++ {
+			eachBrickSize := subvolplanner.BrickSize(j)
+			brickType := subvolplanner.BrickType(j)
+			eachBrickTpSize := uint64(float64(eachBrickSize) * req.SnapshotReserveFactor)
+
+			bricks = append(bricks, smartvolapi.Brick{
+				Type:           brickType,
+				Path:           fmt.Sprintf("%s/%s-s%d-b%d/brick", bricksMountRoot, req.Name, i, j),
+				TpName:         fmt.Sprintf("tp-%s-s%d-b%d", req.Name, i, j),
+				LvName:         fmt.Sprintf("brick-%s-s%d-b%d", req.Name, i, j),
+				Size:           eachBrickSize,
+				TpSize:         eachBrickTpSize,
+				TpMetadataSize: deviceutils.GetPoolMetadataSize(eachBrickTpSize),
+			})
+		}
+
+		subvols = append(subvols, smartvolapi.Subvol{
+			Type:          req.SubvolType,
+			Bricks:        bricks,
+			ReplicaCount:  req.ReplicaCount,
+			ArbiterCount:  req.ArbiterCount,
+			DisperseCount: req.DisperseCount,
+		})
+	}
+
+	return subvols, nil
+}
+
+// PlanBricks creates the brick layout with choosen device and size information
+func PlanBricks(req *smartvolapi.Volume) error {
+	availableVgs, err := getAvailableVgs(req)
+	if err != nil {
+		return err
+	}
+
+	if len(availableVgs) == 0 {
+		return errors.New("No devices registered or available for allocating bricks")
+	}
+
+	subvols, err := getBricksLayout(req)
+	if err != nil {
+		return err
+	}
+
+	zones := make(map[string]struct{})
+
+	for idx, sv := range subvols {
+		// If zones overlap is not specified then do not
+		// reset the zones map so that other subvol bricks
+		// will not get allocated in the same zones
+		if req.SubvolZonesOverlap {
+			zones = make(map[string]struct{})
+		}
+
+		// For the list of bricks, first try to utilize all the
+		// unutilized devices, Once all the devices are used, then try
+		// with device with expected space available.
+		numBricksAllocated := 0
+		for bidx, b := range sv.Bricks {
+			totalsize := b.TpSize + b.TpMetadataSize
+
+			for _, vg := range availableVgs {
+				_, zoneUsed := zones[vg.Zone]
+				if vg.AvailableSize >= totalsize && !zoneUsed && !vg.Used {
+					subvols[idx].Bricks[bidx].PeerID = vg.PeerID
+					subvols[idx].Bricks[bidx].VgName = vg.Name
+
+					zones[vg.Zone] = struct{}{}
+					numBricksAllocated++
+					vg.AvailableSize -= totalsize
+					vg.Used = true
+					break
+				}
+			}
+		}
+
+		// All bricks allocation not satisfied since only fresh devices are
+		// considered. Now consider all devices with available space
+		if len(sv.Bricks) == numBricksAllocated {
+			continue
+		}
+
+		// Try allocating for remaining bricks, No fresh device is available
+		// but enough space is available in the devices
+		for bidx := numBricksAllocated; bidx < len(sv.Bricks); bidx++ {
+			b := sv.Bricks[bidx]
+			totalsize := b.TpSize + b.TpMetadataSize
+
+			for _, vg := range availableVgs {
+				_, zoneUsed := zones[vg.Zone]
+				if vg.AvailableSize >= totalsize && !zoneUsed {
+					subvols[idx].Bricks[bidx].PeerID = vg.PeerID
+					subvols[idx].Bricks[bidx].VgName = vg.Name
+
+					zones[vg.Zone] = struct{}{}
+					numBricksAllocated++
+					vg.AvailableSize -= totalsize
+					vg.Used = true
+					break
+				}
+			}
+		}
+
+		// If the devices are not available as it is required for Volume.
+		if len(sv.Bricks) != numBricksAllocated {
+			return errors.New("No space available or all the devices are not registered")
+		}
+	}
+
+	req.Subvols = subvols
+	return nil
+}

--- a/plugins/smartvol/bricksplanner/subvoltype_disperse.go
+++ b/plugins/smartvol/bricksplanner/subvoltype_disperse.go
@@ -1,0 +1,37 @@
+package bricksplanner
+
+import (
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+)
+
+type disperseSubvolPlanner struct {
+	subvolSize              uint64
+	disperseCount           int
+	disperseDataCount       int
+	disperseRedundancyCount int
+	brickSize               uint64
+}
+
+func (s *disperseSubvolPlanner) Init(req *smartvolapi.Volume, subvolSize uint64) {
+	s.subvolSize = subvolSize
+	s.disperseCount = req.DisperseCount
+	s.disperseDataCount = req.DisperseDataCount
+	s.disperseRedundancyCount = req.DisperseRedundancyCount
+	s.brickSize = s.subvolSize / uint64(s.disperseDataCount)
+}
+
+func (s *disperseSubvolPlanner) BricksCount() int {
+	return s.disperseCount
+}
+
+func (s *disperseSubvolPlanner) BrickSize(idx int) uint64 {
+	return s.brickSize
+}
+
+func (s *disperseSubvolPlanner) BrickType(idx int) string {
+	return "Brick"
+}
+
+func init() {
+	subvolPlanners["disperse"] = &disperseSubvolPlanner{}
+}

--- a/plugins/smartvol/bricksplanner/subvoltype_distribute.go
+++ b/plugins/smartvol/bricksplanner/subvoltype_distribute.go
@@ -1,0 +1,29 @@
+package bricksplanner
+
+import (
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+)
+
+type distributeSubvolPlanner struct {
+	subvolSize uint64
+}
+
+func (s *distributeSubvolPlanner) Init(req *smartvolapi.Volume, subvolSize uint64) {
+	s.subvolSize = subvolSize
+}
+
+func (s *distributeSubvolPlanner) BricksCount() int {
+	return 1
+}
+
+func (s *distributeSubvolPlanner) BrickSize(idx int) uint64 {
+	return s.subvolSize
+}
+
+func (s *distributeSubvolPlanner) BrickType(idx int) string {
+	return "Brick"
+}
+
+func init() {
+	subvolPlanners["distribute"] = &distributeSubvolPlanner{}
+}

--- a/plugins/smartvol/bricksplanner/subvoltype_replicate.go
+++ b/plugins/smartvol/bricksplanner/subvoltype_replicate.go
@@ -1,0 +1,46 @@
+package bricksplanner
+
+import (
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+)
+
+type replicaSubvolPlanner struct {
+	subvolSize       uint64
+	replicaCount     int
+	arbiterCount     int
+	brickSize        uint64
+	arbiterBrickSize uint64
+}
+
+func (s *replicaSubvolPlanner) Init(req *smartvolapi.Volume, subvolSize uint64) {
+	s.subvolSize = subvolSize
+	s.replicaCount = req.ReplicaCount
+	s.arbiterCount = req.ArbiterCount
+	s.brickSize = s.subvolSize
+	// TODO: Calculate Arbiter brick size
+	s.arbiterBrickSize = s.subvolSize
+}
+
+func (s *replicaSubvolPlanner) BricksCount() int {
+	return s.replicaCount
+}
+
+func (s *replicaSubvolPlanner) BrickSize(idx int) uint64 {
+	if idx == (s.replicaCount-1) && s.arbiterCount > 0 {
+		return s.arbiterBrickSize
+	}
+
+	return s.brickSize
+}
+
+func (s *replicaSubvolPlanner) BrickType(idx int) string {
+	if idx == (s.replicaCount-1) && s.arbiterCount > 0 {
+		return "arbiter"
+	}
+
+	return "brick"
+}
+
+func init() {
+	subvolPlanners["replicate"] = &replicaSubvolPlanner{}
+}

--- a/plugins/smartvol/bricksplanner/utils.go
+++ b/plugins/smartvol/bricksplanner/utils.go
@@ -1,0 +1,108 @@
+package bricksplanner
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/gluster/glusterd2/glusterd2/peer"
+	"github.com/gluster/glusterd2/glusterd2/store"
+	"github.com/gluster/glusterd2/pkg/utils"
+	deviceapi "github.com/gluster/glusterd2/plugins/device/api"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+)
+
+var subvolPlanners = make(map[string]SubvolPlanner)
+
+// SubvolPlanner represents planner interface for different subvol types
+type SubvolPlanner interface {
+	Init(*smartvolapi.Volume, uint64)
+	BricksCount() int
+	BrickSize(int) uint64
+	BrickType(int) string
+}
+
+// Vg represents Virtual Volume Group
+type Vg struct {
+	Name          string
+	DeviceName    string
+	PeerID        string
+	Zone          string
+	State         string
+	AvailableSize uint64
+	Used          bool
+}
+
+func getAvailableVgs(req *smartvolapi.Volume) ([]Vg, error) {
+	var vgs []Vg
+	peers, err := peer.GetPeers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range peers {
+		// If Peer is not online, do not consider this device/peer
+		if !store.Store.IsNodeAlive(p.ID) {
+			continue
+		}
+
+		peerzone, exists := p.Metadata["_zone"]
+		if !exists || strings.TrimSpace(peerzone) == "" {
+			peerzone = p.ID.String()
+		}
+
+		// If List of Peer IDs specified to limit choosing the bricks from
+		if len(req.LimitPeers) > 0 && !utils.StringInSlice(p.ID.String(), req.LimitPeers) {
+			continue
+		}
+
+		// If List of zones specified to limit choosing the bricks from
+		if len(req.LimitZones) > 0 && !utils.StringInSlice(peerzone, req.LimitZones) {
+			continue
+		}
+
+		// If Exclude List of Peer IDs specified
+		if len(req.ExcludePeers) > 0 && utils.StringInSlice(p.ID.String(), req.ExcludePeers) {
+			continue
+		}
+
+		// If Exclude List of Zones specified
+		if len(req.ExcludeZones) > 0 && utils.StringInSlice(peerzone, req.ExcludeZones) {
+			continue
+		}
+
+		devicesRaw, exists := p.Metadata["_devices"]
+		if !exists {
+			// No device registered for this peer
+			continue
+		}
+
+		var deviceInfo []deviceapi.Info
+		if err := json.Unmarshal([]byte(devicesRaw), &deviceInfo); err != nil {
+			return nil, err
+		}
+
+		for _, d := range deviceInfo {
+			// If Device is not enabled to be used for provisioning
+			if d.State == deviceapi.DeviceDisabled {
+				continue
+			}
+
+			vgs = append(vgs, Vg{
+				DeviceName:    d.Name,
+				Name:          d.VgName,
+				PeerID:        p.ID.String(),
+				Zone:          peerzone,
+				State:         d.State,
+				AvailableSize: d.AvailableSize,
+				Used:          d.Used,
+			})
+		}
+	}
+
+	// Sort based on Free size available, this acts as rank/weightage each Vgs
+	// during allocation. High priority will be given to the Vg with more FreeSize
+	sort.Slice(vgs, func(i, j int) bool { return vgs[i].AvailableSize > vgs[j].AvailableSize })
+
+	return vgs, nil
+}

--- a/plugins/smartvol/init.go
+++ b/plugins/smartvol/init.go
@@ -1,0 +1,40 @@
+package smartvol
+
+import (
+	"github.com/gluster/glusterd2/glusterd2/servers/rest/route"
+	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/pkg/api"
+	"github.com/gluster/glusterd2/pkg/utils"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+)
+
+// Plugin is a structure which implements GlusterdPlugin interface
+type Plugin struct {
+}
+
+// Name returns name of plugin
+func (p *Plugin) Name() string {
+	return "smartvol"
+}
+
+// RestRoutes returns list of REST API routes to register with Glusterd.
+func (p *Plugin) RestRoutes() route.Routes {
+	return route.Routes{
+		route.Route{
+			Name:         "SmartVolumeCreate",
+			Method:       "POST",
+			Pattern:      "/smartvol",
+			Version:      1,
+			RequestType:  utils.GetTypeString((*smartvolapi.VolCreateReq)(nil)),
+			ResponseType: utils.GetTypeString((*api.VolumeCreateResp)(nil)),
+			HandlerFunc:  smartVolumeCreateHandler,
+		},
+	}
+}
+
+// RegisterStepFuncs registers transaction step functions with
+// Glusterd Transaction framework
+func (p *Plugin) RegisterStepFuncs() {
+	transaction.RegisterStepFunc(txnPrepareBricks, "vol-create.PrepareBricks")
+	transaction.RegisterStepFunc(txnUndoPrepareBricks, "vol-create.UndoPrepareBricks")
+}

--- a/plugins/smartvol/rest.go
+++ b/plugins/smartvol/rest.go
@@ -1,0 +1,223 @@
+package smartvol
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gluster/glusterd2/glusterd2/events"
+	"github.com/gluster/glusterd2/glusterd2/gdctx"
+	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
+	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+	"github.com/gluster/glusterd2/pkg/api"
+	gderrors "github.com/gluster/glusterd2/pkg/errors"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+	"github.com/gluster/glusterd2/plugins/smartvol/bricksplanner"
+
+	"github.com/pborman/uuid"
+)
+
+const (
+	minVolumeSize = 10
+)
+
+func validateVolCreateReq(req *smartvolapi.VolCreateReq) error {
+	if !volume.IsValidName(req.Name) {
+		return gderrors.ErrInvalidVolName
+	}
+
+	if req.Transport != "" && req.Transport != "tcp" && req.Transport != "rdma" {
+		return errors.New("Invalid transport. Supported values: tcp or rdma")
+	}
+
+	if req.Size < minVolumeSize {
+		return errors.New("Invalid Volume Size, Minimum size required is " + strconv.Itoa(minVolumeSize))
+	}
+
+	return nil
+}
+
+func getVolumeReq(req *smartvolapi.Volume) api.VolCreateReq {
+	reqVolCreate := api.VolCreateReq{
+		Name:      req.Name,
+		Transport: req.Transport,
+		Subvols:   make([]api.SubvolReq, len(req.Subvols)),
+		Force:     req.Force,
+	}
+
+	for sidx, sv := range req.Subvols {
+		reqVolCreate.Subvols[sidx] = api.SubvolReq{
+			Type:               sv.Type,
+			Bricks:             make([]api.BrickReq, len(sv.Bricks)),
+			ReplicaCount:       sv.ReplicaCount,
+			ArbiterCount:       sv.ArbiterCount,
+			DisperseCount:      sv.DisperseCount,
+			DisperseData:       sv.DisperseDataCount,
+			DisperseRedundancy: sv.DisperseRedundancyCount,
+		}
+
+		for bidx, b := range sv.Bricks {
+			reqVolCreate.Subvols[sidx].Bricks[bidx] = api.BrickReq{
+				Type:   b.Type,
+				PeerID: b.PeerID,
+				Path:   b.Path,
+			}
+		}
+	}
+
+	return reqVolCreate
+}
+
+func applyDefaults(req *smartvolapi.VolCreateReq) {
+	if req.SnapshotReserveFactor == 0 {
+		req.SnapshotReserveFactor = 1
+	}
+
+	// Snapshot reserve not required if not enabled
+	if !req.SnapshotEnabled {
+		req.SnapshotReserveFactor = 1
+	}
+}
+
+func smartVolumeCreateHandler(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+	logger := gdctx.GetReqLogger(ctx)
+	var err error
+
+	var req smartvolapi.VolCreateReq
+	if err := restutils.UnmarshalRequest(r, &req); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	if err := validateVolCreateReq(&req); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	_, err = volume.GetVolume(req.Name)
+	if err == nil {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, gderrors.ErrVolExists)
+		return
+	} else if err != gderrors.ErrVolNotFound {
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	applyDefaults(&req)
+
+	if req.SnapshotReserveFactor < 1 {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.New("Invalid Snapshot Reserve Factor"))
+		return
+	}
+
+	// Convert request to internal Structure
+	smartvolReq := smartvolapi.Volume{
+		Name:                    req.Name,
+		Transport:               req.Transport,
+		Force:                   req.Force,
+		Size:                    req.Size,
+		DistributeCount:         req.DistributeCount,
+		ReplicaCount:            req.ReplicaCount,
+		ArbiterCount:            req.ArbiterCount,
+		DisperseCount:           req.DisperseCount,
+		DisperseDataCount:       req.DisperseDataCount,
+		DisperseRedundancyCount: req.DisperseRedundancyCount,
+		SnapshotEnabled:         req.SnapshotEnabled,
+		SnapshotReserveFactor:   req.SnapshotReserveFactor,
+		LimitPeers:              req.LimitPeers,
+		LimitZones:              req.LimitZones,
+		ExcludePeers:            req.ExcludePeers,
+		ExcludeZones:            req.ExcludeZones,
+		SubvolZonesOverlap:      req.SubvolZonesOverlap,
+	}
+
+	if err := bricksplanner.PlanBricks(&smartvolReq); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Convert struct to traditional Volume Create format
+	reqVolCreate := getVolumeReq(&smartvolReq)
+
+	nodes, err := reqVolCreate.Nodes()
+	if err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	txn, err := transaction.NewTxnWithLocks(ctx, req.Name)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
+	txn.Nodes = nodes
+	txn.Steps = []*transaction.Step{
+		{
+			DoFunc:   "vol-create.PrepareBricks",
+			UndoFunc: "vol-create.UndoPrepareBricks",
+			Nodes:    nodes,
+		},
+		{
+			DoFunc: "vol-create.CreateVolinfo",
+			Nodes:  []uuid.UUID{gdctx.MyUUID},
+		},
+		{
+			DoFunc: "vol-create.ValidateBricks",
+			Nodes:  nodes,
+		},
+		{
+			DoFunc:   "vol-create.InitBricks",
+			UndoFunc: "vol-create.UndoInitBricks",
+			Nodes:    nodes,
+		},
+		{
+			DoFunc:   "vol-create.StoreVolume",
+			UndoFunc: "vol-create.UndoStoreVolume",
+			Nodes:    []uuid.UUID{gdctx.MyUUID},
+		},
+	}
+
+	if err := txn.Ctx.Set("req", &reqVolCreate); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := txn.Ctx.Set("reqBricksPrepare", &smartvolReq); err != nil {
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := txn.Do(); err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	volinfo, err := volume.GetVolume(req.Name)
+	if err != nil {
+		// FIXME: If volume was created successfully in the txn above and
+		// then the store goes down by the time we reach here, what do
+		// we return to the client ?
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	logger.WithField("volume-name", volinfo.Name).Info("new volume created")
+
+	events.Broadcast(volume.NewEvent(volume.EventVolumeCreated, volinfo))
+
+	resp := (*api.VolumeCreateResp)(volume.CreateVolumeInfoResp(volinfo))
+	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
+}

--- a/plugins/smartvol/transactions.go
+++ b/plugins/smartvol/transactions.go
@@ -1,0 +1,179 @@
+package smartvol
+
+import (
+	"os"
+	"path"
+
+	"github.com/gluster/glusterd2/glusterd2/gdctx"
+	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/plugins/device/deviceutils"
+	smartvolapi "github.com/gluster/glusterd2/plugins/smartvol/api"
+
+	config "github.com/spf13/viper"
+)
+
+func txnPrepareBricks(c transaction.TxnCtx) error {
+	var req smartvolapi.Volume
+	if err := c.Get("reqBricksPrepare", &req); err != nil {
+		c.Logger().WithError(err).WithField(
+			"key", "reqBricksPrepare").Debug("Failed to get key from store")
+		return err
+	}
+
+	for _, sv := range req.Subvols {
+		for _, b := range sv.Bricks {
+			if b.PeerID != gdctx.MyUUID.String() {
+				continue
+			}
+
+			brickMountDir := path.Dir(b.Path)
+
+			// Create Mount directory
+			err := os.MkdirAll(brickMountDir, os.ModeDir|os.ModePerm)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("path", brickMountDir).
+					Error("Failed to create brick mount directory")
+				return err
+			}
+
+			// Thin Pool Creation
+			err = deviceutils.CreateTP(b.VgName, b.TpName, b.TpSize, b.TpMetadataSize)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("vg-name", b.VgName).
+					WithField("tp-name", b.TpName).
+					WithField("tp-size", b.TpSize).
+					WithField("tp-meta-size", b.TpMetadataSize).
+					Error("Thinpool Creation failed")
+				return err
+			}
+
+			// LV Creation
+			err = deviceutils.CreateLV(b.VgName, b.TpName, b.LvName, b.Size)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("vg-name", b.VgName).
+					WithField("tp-name", b.TpName).
+					WithField("lv-name", b.LvName).
+					WithField("size", b.Size).
+					Error("lvcreate failed")
+				return err
+			}
+
+			dev := "/dev/" + b.VgName + "/" + b.LvName
+			// Make Filesystem
+			err = deviceutils.MakeXfs(dev)
+			if err != nil {
+				c.Logger().WithError(err).WithField("dev", dev).Error("mkfs.xfs failed")
+				return err
+			}
+
+			// Mount the Created FS
+			err = deviceutils.BrickMount(dev, brickMountDir)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("dev", dev).
+					WithField("path", brickMountDir).
+					Error("brick mount failed")
+				return err
+			}
+
+			// Create a directory in Brick Mount
+			err = os.MkdirAll(b.Path, os.ModeDir|os.ModePerm)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("path", b.Path).
+					Error("Failed to create brick directory in mount")
+				return err
+			}
+
+			// Update current Vg free size
+			deviceutils.UpdateDeviceFreeSize(gdctx.MyUUID.String(), b.VgName)
+
+			// Persist mount points in custom fstab file
+			// On Glusterd2 restart, all bricks should be
+			// mounted using mount -a -T <fstab-file>
+			fstabFile := config.GetString("localstatedir") + "/fstab"
+			err = deviceutils.FstabAddMount(fstabFile, deviceutils.FstabMount{
+				Device:           dev,
+				MountPoint:       brickMountDir,
+				FilesystemFormat: "xfs",
+				MountOptions:     "rw,inode64,noatime,nouuid",
+				DumpValue:        "1",
+				FsckOption:       "2",
+			})
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("fstab", fstabFile).
+					WithField("device", dev).
+					WithField("mount", brickMountDir).
+					Error("Failed to add entry to fstab file")
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func txnUndoPrepareBricks(c transaction.TxnCtx) error {
+	var req smartvolapi.Volume
+	if err := c.Get("reqBricksPrepare", &req); err != nil {
+		c.Logger().WithError(err).WithField(
+			"key", "reqBricksPrepare").Debug("Failed to get key from store")
+		return err
+	}
+
+	for _, sv := range req.Subvols {
+		for _, b := range sv.Bricks {
+
+			if b.PeerID != gdctx.MyUUID.String() {
+				continue
+			}
+
+			brickMountDir := path.Dir(b.Path)
+
+			// UnMount the Brick
+			err := deviceutils.BrickUnmount(brickMountDir)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("path", brickMountDir).
+					Error("brick unmount failed")
+			}
+
+			// Remove entry from fstab if available
+			fstabFile := config.GetString("localstatedir") + "/fstab"
+			err = deviceutils.FstabRemoveMount(fstabFile, brickMountDir)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("fstab", fstabFile).
+					WithField("mount", brickMountDir).
+					Error("Failed to remove entry from fstab file")
+			}
+
+			// Remove LV
+			err = deviceutils.RemoveLV(b.VgName, b.LvName)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("vg-name", b.VgName).
+					WithField("lv-name", b.LvName).
+					Error("lv remove failed")
+			}
+
+			// Remove Thin Pool
+			err = deviceutils.RemoveLV(b.VgName, b.TpName)
+			if err != nil {
+				c.Logger().WithError(err).
+					WithField("vg-name", b.VgName).
+					WithField("tp-name", b.TpName).
+					Error("thin pool remove failed")
+			}
+
+			// Update current Vg free size
+			deviceutils.UpdateDeviceFreeSize(gdctx.MyUUID.String(), b.VgName)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
With this feature, Gluster can choose the bricks automatically based
on the given Volume size.

## Usage

Gluster will not assume the list of devices available in each
peer. Register the devices which can be used by Gluster for
provisioning the bricks.

    glustercli device add <peerid> <device>


Once the devices are registered, Gluster Volume can be created using,

    glustercli volume create gv1 --size 1G


To create distributed replicate Volume, specify the distribute count as below.

    glustercli volume create gv1 --size 1G --replica 3 --distribute 2

Options available with this command are,

    --size                    (required) Size of Volume
    --distribute              (optional) Distribute count, Default value is 1
    --replica                 (optional) Replica count(Possible values: 2, 3),
                                         Default value is 0
    --arbiter                 (optional) Arbiter Count(Possible values: 1)
    --disperse                (optional) Disperse Count, Default value is 0
    --disperse-data           (optional) Disperse Data Count,Default value is 0
    --redundancy              (optional) Disperse Redundancy Count,
                                         Default value is 0
    --limit-peers             (optional) List of Peer IDs, Create Volume only
                                         using peers which are given in this
                                         list, Default value is []
    --limit-zones             (optional) List of Zones, Create Volume only
                                         using Peers which belong to these
                                         zones, Default value is []
    --exclude-peers           (optional) Do not use these Peers for bricks,
                                         Default value is []
    --exclude-zones           (optional) Do not use the peers for creating
                                         bricks which belongs to these Zones,
                                         Default value is []
    --snapshot-enabled        (optional) If Snapshot feature is required for
                                         the Volume, Default value is false
    --snapshot-reserve-factor (optional) Additional space for Snapshots,
                                         Default value is 1
    --subvols-zones-overlap   (optional) This can be set to true if brick
                                         belonging to other sub volume can be
                                         created on same zone, Default
                                         value is false

If multiple peers belong to same zone(or same rack server), bricks
belonging to same volume/sub volume should not choose from the same
zone. To set the zone to a peer,

    glustercli zone set <peerid> <zone>

Note: Zone CLI implementation is in progress, APIs are available

## How it works?

### Number of sub volumes and subvolume size
Find number of sub volumes and sub volume size using the distribute
count provided

    number_of_subvols = distribute_count
    subvolume_size = size / number_of_subvols

### Volume Type
Find Volume Type based on replica/disperse/arbiter count

    if replica_count > 0 then volume_type = "Replicate"
    if disperse_count > 0 then volume_type = "Disperse"
    if arbiter_count > 0 then volume_type = "Arbiter"
    else volume_type = "Distribute"

### Brick Size
Find each Brick size, Thin pool size and number of bricks per sub
volume based on Volume Type, replica/disperse/arbiter count,
snapshot reserve factor and sub volume size.

If Volume Type is Replicate

    each_brick_size = subvolume_size
    thinpool_size = each_brick_size * snapshot_reserve_factor
    number_of_bricks_per_subvolume = replica_count

If Volume Type is Arbiter

    each_brick_size = subvolume_size
    thinpool_size = each_brick_size * snapshot_reserve_factor
 
    arbiter_brick_size = 4KB * each_brick_size / average_file_size_kb
    arbiter_thinpool_size = arbiter_brick_size * snapshot_reserve_factor

If Volume Type is Disperse

    each_brick_size = subvolume_size / disperse_data_count
    thinpool_size = each_brick_size * snapshot_reserve_factor
    number_of_bricks_per_subvolume = disperse_count

Note: Add `0.5%`(max `16Gb`) to thin pool size for metadata

### Brick Layout
Construct **Brick layout** based on the above information. Below
example shows the brick layout of `testvol` with `size=1G`,
`distribute=2` and `replica=2`. Note that peer and
vgname information is not yet available.

    {
        "name": "testvol",
        "subvols": [
            {
                "type": "replicate",
                "bricks": [
                    {
                        "peer": "",
                        "path": "/var/lib/glusterd2/mounts/testvol_s0_b0/brick",
                        "size": 500,
                        "tpsize": 500,
                        "vgname": ""
                    },
                    {
                        "peer": "",
                        "path": "/var/lib/glusterd2/mounts/testvol_s0_b1/brick",
                        "size": 500,
                        "tpsize": 500,
                        "vgname": ""
                    }
                ],
                "replica": 2
            },
            {
                "type": "replicate",
                "bricks": [
                    {
                        "peer": "",
                        "path": "/var/lib/glusterd2/mounts/testvol_s1_b0/brick",
                        "size": 500,
                        "tpsize": 500,
                        "vgname": ""
                    },
                    {
                        "peer": "",
                        "path": "/var/lib/glusterd2/mounts/testvol_s1_b0/brick",
                        "size": 500,
                        "tpsize": 500,
                        "vgname": ""
                    }
                ],
                "replica": 2
            }
        ],
    }


### Choose device
To satisfy the requirement of above brick layout, iterate the devices
list and choose a device which satisfies the following requirements.

- Same device/peer/zone should not be used for bricks belonging to
  same sub volume.
- Same device/peer/zone should not be used for bricks belonging to
  different sub volumes of same volume unless
  `subvols-zones-overlap=true`

Many approaches can be followed for choosing the peer and device
for each brick.

- **Fill first** - fully utilize the devices before picking new device
    for allocating bricks. For example, If we have 10GB devices in 10
    peers, after creating 10 volumes(replica 3) only 3 devices gets
    filled up out of 10 devices.
- **Spread first** - More priority will be given to fresh devices
    while choosing a device for brick. Allocate from used devices only
    when no new devices are available. Before allocating the bricks,
    Sort the list of devices based on available free size(Descending
    order).

Gluster's intelligent volume provisioning uses the "Spread first"
approach since it distributes the bricks across the peers. [Heketi](https://github.com/heketi/heketi)
uses **Simple Ring Allocator** to choose the devices and peers. More details
available [here](https://github.com/heketi/heketi/wiki/Simple-Ring-Allocator).

Once the bricks layout is decided, devices allocation will be done in
two iterations. In the first iteration, bricks will be chosen from
the fresh devices(Number of LVs=0), if the number of bricks and size
required is not satisfied then, in the second iteration, bricks will
be chosen from the other available devices.

To summarize,

- Find number of sub volumes based on distribute count
- Find Volume Type based on replica/disperse/arbiter count
- Find number of bricks per sub volume based on Volume Type and
  replica/disperse/arbiter counts
- Find each brick size based on Volume size, Number of Sub volumes and
  Volume type.
- Prepare bricks layout without Peer and device information
- First iteration, choose fresh devices for bricks
- Second iteration, choose other devices for bricks if the number of
  bricks required is not satisfied with previous step.
- Pass this information to Glusterd2 Transaction to prepare the bricks.

### Steps involved in Brick preparation Transaction

Transaction framework of Glusterd2 will execute the following steps in
the identified brick peers.

- Prepare Thin pool based on ThinPool size provided by the planner
- Prepare Logical Volume based on the Brick size provided by the
  planner
- Create XFS File system
- Mount the FS and add to custom `fstab` file

If Transaction fails, rollback will try the following steps

- Unmount the Brick if mounted
- Remove Logical Volume and Thin Pool
- Cleanup the temp directories

## References
- Arbiter capacity requirements
  https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/3.3/html/administration_guide/creating_arbitrated_replicated_volumes#sect-Arbiter_Requirements
- Disperse Brick size calculation
  https://docs.gluster.org/en/v3/Administrator%20Guide/Setting%20Up%20Volumes/#creating-dispersed-volumes
- Bricks provisioning documentation https://access.redhat.com/documentation/en-us/red_hat_gluster_storage/3.3/html-single/administration_guide/#Formatting_and_Mounting_Bricks
- Ansible playbooks for bricks provisioning https://github.com/gluster/gluster-ansible-infra/tree/master/roles/backend_setup/tasks
- Heketi Project https://github.com/heketi/heketi


Updates: #466
Signed-off-by: Aravinda VK <avishwan@redhat.com>