### PR TITLE
xlator .so loading: gracefully handle panic (again)

### DIFF
--- a/glusterd2/xlator/global.go
+++ b/glusterd2/xlator/global.go
@@ -1,7 +1,12 @@
 package xlator
 
 import (
+	"fmt"
+	"runtime/debug"
+
 	"github.com/gluster/glusterd2/glusterd2/xlator/options"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -15,6 +20,15 @@ var (
 // Load load all available xlators and intializes the xlators and options maps
 func Load() (err error) {
 
+	defer func() {
+		if r := recover(); r != nil {
+			log.Info(string(debug.Stack()))
+			err = fmt.Errorf("recover()ed at xlator.Load(): %s", r)
+			log.Error("Your version of glusterfs is incomaptible. ",
+				"Please install latest glusterfs from source (branch: master)")
+		}
+	}()
+
 	xls, err := loadAllXlators()
 	if err != nil {
 		return
@@ -23,8 +37,9 @@ func Load() (err error) {
 
 	loadOptions()
 
-	if err := registerAllValidations(); err != nil {
-		return err
+	err = registerAllValidations()
+	if err != nil {
+		return
 	}
 
 	return


### PR DESCRIPTION
This re-introduces most of code from the following commit:
bd97f9e70e01ec9d4b55d2aef2f220ef386ba462

Closes #666
Signed-off-by: Prashanth Pai <ppai@redhat.com>