### PR TITLE
updated key for specifing external etcd URL

### DIFF
--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -83,7 +83,7 @@ Edit **glusterd2.toml** config option and add `noembed` option with specifying
 the etcd endpoint:
 
 ```toml
-etcdcurls = "http://127.0.0.1:2379"
+etcdendpoints = "http://127.0.0.1:2379"
 noembed = true
 ```
 


### PR DESCRIPTION
updated development-guide to specify external ETCD URL 

etcdendpoints is the key in glusterd2.toml for external ETCD URL

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>