### PR TITLE
e2e: make a central, configurable, base workdir

### DIFF
--- a/e2e/config/1.toml
+++ b/e2e/config/1.toml
@@ -1,5 +1,5 @@
-workdir = "/tmp/gd2_func_test/w1"
-rundir = "/tmp/gd2_func_test/w1/run/gluster"
+workdir = "w1"
+rundir = "w1/run/gluster"
 logfile = "w1.log"
 peeraddress = "127.0.0.1:24008"
 clientaddress = "127.0.0.1:24007"

--- a/e2e/config/2.toml
+++ b/e2e/config/2.toml
@@ -1,5 +1,5 @@
-workdir = "/tmp/gd2_func_test/w2"
-rundir = "/tmp/gd2_func_test/w2/run/gluster"
+workdir = "w2"
+rundir = "w2/run/gluster"
 logfile = "w2.log"
 peeraddress = "127.0.0.1:23008"
 clientaddress = "127.0.0.1:23007"

--- a/e2e/config/3.toml
+++ b/e2e/config/3.toml
@@ -1,5 +1,5 @@
-workdir = "/tmp/gd2_func_test/w3"
-rundir = "/tmp/gd2_func_test/w3/run/gluster"
+workdir = "w3"
+rundir = "w3/run/gluster"
 logfile = "w3.log"
 peeraddress = "127.0.0.1:22008"
 clientaddress = "127.0.0.1:22007"

--- a/e2e/config/4.toml
+++ b/e2e/config/4.toml
@@ -1,5 +1,5 @@
-workdir = "/tmp/gd2_func_test/w4"
-rundir = "/tmp/gd2_func_test/w4/run/gluster"
+workdir = "w4"
+rundir = "w4/run/gluster"
 logfile = "w4.log"
 peeraddress = "127.0.0.1:21008"
 clientaddress = "127.0.0.1:21007"

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	binDir   string
-	functest bool
+	binDir      string
+	baseWorkdir = "/tmp/gd2_func_test"
+	functest    bool
 )
 
 func TestMain(m *testing.M) {
@@ -18,6 +19,7 @@ func TestMain(m *testing.M) {
 
 	flag.BoolVar(&functest, "functest", false, "Run or skip functional test")
 	flag.StringVar(&binDir, "bindir", defBinDir, "The directory containing glusterd2 binary")
+	flag.StringVar(&baseWorkdir, "workdir", baseWorkdir, "The base directory for test working directories")
 	flag.Parse()
 
 	if !functest {
@@ -32,7 +34,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Cleanup leftovers from previous test runs. But don't cleanup after.
-	os.RemoveAll("/tmp/gd2_func_test")
+	os.RemoveAll(baseWorkdir)
 
 	v := m.Run()
 	os.Exit(v)


### PR DESCRIPTION
Previously, e2e tests were hard-coding the base workdir in
the main_test.go file and in the config toml files. This change
centralizes the base path in a top-level variable and makes
it possible to specify custom values for the workdir. This
can be useful if /tmp is inappropriate for this task on a
particular system or if multiple e2e tests are to be run in
parallel so that the caller may specify unique paths for
each test.
The toml files are adjusted to contain relative paths.

Signed-off-by: John Mulligan <jmulligan@redhat.com>