### PR TITLE
volume state dump for default values 

### DIFF
--- a/glustercli/cmd/volume-statedump.go
+++ b/glustercli/cmd/volume-statedump.go
@@ -72,7 +72,9 @@ func volumeStatedumpCmdRun(cmd *cobra.Command, args []string) {
 		pid, _ := strconv.Atoi(s[1])
 		req.Client.Host = s[0]
 		req.Client.Pid = pid
-	} else {
+	}
+
+	if req.Quota == false && req.Client.Host == "" {
 		// TODO: The REST API doesn't support taking statedump of a single specified brick.
 		req.Bricks = true
 	}


### PR DESCRIPTION
if we pass --quota ==false the cmd.Flags().Changed will get hit 

get volume state dump with req.brick == true, when the quota is false and the client is empty  
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>