### PR TITLE
Provide an option to set Metadata in volumes

### DIFF
--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -146,6 +146,12 @@ func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
 		return nil, err
 	}
 
+	if req.Metadata != nil {
+		volinfo.Metadata = req.Metadata
+	} else {
+		volinfo.Metadata = make(map[string]string)
+	}
+
 	return volinfo, nil
 }
 

--- a/glusterd2/commands/volumes/volume-create_test.go
+++ b/glusterd2/commands/volumes/volume-create_test.go
@@ -30,6 +30,8 @@ func TestCreateVolinfo(t *testing.T) {
 		{PeerID: u.String(), Path: "/tmp/b1"},
 		{PeerID: u.String(), Path: "/tmp/b2"},
 	}}}
+	msg.Metadata = make(map[string]string)
+	msg.Metadata["owner"] = "gd2test"
 	vol, e := newVolinfo(msg)
 	assert.Nil(t, e)
 	assert.NotNil(t, vol)

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -109,6 +109,7 @@ type Volinfo struct {
 	Auth        VolAuth // TODO: should not be returned to client
 	GraphMap    map[string]string
 	HealEnabled bool
+	Metadata    map[string]string
 }
 
 // VolAuth represents username and password used by trusted/internal clients

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -184,5 +184,6 @@ func CreateVolumeInfoResp(v *Volinfo) *api.VolumeInfo {
 		State:     api.VolState(v.State),
 		Options:   v.Options,
 		Subvols:   CreateSubvolInfo(&v.Subvols),
+		Metadata:  v.Metadata,
 	}
 }

--- a/pkg/api/volume_req.go
+++ b/pkg/api/volume_req.go
@@ -29,6 +29,7 @@ type VolCreateReq struct {
 	Advanced     bool              `json:"advanced,omitempty"`
 	Experimental bool              `json:"experimental,omitempty"`
 	Deprecated   bool              `json:"deprecated,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
 }
 
 // VolOptionReq represents an incoming request to set volume options

--- a/pkg/api/volume_resp.go
+++ b/pkg/api/volume_resp.go
@@ -62,6 +62,7 @@ type VolumeInfo struct {
 	Options      map[string]string `json:"options"`
 	State        VolState          `json:"state"`
 	Subvols      []Subvol          `json:"subvols"`
+	Metadata     map[string]string `json:"metadata"`
 }
 
 // VolumeStatusResp response contains the statuses of all bricks of the volume.


### PR DESCRIPTION
Deals with [#462](https://github.com/gluster/glusterd2/issues/462)
Add Metadata as a new field in volinfo which acts like a dictionary and populate it during volume create.

Signed-off-by: Vishal Pandey <vpandey@redhat.com>