### PR TITLE
e2e: move volume tmp dirs under base workdir

### DIFF
--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -40,7 +40,7 @@ func TestVolume(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir("", t.Name())
+	tmpDir, err = ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
 	t.Logf("Using temp dir: %s", tmpDir)
 	//defer os.RemoveAll(tmpDir)
@@ -237,7 +237,7 @@ func TestVolumeOptions(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir("", t.Name())
+	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	defer os.RemoveAll(brickDir)
 
 	brickPath, err := ioutil.TempDir(brickDir, "brick")


### PR DESCRIPTION
Instead of dropping the fake volume dirs into /tmp directly
(or whatever the os tmpdir happens to be)
locate them under the base workdir. This causes them to be
cleaned up & managed along with the glusterd2 process working dirs.

Signed-off-by: John Mulligan <jmulligan@redhat.com>