### PR TITLE
added functionality to expose flags in volume create and expand

### DIFF
--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -48,7 +48,6 @@ func TestVolume(t *testing.T) {
 
 	// Create the volume
 	t.Run("Create", testVolumeCreate)
-
 	// Expand the volume
 	t.Run("Expand", testVolumeExpand)
 
@@ -112,17 +111,83 @@ func testVolumeCreate(t *testing.T) {
 	createReq.Name = "##@@#@!#@!!@#"
 	_, err = client.VolumeCreate(createReq)
 	r.NotNil(err)
+
 }
 
+func testVolumeCreateWithFlags(t *testing.T) {
+	r := require.New(t)
+
+	var brickPaths []string
+
+	for i := 1; i <= 4; i++ {
+		brickPaths = append(brickPaths, fmt.Sprintf(baseWorkdir+t.Name()+"/b/%d", i))
+	}
+
+	flags := make(map[string]bool)
+	//set flags to allow rootdir
+	flags["allow-root-dir"] = true
+	//set flags create brick dir
+	flags["create-brick-dir"] = true
+
+	createReqBrick := api.VolCreateReq{
+		Name: t.Name(),
+		Subvols: []api.SubvolReq{
+			{
+				ReplicaCount: 2,
+				Type:         "replicate",
+				Bricks: []api.BrickReq{
+					{PeerID: gds[0].PeerID(), Path: brickPaths[0]},
+					{PeerID: gds[1].PeerID(), Path: brickPaths[1]},
+				},
+			},
+			{
+				Type:         "replicate",
+				ReplicaCount: 2,
+				Bricks: []api.BrickReq{
+					{PeerID: gds[0].PeerID(), Path: brickPaths[2]},
+					{PeerID: gds[1].PeerID(), Path: brickPaths[3]},
+				},
+			},
+		},
+		Flags: flags,
+	}
+
+	_, err := client.VolumeCreate(createReqBrick)
+	r.Nil(err)
+
+	//delete volume
+	r.Nil(client.VolumeDelete(t.Name()))
+
+	createReqBrick.Name = t.Name()
+	//set reuse-brick flag
+	flags["reuse-bricks"] = true
+	createReqBrick.Flags = flags
+
+	_, err = client.VolumeCreate(createReqBrick)
+	r.Nil(err)
+
+	r.Nil(client.VolumeDelete(t.Name()))
+
+	//recreate deleted volume
+	_, err = client.VolumeCreate(createReqBrick)
+	r.Nil(err)
+
+	//delete volume
+	r.Nil(client.VolumeDelete(t.Name()))
+
+}
 func testVolumeExpand(t *testing.T) {
 	r := require.New(t)
 
 	var brickPaths []string
 	for i := 1; i <= 4; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
-		brickPaths = append(brickPaths, brickPath)
+		brickPaths = append(brickPaths, fmt.Sprintf(fmt.Sprintf(baseWorkdir+t.Name()+"/b/%d/", i)))
 	}
+
+	flags := make(map[string]bool)
+	//set flags to allow rootdir and create brick dir
+	flags["create-brick-dir"] = true
+	flags["allow-root-dir"] = true
 
 	expandReq := api.VolExpandReq{
 		Bricks: []api.BrickReq{
@@ -131,8 +196,10 @@ func testVolumeExpand(t *testing.T) {
 			{PeerID: gds[0].PeerID(), Path: brickPaths[2]},
 			{PeerID: gds[1].PeerID(), Path: brickPaths[3]},
 		},
-		Force: true,
+		Flags: flags,
 	}
+
+	//expand with new brick dir which is not created
 	_, err := client.VolumeExpand(volname, expandReq)
 	r.Nil(err)
 }

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -48,9 +48,11 @@ func init() {
 	volumeCreateCmd.Flags().StringSliceVar(&flagCreateVolumeOptions, "options", []string{},
 		"Volume options in the format option:value,option:value")
 	volumeCreateCmd.Flags().BoolVar(&flagCreateAdvOpts, "advanced", false, "Allow advanced options")
-	volumeCreateCmd.Flags().BoolVar(&flagCreateExpOpts, "experimental", false, "Allow experimental options")
-	volumeCreateCmd.Flags().BoolVar(&flagCreateDepOpts, "deprecated", false, "Allow deprecated options")
-	volumeCmd.AddCommand(volumeCreateCmd)
+	volumeCreateCmd.Flags().BoolVar(&flagReuseBricks, "reuse-bricks", false, "Reuse bricks")
+	volumeCreateCmd.Flags().BoolVar(&flagAllowRootDir, "allow-root-dir", false, "Allow root directory")
+	volumeCreateCmd.Flags().BoolVar(&flagAllowMountAsBrick, "allow-mount-as-brick", false, "Allow mount as bricks")
+	volumeCreateCmd.Flags().BoolVar(&flagCreateBrickDir, "create-brick-dir", false, "Create brick directory")
+
 }
 
 func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
@@ -133,6 +135,12 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 			)
 		}
 	}
