### PR TITLE
Return 400(Bad Request) instead of 422(unprocessable entity)

### DIFF
--- a/glusterd2/commands/global/setglobaloptions.go
+++ b/glusterd2/commands/global/setglobaloptions.go
@@ -15,7 +15,7 @@ func setGlobalOptionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.GlobalOptionReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/peers/addpeer.go
+++ b/glusterd2/commands/peers/addpeer.go
@@ -21,7 +21,7 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.PeerAddReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/peers/editpeer.go
+++ b/glusterd2/commands/peers/editpeer.go
@@ -9,6 +9,7 @@ import (
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
 	"github.com/gluster/glusterd2/pkg/api"
+	"github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
@@ -21,7 +22,7 @@ func editPeer(w http.ResponseWriter, r *http.Request) {
 
 	var req api.PeerEditReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/volumes/optiongroup-create.go
+++ b/glusterd2/commands/volumes/optiongroup-create.go
@@ -29,7 +29,7 @@ func optionGroupCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.OptionGroupReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -63,7 +63,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.VolCreateReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, err)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, gderrors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -43,7 +43,7 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.VolExpandReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -87,7 +87,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.VolOptionReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/glusterd2/commands/volumes/volume-statedump.go
+++ b/glusterd2/commands/volumes/volume-statedump.go
@@ -94,7 +94,7 @@ func volumeStatedumpHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req api.VolStatedumpReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, gderrors.ErrJSONParsingFailed)
 		return
 	}
 

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/peer"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/pkg/errors"
 	deviceapi "github.com/gluster/glusterd2/plugins/device/api"
 
 	"github.com/gorilla/mux"
@@ -21,7 +22,7 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 	req := new(deviceapi.AddDeviceReq)
 	if err := restutils.UnmarshalRequest(r, req); err != nil {
 		logger.WithError(err).Error("Failed to Unmarshal request")
-		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, "Unable to marshal request")
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 	peerID := mux.Vars(r)["peerid"]

--- a/plugins/events/rest.go
+++ b/plugins/events/rest.go
@@ -19,7 +19,7 @@ func webhookAddHandler(w http.ResponseWriter, r *http.Request) {
 	var req eventsapi.Webhook
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
 		restutils.SendHTTPError(
-			ctx, w, http.StatusUnprocessableEntity,
+			ctx, w, http.StatusBadRequest,
 			errors.ErrJSONParsingFailed)
 		return
 	}
@@ -57,7 +57,7 @@ func webhookDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req eventsapi.Webhook
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity,
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest,
 			errors.ErrJSONParsingFailed)
 		return
 	}

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -90,7 +90,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var req georepapi.GeorepCreateReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -236,7 +236,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	// Parse the JSON body to get additional details of request
 	var req georepapi.GeorepCommandsReq
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -709,7 +709,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var req map[string]string
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -852,7 +852,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var req []string
 	if err := restutils.UnmarshalRequest(r, &req); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 
@@ -1082,7 +1082,7 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse the JSON body to get additional details of request
 	var sshkeys []georepapi.GeorepSSHPublicKey
 	if err := restutils.UnmarshalRequest(r, &sshkeys); err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusUnprocessableEntity, errors.ErrJSONParsingFailed)
+		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
 	}
 


### PR DESCRIPTION
Fixes [#611](https://github.com/gluster/glusterd2/issues/611).

Return Status Code 400(Bad Request) instead of 422(unprocessable entity) whenever JSON Parsing fails.

Signed-off-by: Vishal Pandey <vpandey@redhat.com>