### PR TITLE
recover as the first middleware handler in rest server

### DIFF
--- a/glusterd2/servers/rest/rest.go
+++ b/glusterd2/servers/rest/rest.go
@@ -76,8 +76,8 @@ func NewMuxed(m cmux.CMux) *GDRest {
 
 	// Chain of ordered middlewares.
 	rest.server.Handler = alice.New(
-		middleware.Expvar,
 		middleware.Recover,
+		middleware.Expvar,
 		middleware.ReqIDGenerator,
 		middleware.LogRequest,
 		middleware.Auth,


### PR DESCRIPTION
interchanged  Recover and Expvar handlers position in the rest server

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>