+	//set flags
+	flags := make(map[string]bool)
+	flags["reuse-bricks"] = flagReuseBricks
+	flags["allow-root-dir"] = flagAllowRootDir
+	flags["allow-mount-as-brick"] = flagAllowMountAsBrick
+	flags["create-brick-dir"] = flagCreateBrickDir
 
 	options := make(map[string]string)
 	//set options
@@ -161,6 +169,7 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 		Advanced:     flagCreateAdvOpts,
 		Experimental: flagCreateExpOpts,
 		Deprecated:   flagCreateDepOpts,
+		Flags:        flags,
 	}
 
 	// handle thin-arbiter

--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -49,6 +49,8 @@ var (
 	flagCmdMetadataKey    string
 	flagCmdMetadataValue  string
 	flagCmdDeleteMetadata bool
+	//volume expand flags
+	flagReuseBricks, flagAllowRootDir, flagAllowMountAsBrick, flagCreateBrickDir bool
 )
 
 func init() {
@@ -79,6 +81,10 @@ func init() {
 	// Volume Expand
 	volumeExpandCmd.Flags().IntVarP(&flagExpandCmdReplicaCount, "replica", "", 0, "Replica Count")
 	volumeExpandCmd.Flags().BoolVarP(&flagExpandCmdForce, "force", "f", false, "Force")
+	volumeExpandCmd.Flags().BoolVar(&flagReuseBricks, "reuse-bricks", false, "Reuse Bricks")
+	volumeExpandCmd.Flags().BoolVar(&flagAllowRootDir, "allow-root-dir", false, "Allow Root Directory")
+	volumeExpandCmd.Flags().BoolVar(&flagAllowMountAsBrick, "allow-mount-as-brick", false, "Allow Mount as Bricks")
+	volumeExpandCmd.Flags().BoolVar(&flagCreateBrickDir, "create-brick-dir", false, "Create brick directory")
 	volumeCmd.AddCommand(volumeExpandCmd)
 
 	// Volume Edit
@@ -440,10 +446,18 @@ var volumeExpandCmd = &cobra.Command{
 			}
 			failure("Error getting brick UUIDs", err, 1)
 		}
+		//set flags
+		flags := make(map[string]bool)
+		flags["reuse-bricks"] = flagReuseBricks
+		flags["allow-root-dir"] = flagAllowRootDir
+		flags["allow-mount-as-brick"] = flagAllowMountAsBrick
+		flags["create-brick-dir"] = flagCreateBrickDir
+
 		vol, err := client.VolumeExpand(volname, api.VolExpandReq{
 			ReplicaCount: flagExpandCmdReplicaCount,
 			Bricks:       bricks, // string of format <UUID>:<path>
 			Force:        flagExpandCmdForce,
+			Flags:        flags,
 		})
 		if err != nil {
 			if verbose {

--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -2,6 +2,7 @@ package brick
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pborman/uuid"
 	"golang.org/x/sys/unix"
@@ -78,6 +79,16 @@ func (b *Brickinfo) Validate(check InitChecks) error {
 
 	if err = validatePathLength(b.Path); err != nil {
 		return err
+	}
+
+	if _, err = os.Stat(b.Path); os.IsNotExist(err) {
+		if check.CreateBrickDir {
+			if err = os.MkdirAll(b.Path, 0775); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	if err = unix.Lstat(b.Path, &brickStat); err != nil {

--- a/glusterd2/brick/validation.go
+++ b/glusterd2/brick/validation.go
@@ -20,11 +20,46 @@ const (
 
 // InitChecks is a set of checks to be run on a brick
 type InitChecks struct {
-	IsInUse  bool
-	IsMount  bool
-	IsOnRoot bool
+	IsInUse        bool
+	IsMount        bool
+	IsOnRoot       bool
+	CreateBrickDir bool
 }
 
+// PrepareChecks initializes InitChecks based on req
+func PrepareChecks(force bool, req map[string]bool) *InitChecks {
+	c := &InitChecks{}
+
+	if force {
+		// skip all checks if force is set to true
+
+		c.CreateBrickDir = true
+		return c
+	}
+
+	// do all the checks except the ones explicitly excluded
+	c.IsInUse = true
+	c.IsOnRoot = true
+	c.IsMount = true
+	c.CreateBrickDir = false
+
+	if value, ok := req["reuse-bricks"]; ok && value {
+		c.IsInUse = false
+	}
+
+	if value, ok := req["allow-root-dir"]; ok && value {
+		c.IsOnRoot = false
+	}
+
+	if value, ok := req["allow-mount-as-brick"]; ok && value {
+		c.IsMount = false
+	}
+	if value, ok := req["create-brick-dir"]; ok && value {
+		c.CreateBrickDir = true
+	}
+
+	return c
+}
 func validatePathLength(path string) error {
 
 	if len(filepath.Clean(path)) >= syscall.PathMax {

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/xlator"
 	"github.com/gluster/glusterd2/glusterd2/xlator/options"
 	"github.com/gluster/glusterd2/pkg/api"
+	gderrors "github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
@@ -261,6 +262,22 @@ func LoadDefaultGroupOptions() error {
 	}
 	if _, err := store.Store.Put(context.TODO(), "groupoptions", string(groupOptions)); err != nil {
 		return err
+	}
+	return nil
+}
+
+//validateVolumeFlags checks for Flags in volume create and expand
+func validateVolumeFlags(flag map[string]bool) error {
+	if len(flag) > 4 {
+		return gderrors.ErrInvalidVolFlags
+	}
+	for key := range flag {
+		switch key {
+		case "reuse-bricks", "allow-root-dir", "allow-mount-as-brick", "create-brick-dir":
+			continue
+		default:
+			return fmt.Errorf("volume flag not supported %s", key)
+		}
 	}
 	return nil
 }

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -194,15 +194,9 @@ func createVolinfo(c transaction.TxnCtx) error {
 		return err
 	}
 
-	// TODO: Expose this granularity in the volume create API.
-	var checks brick.InitChecks
-	if !req.Force {
-		checks.IsInUse = true
-		checks.IsMount = true
-		checks.IsOnRoot = true
-	}
+	checks := brick.PrepareChecks(req.Force, req.Flags)
 
-	err = c.Set("brick-checks", &checks)
+	err = c.Set("brick-checks", checks)
 
 	return err
 }

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -43,7 +43,7 @@ func validateVolCreateReq(req *api.VolCreateReq) error {
 		}
 	}
 
-	return nil
+	return validateVolumeFlags(req.Flags)
 }
 
 func checkDupBrickEntryVolCreate(req api.VolCreateReq) error {

--- a/glusterd2/commands/volumes/volume-expand-txn.go
+++ b/glusterd2/commands/volumes/volume-expand-txn.go
@@ -59,13 +59,9 @@ func expandValidatePrepare(c transaction.TxnCtx) error {
 		return err
 	}
 
-	var checks brick.InitChecks
-	if !req.Force {
-		checks.IsInUse = true
-		checks.IsMount = true
-		checks.IsOnRoot = true
-	}
-	if err := c.Set("brick-checks", &checks); err != nil {
+	checks := brick.PrepareChecks(req.Force, req.Flags)
+
+	if err := c.Set("brick-checks", checks); err != nil {
 		return err
 	}
 

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -35,7 +35,8 @@ func registerVolExpandStepFuncs() {
 		transaction.RegisterStepFunc(sf.sf, sf.name)
 	}
 }
-func checkDupBrickEntryVolExpand(req api.VolExpandReq) error {
+
+func validateVolumeExpandReq(req api.VolExpandReq) error {
 	dupEntry := map[string]bool{}
 
 	for _, brick := range req.Bricks {
@@ -46,7 +47,8 @@ func checkDupBrickEntryVolExpand(req api.VolExpandReq) error {
 
 	}
 
-	return nil
+	return validateVolumeFlags(req.Flags)
+
 }
 
 func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +63,7 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := checkDupBrickEntryVolExpand(req); err != nil {
+	if err := validateVolumeExpandReq(req); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
 		return
 	}

--- a/pkg/api/volume_req.go
+++ b/pkg/api/volume_req.go
@@ -20,6 +20,12 @@ type SubvolReq struct {
 }
 
 // VolCreateReq represents a Volume Create Request
+/*supported Flags
+"reuse-bricks" : for reusing of bricks
+"allow-root-dir" : allow root directory to create brick
+"allow-mount-as-brick" : reuse if its already mountpoint
+"create-brick-dir" : if brick dir is not present, create it
+*/
 type VolCreateReq struct {
 	Name         string            `json:"name"`
 	Transport    string            `json:"transport,omitempty"`
@@ -30,6 +36,7 @@ type VolCreateReq struct {
 	Experimental bool              `json:"experimental,omitempty"`
 	Deprecated   bool              `json:"deprecated,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
+	Flags        map[string]bool   `json:"flags,omitempty"`
 }
 
 // VolOptionReq represents an incoming request to set volume options
@@ -47,10 +54,17 @@ type VolOptionResetReq struct {
 }
 
 // VolExpandReq represents a request to expand the volume by adding more bricks
+/*supported Flags
+"reuse-bricks" : for reusing of bricks
+"allow-root-dir" : allow root directory to create brick
+"allow-mount-as-brick" : reuse if its already mountpoint
+"create-brick-dir" : if brick dir is not present, create it
+*/
 type VolExpandReq struct {
-	ReplicaCount int        `json:"replica,omitempty"`
-	Bricks       []BrickReq `json:"bricks"`
-	Force        bool       `json:"force,omitempty"`
+	ReplicaCount int             `json:"replica,omitempty"`
+	Bricks       []BrickReq      `json:"bricks"`
+	Force        bool            `json:"force,omitempty"`
+	Flags        map[string]bool `json:"flags,omitempty"`
 }
 
 // VolumeOption represents an option that is part of a profile

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -42,4 +42,5 @@ var (
 	ErrDuplicateBrickPath      = errors.New("Duplicate brick entry")
 	ErrRestrictedKeyFound      = errors.New("Key names starting with '_' are restricted in metadata field")
 	ErrVolFileNotFound         = errors.New("volume file not found")
+	ErrInvalidVolFlags         = errors.New("invalid volume flags")
 )


### PR DESCRIPTION
added functionality to expose flags in volume create and expand
added an additional flag to create brick dir if it's not exists

exposed flags for volume creation and expansion in glustercli

added e2e test cases for flags in
volume create and volume expand

Fixes #751
Fixes #675
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>