### PR TITLE
Set request logger to logrus.FieldLogger interface type

### DIFF
--- a/glusterd2/gdctx/context.go
+++ b/glusterd2/gdctx/context.go
@@ -29,13 +29,13 @@ func GetReqID(ctx context.Context) uuid.UUID {
 }
 
 // WithReqLogger returns a new context with provided logger set as a value in the context.
-func WithReqLogger(ctx context.Context, logger *log.Entry) context.Context {
+func WithReqLogger(ctx context.Context, logger log.FieldLogger) context.Context {
 	return context.WithValue(ctx, reqLoggerKey, logger)
 }
 
 // GetReqLogger returns logger stored in the context provided.
-func GetReqLogger(ctx context.Context) *log.Entry {
-	reqLogger, ok := ctx.Value(reqLoggerKey).(*log.Entry)
+func GetReqLogger(ctx context.Context) log.FieldLogger {
+	reqLogger, ok := ctx.Value(reqLoggerKey).(log.FieldLogger)
 	if !ok {
 		return nil
 	}

--- a/glusterd2/middleware/request_id.go
+++ b/glusterd2/middleware/request_id.go
@@ -21,8 +21,8 @@ func ReqIDGenerator(next http.Handler) http.Handler {
 		w.Header().Set("X-Request-ID", reqID.String())
 
 		// Create request-scoped logger and set in request context
-		reqLogger := log.WithField("reqid", reqID.String())
-		ctx = gdctx.WithReqLogger(ctx, reqLogger)
+		reqLoggerEntry := log.WithField("reqid", reqID.String())
+		ctx = gdctx.WithReqLogger(ctx, reqLoggerEntry)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/glusterd2/middleware/request_logging.go
+++ b/glusterd2/middleware/request_logging.go
@@ -14,8 +14,8 @@ import (
 // Apache Common Log Format (CLF)
 func LogRequest(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		l := log.WithField("reqid", gdctx.GetReqID(r.Context()).String())
-		delete(l.Data, logging.SourceField)
-		handlers.LoggingHandler(l.Writer(), next).ServeHTTP(w, r)
+		entry := log.WithField("reqid", gdctx.GetReqID(r.Context()).String())
+		delete(entry.Data, logging.SourceField)
+		handlers.LoggingHandler(entry.Writer(), next).ServeHTTP(w, r)
 	})
 }

--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -102,6 +103,9 @@ func CreateLockFuncs(key string) (LockUnlockFunc, LockUnlockFunc) {
 
 	lockFunc := func(ctx context.Context) error {
 		logger := gdctx.GetReqLogger(ctx)
+		if logger == nil {
+			logger = log.StandardLogger()
+		}
 
 		ctx, cancel := context.WithTimeout(ctx, lockObtainTimeout)
 		defer cancel()
@@ -122,6 +126,9 @@ func CreateLockFuncs(key string) (LockUnlockFunc, LockUnlockFunc) {
 
 	unlockFunc := func(ctx context.Context) error {
 		logger := gdctx.GetReqLogger(ctx)
+		if logger == nil {
+			logger = log.StandardLogger()
+		}
 
 		logger.WithField("key", key).Debug("attempting to unlock")
 		if err := locker.Unlock(context.Background()); err != nil {


### PR DESCRIPTION
Request logger was eariler being set to logrus.Entry type.

With this change, request logger is set to logrus.FieldLogger which is
an interface and logrus.Entry implements this interface. Further,
renamed variables to make difference between logger and entry more
clear.

This change also fixes a crash in transaction.CreateLockFuncs() which
occurs when logger is nil. Logger will be nil if context passed is
not derived from the REST request.

Signed-off-by: Prashanth Pai <ppai@redhat.com>