### PR TITLE
Provide actors/hooks for volume set operation

### DIFF
--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -79,8 +79,8 @@ func CreateLockSteps(key string) (*Step, *Step, error) {
 		return nil, nil, err
 	}
 
-	lockStep := &Step{lockFunc, unlockFunc, []uuid.UUID{gdctx.MyUUID}}
-	unlockStep := &Step{unlockFunc, "", []uuid.UUID{gdctx.MyUUID}}
+	lockStep := &Step{lockFunc, unlockFunc, []uuid.UUID{gdctx.MyUUID}, false}
+	unlockStep := &Step{unlockFunc, "", []uuid.UUID{gdctx.MyUUID}, false}
 
 	return lockStep, unlockStep, nil
 }

--- a/glusterd2/transaction/step.go
+++ b/glusterd2/transaction/step.go
@@ -20,6 +20,7 @@ type Step struct {
 	DoFunc   string
 	UndoFunc string
 	Nodes    []uuid.UUID
+	Skip     bool
 }
 
 var (

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -87,6 +87,10 @@ func (t *Txn) Do() error {
 	expTxn.Add("initiated_txn_in_progress", 1)
 
 	for i, s := range t.Steps {
+		if s.Skip {
+			continue
+		}
+
 		if err := s.do(t.Ctx); err != nil {
 			if !t.DisableRollback {
 				t.Ctx.Logger().WithError(err).Error("Transaction failed, rolling back changes")
@@ -103,6 +107,9 @@ func (t *Txn) Do() error {
 // The Steps are undone in the reverse order, from the failed step.
 func (t *Txn) undo(n int) {
 	for i := n; i >= 0; i-- {
+		if t.Steps[i].Skip {
+			continue
+		}
 		t.Steps[i].undo(t.Ctx)
 	}
 }

--- a/glusterd2/xlator/actors.go
+++ b/glusterd2/xlator/actors.go
@@ -1,0 +1,34 @@
+package xlator
+
+import (
+	"github.com/gluster/glusterd2/glusterd2/volume"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// OptionActor is an interface that contains Do and Undo methods. These methods
+// are invoked during volume set on ALL nodes that make up the volume.
+// Each plugin or xlator can provide a type satisying OptionActor interface to
+// have the xlator/feature specific logic executed during volume set. An example
+// of such logic is the task of starting and stopping daemon.
+type OptionActor interface {
+	// Do function takes volinfo, option key, option value.
+	Do(*volume.Volinfo, string, string) error
+	// Undo function takes volinfo, option key, option value. The returned
+	// error is currently ignored.
+	Undo(*volume.Volinfo, string, string) error
+}
+
+// RegisterOptionActor registers a xlator's type implementing OptionActor
+// interface. The Do() and Undo() methods of the interface will be invoked
+// later during volume set operation.
+func RegisterOptionActor(xlator string, actor OptionActor) error {
+	xl, err := Find(xlator)
+	if err != nil {
+		log.WithError(err).WithField("xlator",
+			xlator).Error("Could not register xlator actor type")
+		return err
+	}
+	xl.Actor = actor
+	return nil
+}

--- a/glusterd2/xlator/xlator.go
+++ b/glusterd2/xlator/xlator.go
@@ -10,7 +10,10 @@ type Xlator struct {
 	Options   []*options.Option
 	Flags     uint32
 	OpVersion []uint32
-	Validate  ValidationFunc
+
+	// Not loaded from .so, set by glusterd2 code
+	Validate ValidationFunc
+	Actor    OptionActor
 
 	// This is pretty much useless now.
 	rawID uint32


### PR DESCRIPTION
...that xlators can hook into to perform some custom action on nodes
that make up the volume. Actions can be something like starting or
stopping a daemon.

Closes #664 

Signed-off-by: Prashanth Pai <ppai@redhat.com>