### PR TITLE
Store peer address provided during peer add 

### DIFF
--- a/glusterd2/peer/self.go
+++ b/glusterd2/peer/self.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/pkg/errors"
+	"github.com/gluster/glusterd2/pkg/utils"
 
 	config "github.com/spf13/viper"
 )
@@ -47,6 +48,7 @@ func AddSelfDetails() error {
 		Name:          gdctx.HostName,
 		PeerAddresses: []string{config.GetString("peeraddress")},
 	}
+
 	p.ClientAddresses, err = normalizeAddrs()
 	if err != nil {
 		return err
@@ -56,8 +58,17 @@ func AddSelfDetails() error {
 	if err == errors.ErrPeerNotFound {
 		p.Metadata = make(map[string]string)
 		p.Metadata["_zone"] = p.ID.String()
+
 	} else if err == nil && peerInfo != nil {
 		p.Metadata = peerInfo.Metadata
+
+		found := utils.StringInSlice(p.PeerAddresses[0], peerInfo.PeerAddresses)
+		if !found {
+			p.PeerAddresses = append(peerInfo.PeerAddresses, p.PeerAddresses...)
+		} else {
+			p.PeerAddresses = peerInfo.PeerAddresses
+		}
+
 	} else {
 		return err
 	}

--- a/pkg/utils/peerutils.go
+++ b/pkg/utils/peerutils.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FormRemotePeerAddress will check and validate peeraddress provided. It will
-// return an address of the form <ip:port>
+// return an address of the form <host:port>
 func FormRemotePeerAddress(peeraddress string) (string, error) {
 
 	host, port, err := net.SplitHostPort(peeraddress)


### PR DESCRIPTION
store peer addresses provided during peer add in ETCD.

if peer address already present in the store
update configuration on startup

this allows the users to use peer address
provided during peer add, for any other
operations(ex:- volume create,expand)

Fixes: #725 
Fixes: #758
Fixes: #724
Fixes: #721
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>