### PR TITLE
New transaction locking mechanisms

### DIFF
--- a/glusterd2/commands/peers/editpeer.go
+++ b/glusterd2/commands/peers/editpeer.go
@@ -41,7 +41,7 @@ func editPeer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 	lock, unlock, err := transaction.CreateLockSteps(peerID)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)

--- a/glusterd2/commands/peers/editpeer.go
+++ b/glusterd2/commands/peers/editpeer.go
@@ -40,21 +40,22 @@ func editPeer(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-	lock, unlock, err := transaction.CreateLockSteps(peerID)
+	txn, err := transaction.NewTxnWithLocks(ctx, peerID)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
 		return
 	}
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "peer-edit",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
 		},
-		unlock,
 	}
 	err = txn.Ctx.Set("peerid", peerID)
 	if err != nil {

--- a/glusterd2/commands/volumes/bricks-status.go
+++ b/glusterd2/commands/volumes/bricks-status.go
@@ -80,7 +80,7 @@ func volumeBricksStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 	txn.Steps = []*transaction.Step{
 		{
 			DoFunc: "bricks-status.Check",

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -117,7 +117,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	lock, unlock, err := transaction.CreateLockSteps(req.Name)
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -116,17 +116,18 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	lock, unlock, err := transaction.CreateLockSteps(req.Name)
+	txn, err := transaction.NewTxnWithLocks(ctx, req.Name)
 	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
 		return
 	}
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "vol-create.CreateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -145,7 +146,6 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 			UndoFunc: "vol-create.UndoStoreVolume",
 			Nodes:    []uuid.UUID{gdctx.MyUUID},
 		},
-		unlock,
 	}
 
 	if err := txn.Ctx.Set("req", &req); err != nil {

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -66,10 +66,8 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	logger := gdctx.GetReqLogger(ctx)
 	volname := mux.Vars(r)["volname"]
 
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	// Taking a lock outside the txn as volinfo.Nodes() must also
-	// be populated holding the lock. See issue #510
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -77,7 +75,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
@@ -94,9 +92,6 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errMsg)
 		return
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -96,7 +96,7 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-edit.go
+++ b/glusterd2/commands/volumes/volume-edit.go
@@ -29,8 +29,8 @@ func volumeEditHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//Lock on Volume Name
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -38,7 +38,7 @@ func volumeEditHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	//validate volume name
 	volinfo, err := volume.GetVolume(volname)

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -66,6 +66,17 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
@@ -86,15 +97,6 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	lock, unlock, err := transaction.CreateLockSteps(volname)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
 	nodes, err := req.Nodes()
 	if err != nil {
 		logger.WithError(err).Error("could not prepare node list")
@@ -113,7 +115,6 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		// TODO: This is a lot of steps. We can combine a few if we
 		// do not re-use the same step functions across multiple
 		// volume operations.
-		lock,
 		{
 			DoFunc: "vol-expand.ValidateAndPrepare",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -140,7 +141,6 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "vol-expand.NotifyClients",
 			Nodes:  allNodes,
 		},
-		unlock,
 	}
 
 	if err := txn.Ctx.Set("req", &req); err != nil {

--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -93,7 +93,7 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	nodes, err := req.Nodes()
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -158,10 +158,8 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	// Taking a lock outside the txn as volinfo.Nodes() must also
-	// be populated holding the lock.
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -169,7 +167,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
@@ -180,9 +178,6 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	allNodes, err := peer.GetPeerIDs()
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -182,7 +182,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	allNodes, err := peer.GetPeerIDs()
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -107,7 +107,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-start.go
+++ b/glusterd2/commands/volumes/volume-start.go
@@ -78,10 +78,8 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	// Taking a lock outside the txn as volinfo.Nodes() must also
-	// be populated holding the lock. See issue #510
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -89,7 +87,7 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
@@ -105,9 +103,6 @@ func volumeStartHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStarted)
 		return
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-statedump.go
+++ b/glusterd2/commands/volumes/volume-statedump.go
@@ -130,7 +130,7 @@ func volumeStatedumpHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-statedump.go
+++ b/glusterd2/commands/volumes/volume-statedump.go
@@ -103,8 +103,8 @@ func volumeStatedumpHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -112,7 +112,7 @@ func volumeStatedumpHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
@@ -128,9 +128,6 @@ func volumeStatedumpHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, gderrors.ErrVolNotStarted)
 		return
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -76,10 +76,8 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	logger := gdctx.GetReqLogger(ctx)
 	volname := mux.Vars(r)["volname"]
 
-	lock, unlock := transaction.CreateLockFuncs(volname)
-	// Taking a lock outside the txn as volinfo.Nodes() must also
-	// be populated holding the lock. See issue #510
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -87,7 +85,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
@@ -103,9 +101,6 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrVolAlreadyStopped)
 		return
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/volumes/volume-stop.go
+++ b/glusterd2/commands/volumes/volume-stop.go
@@ -105,7 +105,7 @@ func volumeStopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"time"
 
-	"github.com/gluster/glusterd2/glusterd2/gdctx"
 	"github.com/gluster/glusterd2/glusterd2/store"
 
 	"github.com/coreos/etcd/clientv3/concurrency"
-	"github.com/pborman/uuid"
 )
 
 const (
@@ -24,70 +22,6 @@ var (
 	// ErrLockExists is returned when a lock already exists within the transaction
 	ErrLockExists = errors.New("existing lock found for given lock ID")
 )
-
-// createLockStepFunc returns the registry IDs of StepFuncs which lock/unlock the given key.
-// If existing StepFuncs are not found, new funcs are created and registered.
-func createLockStepFunc(key string) (string, string, error) {
-	lockFuncID := key + ".Lock"
-	unlockFuncID := key + ".Unlock"
-
-	_, lockFuncFound := getStepFunc(lockFuncID)
-	_, unlockFuncFound := getStepFunc(unlockFuncID)
-
-	if lockFuncFound && unlockFuncFound {
-		return lockFuncID, unlockFuncID, nil
-	}
-
-	key = lockPrefix + key
-	locker := concurrency.NewMutex(store.Store.Session, key)
-
-	lockFunc := func(c TxnCtx) error {
-
-		ctx, cancel := context.WithTimeout(context.Background(), lockObtainTimeout)
-		defer cancel()
-
-		c.Logger().WithField("key", key).Debug("attempting to lock")
-		err := locker.Lock(ctx)
-		switch err {
-		case nil:
-			c.Logger().WithField("key", key).Debug("lock obtained")
-		case context.DeadlineExceeded:
-			// Propagate this all the way back to the client as a HTTP 409 response
-			c.Logger().WithField("key", key).Debug("timeout: failed to obtain lock")
-			err = ErrLockTimeout
-		}
-
-		return err
-	}
-	RegisterStepFunc(lockFunc, lockFuncID)
-
-	unlockFunc := func(c TxnCtx) error {
-
-		c.Logger().WithField("key", key).Debug("attempting to unlock")
-		err := locker.Unlock(context.Background())
-		if err == nil {
-			c.Logger().WithField("key", key).Debug("lock unlocked")
-		}
-
-		return err
-	}
-	RegisterStepFunc(unlockFunc, unlockFuncID)
-
-	return lockFuncID, unlockFuncID, nil
-}
-
-// CreateLockSteps returns a lock and an unlock Step which lock/unlock the given key
-func CreateLockSteps(key string) (*Step, *Step, error) {
-	lockFunc, unlockFunc, err := createLockStepFunc(key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	lockStep := &Step{lockFunc, unlockFunc, []uuid.UUID{gdctx.MyUUID}, false}
-	unlockStep := &Step{unlockFunc, "", []uuid.UUID{gdctx.MyUUID}, false}
-
-	return lockStep, unlockStep, nil
-}
 
 func (t *Txn) lock(lockID string) error {
 	// Ensure that no prior lock exists for the given lockID in this transaction

--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -18,9 +18,13 @@ const (
 	lockObtainTimeout = 5 * time.Second
 )
 
-// ErrLockTimeout is the error returned when lock could not be obtained
-// and the request timed out
-var ErrLockTimeout = errors.New("could not obtain lock: another conflicting transaction may be in progress")
+var (
+	// ErrLockTimeout is the error returned when lock could not be obtained
+	// and the request timed out
+	ErrLockTimeout = errors.New("could not obtain lock: another conflicting transaction may be in progress")
+	// ErrLockExists is returned when a lock already exists within the transaction
+	ErrLockExists = errors.New("existing lock found for given lock ID")
+)
 
 // createLockStepFunc returns the registry IDs of StepFuncs which lock/unlock the given key.
 // If existing StepFuncs are not found, new funcs are created and registered.
@@ -141,4 +145,52 @@ func CreateLockFuncs(key string) (LockUnlockFunc, LockUnlockFunc) {
 	}
 
 	return lockFunc, unlockFunc
+}
+
+func (t *Txn) lock(lockID string) error {
+	// Ensure that no prior lock exists for the given lockID in this transaction
+	if _, ok := t.locks[lockID]; ok {
+		return ErrLockExists
+	}
+
+	logger := t.Ctx.Logger().WithField("lockID", lockID)
+	logger.Debug("attempting to obtain lock")
+
+	key := lockPrefix + lockID
+	locker := concurrency.NewMutex(store.Store.Session, key)
+
+	ctx, cancel := context.WithTimeout(store.Store.Ctx(), lockObtainTimeout)
+	defer cancel()
+
+	err := locker.Lock(ctx)
+	switch err {
+	case nil:
+		logger.Debug("lock obtained")
+		// Attach lock to the transaction
+		t.locks[lockID] = locker
+
+	case context.DeadlineExceeded:
+		// Propagate this all the way back to the client as a HTTP 409 response
+		logger.Debug("timeout: failed to obtain lock")
+		err = ErrLockTimeout
+
+	default:
+		logger.WithError(err).Error("failed to obtain lock")
+	}
+
+	return err
+}
+
+// Lock obtains a cluster wide transaction lock on the given lockID/lockIDs,
+// and attaches the obtained locks to the transaction
+func (t *Txn) Lock(lockID string, lockIDs ...string) error {
+	if err := t.lock(lockID); err != nil {
+		return err
+	}
+	for _, id := range lockIDs {
+		if err := t.lock(id); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pborman/uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -88,63 +87,6 @@ func CreateLockSteps(key string) (*Step, *Step, error) {
 	unlockStep := &Step{unlockFunc, "", []uuid.UUID{gdctx.MyUUID}, false}
 
 	return lockStep, unlockStep, nil
-}
-
-// LockUnlockFunc is signature of functions used for distributed locking
-// and unlocking.
-type LockUnlockFunc func(ctx context.Context) error
-
-// CreateLockFuncs creates and returns functions for distributed lock and
-// unlock. This is similar to CreateLockSteps() but returns normal functions.
-func CreateLockFuncs(key string) (LockUnlockFunc, LockUnlockFunc) {
-
-	key = lockPrefix + key
-	locker := concurrency.NewMutex(store.Store.Session, key)
-
-	// TODO: There is an opportunity for refactor here to re-use code
-	// between CreateLockFunc and CreateLockSteps. This variant doesn't
-	// have registry either.
-
-	lockFunc := func(ctx context.Context) error {
-		logger := gdctx.GetReqLogger(ctx)
-		if logger == nil {
-			logger = log.StandardLogger()
-		}
-
-		ctx, cancel := context.WithTimeout(ctx, lockObtainTimeout)
-		defer cancel()
-
-		logger.WithField("key", key).Debug("attempting to lock")
-		err := locker.Lock(ctx)
-		switch err {
-		case nil:
-			logger.WithField("key", key).Debug("lock obtained")
-		case context.DeadlineExceeded:
-			// Propagate this all the way back to the client as a HTTP 409 response
-			logger.WithField("key", key).Debug("timeout: failed to obtain lock")
-			err = ErrLockTimeout
-		}
-
-		return err
-	}
-
-	unlockFunc := func(ctx context.Context) error {
-		logger := gdctx.GetReqLogger(ctx)
-		if logger == nil {
-			logger = log.StandardLogger()
-		}
-
-		logger.WithField("key", key).Debug("attempting to unlock")
-		if err := locker.Unlock(context.Background()); err != nil {
-			logger.WithField("key", key).WithError(err).Error("unlock failed")
-			return err
-		}
-
-		logger.WithField("key", key).Debug("lock unlocked")
-		return nil
-	}
-
-	return lockFunc, unlockFunc
 }
 
 func (t *Txn) lock(lockID string) error {

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -54,6 +54,7 @@ func NewTxn(ctx context.Context) *Txn {
 	}).WithPrefix(prefix)
 
 	t.Ctx.Logger().Debug("new transaction created")
+	expTxn.Add("initiated_txn_in_progress", 1)
 	return t
 }
 
@@ -71,12 +72,6 @@ func NewTxnWithLocks(ctx context.Context, lockIDs ...string) *Txn {
 	return t
 }
 
-// Cleanup cleans the leftovers after a transaction ends
-func (t *Txn) Cleanup() {
-	store.Store.Delete(context.TODO(), t.Ctx.Prefix(), clientv3.WithPrefix())
-	expTxn.Add("initiated_txn_in_progress", -1)
-}
-
 // Done releases any obtained locks and cleans up the transaction namespace
 // Done must be called after a transaction ends
 func (t *Txn) Done() {
@@ -84,7 +79,8 @@ func (t *Txn) Done() {
 	for _, locker := range t.locks {
 		locker.Unlock(context.Background())
 	}
-	t.Cleanup()
+	store.Store.Delete(context.TODO(), t.Ctx.Prefix(), clientv3.WithPrefix())
+	expTxn.Add("initiated_txn_in_progress", -1)
 }
 
 func (t *Txn) checkAlive() error {
@@ -115,7 +111,6 @@ func (t *Txn) Do() error {
 	}
 
 	t.Ctx.Logger().Debug("Starting transaction")
-	expTxn.Add("initiated_txn_in_progress", 1)
 
 	for i, s := range t.Steps {
 		if s.Skip {

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -59,17 +59,17 @@ func NewTxn(ctx context.Context) *Txn {
 }
 
 // NewTxnWithLocks returns an empty Txn with locks obtained on given lockIDs
-func NewTxnWithLocks(ctx context.Context, lockIDs ...string) *Txn {
+func NewTxnWithLocks(ctx context.Context, lockIDs ...string) (*Txn, error) {
 	t := NewTxn(ctx)
 
 	for _, id := range lockIDs {
 		if err := t.Lock(id); err != nil {
 			t.Done()
-			return nil
+			return nil, err
 		}
 	}
 
-	return t
+	return t, nil
 }
 
 // Done releases any obtained locks and cleans up the transaction namespace

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/store"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -24,6 +25,8 @@ var expTxn = expvar.NewMap("txn")
 type Txn struct {
 	id    uuid.UUID
 	reqID uuid.UUID
+	locks map[string]*concurrency.Mutex
+
 	Ctx   TxnCtx
 	Steps []*Step
 
@@ -39,13 +42,31 @@ type Txn struct {
 // NewTxn returns an initialized Txn without any steps
 func NewTxn(ctx context.Context) *Txn {
 	t := new(Txn)
+
 	t.id = uuid.NewRandom()
 	t.reqID = gdctx.GetReqID(ctx)
+	t.locks = make(map[string]*concurrency.Mutex)
+
 	prefix := txnPrefix + t.id.String()
 	t.Ctx = NewCtxWithLogFields(log.Fields{
 		"txnid": t.id.String(),
 		"reqid": t.reqID.String(),
 	}).WithPrefix(prefix)
+
+	t.Ctx.Logger().Debug("new transaction created")
+	return t
+}
+
+// NewTxnWithLocks returns an empty Txn with locks obtained on given lockIDs
+func NewTxnWithLocks(ctx context.Context, lockIDs ...string) *Txn {
+	t := NewTxn(ctx)
+
+	for _, id := range lockIDs {
+		if err := t.Lock(id); err != nil {
+			t.Done()
+			return nil
+		}
+	}
 
 	return t
 }
@@ -54,6 +75,16 @@ func NewTxn(ctx context.Context) *Txn {
 func (t *Txn) Cleanup() {
 	store.Store.Delete(context.TODO(), t.Ctx.Prefix(), clientv3.WithPrefix())
 	expTxn.Add("initiated_txn_in_progress", -1)
+}
+
+// Done releases any obtained locks and cleans up the transaction namespace
+// Done must be called after a transaction ends
+func (t *Txn) Done() {
+	// Release obtained locks
+	for _, locker := range t.locks {
+		locker.Unlock(context.Background())
+	}
+	t.Cleanup()
 }
 
 func (t *Txn) checkAlive() error {

--- a/plugins/bitrot/rest.go
+++ b/plugins/bitrot/rest.go
@@ -25,6 +25,17 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volName)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
@@ -55,26 +66,14 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 	   scrubber othewise bitd */
 	volinfo.Options[keyFeaturesScrub] = "true"
 
-	// Transaction which starts bitd and scrubber on all nodes.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
-	//Lock on Volume Name
-	lock, unlock, err := transaction.CreateLockSteps(volName)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = volinfo.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "vol-option.UpdateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -84,12 +83,10 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "vol-option.NotifyVolfileChange",
 			Nodes:  txn.Nodes,
 		},
-
 		{
 			DoFunc: "bitrot-enable.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	err = txn.Do()
@@ -116,6 +113,17 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volName)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
@@ -138,26 +146,14 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 	// Disable scrub by updating volinfo Options
 	volinfo.Options[keyFeaturesScrub] = "false"
 
-	// Transaction which stop bitd and scrubber on all nodes.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
-	//Lock on Volume Name
-	lock, unlock, err := transaction.CreateLockSteps(volName)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = volinfo.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "vol-option.UpdateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -171,7 +167,6 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "bitrot-disable.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	err = txn.Do()
@@ -196,6 +191,17 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volName)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
 	if err != nil {
@@ -219,25 +225,12 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transaction which starts scrubber on demand.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	//Lock on Volume Name
-	lock, unlock, err := transaction.CreateLockSteps(volName)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = volinfo.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "bitrot-scrubondemand.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 	txn.Ctx.Set("volname", volName)
 
@@ -260,6 +253,17 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
+
+	txn, err := transaction.NewTxnWithLocks(ctx, volName)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
 
 	// Validate volume existence
 	volinfo, err := volume.GetVolume(volName)
@@ -286,30 +290,16 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transaction which gets scrubber status.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	//Lock on Volume Name
-	lock, unlock, err := transaction.CreateLockSteps(volName)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError,
-			err)
-		return
-	}
-
 	// Some nodes may not be up, which is okay.
 	txn.DontCheckAlive = true
 	txn.DisableRollback = true
 
 	txn.Nodes = volinfo.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "bitrot-scrubstatus.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 	txn.Ctx.Set("volname", volName)
 

--- a/plugins/bitrot/rest.go
+++ b/plugins/bitrot/rest.go
@@ -57,7 +57,7 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which starts bitd and scrubber on all nodes.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
@@ -140,7 +140,7 @@ func bitrotDisableHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which stop bitd and scrubber on all nodes.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	if err := txn.Ctx.Set("volinfo", volinfo); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
@@ -221,7 +221,7 @@ func bitrotScrubOndemandHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which starts scrubber on demand.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volName)
@@ -288,7 +288,7 @@ func bitrotScrubStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which gets scrubber status.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volName)

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -33,8 +33,8 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lock, unlock := transaction.CreateLockFuncs(peerID)
-	if err := lock(ctx); err != nil {
+	txn, err := transaction.NewTxnWithLocks(ctx, peerID)
+	if err != nil {
 		if err == transaction.ErrLockTimeout {
 			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
 		} else {
@@ -42,7 +42,7 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer unlock(ctx)
+	defer txn.Done()
 
 	peerInfo, err := peer.GetPeer(peerID)
 	if err != nil {
@@ -69,9 +69,6 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
 
 	txn.Nodes = []uuid.UUID{peerInfo.ID}
 	txn.Steps = []*transaction.Step{

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -71,7 +71,7 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Nodes = []uuid.UUID{peerInfo.ID}
 	txn.Steps = []*transaction.Step{

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -160,7 +160,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which updates the Geo-rep session
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
@@ -292,7 +292,7 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
@@ -424,7 +424,7 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
@@ -514,7 +514,7 @@ func georepStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Status Transaction
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
@@ -785,7 +785,7 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 	// TODO: change the lock key
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
@@ -927,7 +927,7 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 	// TODO: change the lock key
 	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
 	if err != nil {
@@ -1024,7 +1024,7 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which updates the Geo-rep session
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(volname)
@@ -1120,7 +1120,7 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which updates the Geo-rep session
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	// Lock on Master Volume name
 	lock, unlock, err := transaction.CreateLockSteps(volname)

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -110,6 +110,17 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, req.MasterVol)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Check if Master volume exists and Matches with passed Volume ID
 	vol, e := volume.GetVolume(req.MasterVol)
 	if e != nil {
@@ -158,17 +169,6 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 		geoSession.Options["gluster-logdir"] = path.Join(config.GetString("logdir"), "glusterfs")
 	}
 
-	// Transaction which updates the Geo-rep session
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	// Lock on Master Volume name
-	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	// Required Volume Options
 	vol.Options["marker.xtime"] = "on"
 	vol.Options["marker.gsync-force-xtime"] = "on"
@@ -179,7 +179,6 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "vol-option.UpdateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -192,7 +191,6 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "georeplication-create.Commit",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("geosession", geoSession); err != nil {
@@ -275,6 +273,17 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 		return
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, geoSession.MasterVol)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Fetch Volume details and check if Volume is in started state
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
@@ -288,15 +297,6 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 
 	if action == actionStart && vol.State != volume.VolStarted {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "master volume not started")
-		return
-	}
-
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -326,12 +326,10 @@ func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionTy
 	}
 
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: doFunc,
 			Nodes:  vol.Nodes(),
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
@@ -412,6 +410,17 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, geoSession.MasterVol)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Fetch Volume details and check if Volume exists
 	_, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
@@ -423,23 +432,12 @@ func georepDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	// TODO: Add transaction step to clean xattrs specific to georep session
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "georeplication-delete.Commit",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
@@ -759,6 +757,17 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, geoSession.MasterVol)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
 		if err == errors.ErrVolNotFound {
@@ -784,18 +793,8 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 		geoSession.Options[k] = v
 	}
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-	// TODO: change the lock key
-	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "georeplication-configset.Commit",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -804,7 +803,6 @@ func georepConfigSetHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "georeplication-configfilegen.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
@@ -912,6 +910,17 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 		restartRequired = false
 	}
 
+	txn, err := transaction.NewTxnWithLocks(ctx, geoSession.MasterVol)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	vol, e := volume.GetVolume(geoSession.MasterVol)
 	if e != nil {
 		if err == errors.ErrVolNotFound {
@@ -926,18 +935,8 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 		delete(geoSession.Options, k)
 	}
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-	// TODO: change the lock key
-	lock, unlock, err := transaction.CreateLockSteps(geoSession.MasterVol)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "georeplication-configset.Commit",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -946,7 +945,6 @@ func georepConfigResetHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "georeplication-configfilegen.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("mastervolid", masterid.String()); err != nil {
@@ -1011,6 +1009,17 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Check if Volume exists
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
@@ -1022,25 +1031,12 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transaction which updates the Geo-rep session
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	// Lock on Master Volume name
-	lock, unlock, err := transaction.CreateLockSteps(volname)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "georeplication-ssh-keygen.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("volname", volname); err != nil {
@@ -1100,6 +1096,17 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Check if Volume exists
 	vol, e := volume.GetVolume(volname)
 	if e != nil {
@@ -1118,25 +1125,12 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transaction which updates the Geo-rep session
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	// Lock on Master Volume name
-	lock, unlock, err := transaction.CreateLockSteps(volname)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "georeplication-ssh-keypush.Commit",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err = txn.Ctx.Set("sshkeys", sshkeys); err != nil {

--- a/plugins/glustershd/rest.go
+++ b/plugins/glustershd/rest.go
@@ -58,7 +58,7 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Transaction which starts self heal daemon on all nodes with atleast one brick.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	//Lock on Volume Name
 	lock, unlock, err := transaction.CreateLockSteps(volname)
@@ -140,7 +140,7 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 	// Transaction which checks if all replicate volumes are stopped before
 	// stopping the self-heal daemon.
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	// Lock on volume name.
 	lock, unlock, err := transaction.CreateLockSteps(volname)

--- a/plugins/glustershd/rest.go
+++ b/plugins/glustershd/rest.go
@@ -30,6 +30,17 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	//validate volume name
 	v, err := volume.GetVolume(volname)
 	if err != nil {
@@ -56,22 +67,10 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	// Transaction which starts self heal daemon on all nodes with atleast one brick.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	//Lock on Volume Name
-	lock, unlock, err := transaction.CreateLockSteps(volname)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	v.HealEnabled = true
 
 	txn.Nodes = v.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc:   "vol-option.UpdateVolinfo",
 			Nodes:    []uuid.UUID{gdctx.MyUUID},
@@ -85,7 +84,6 @@ func glustershEnableHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "vol-option.NotifyVolfileChange",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err := txn.Ctx.Set("volinfo", v); err != nil {
@@ -117,6 +115,17 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volname)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	//validate volume name
 	v, err := volume.GetVolume(volname)
 	if err != nil {
@@ -137,23 +146,10 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transaction which checks if all replicate volumes are stopped before
-	// stopping the self-heal daemon.
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
-	// Lock on volume name.
-	lock, unlock, err := transaction.CreateLockSteps(volname)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	v.HealEnabled = false
 
 	txn.Nodes = v.Nodes()
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc:   "vol-option.UpdateVolinfo",
 			Nodes:    []uuid.UUID{gdctx.MyUUID},
@@ -168,7 +164,6 @@ func glustershDisableHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "vol-option.NotifyVolfileChange",
 			Nodes:  txn.Nodes,
 		},
-		unlock,
 	}
 
 	if err := txn.Ctx.Set("volinfo", v); err != nil {

--- a/plugins/quota/rest.go
+++ b/plugins/quota/rest.go
@@ -47,6 +47,17 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := gdctx.GetReqLogger(ctx)
 
+	txn, err := transaction.NewTxnWithLocks(ctx, volName)
+	if err != nil {
+		if err == transaction.ErrLockTimeout {
+			restutils.SendHTTPError(ctx, w, http.StatusConflict, err)
+		} else {
+			restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	defer txn.Done()
+
 	// Validate volume existence
 	vol, err := volume.GetVolume(volName)
 	if err != nil {
@@ -73,23 +84,13 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 	// Enable quota
 	vol.Options[quotaEnabledKey] = "on"
 
-	txn := transaction.NewTxn(ctx)
-	defer txn.Done()
-
 	if err := txn.Ctx.Set("volinfo", vol); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
-	lock, unlock, err := transaction.CreateLockSteps(volName)
-	if err != nil {
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
-		return
-	}
-
 	txn.Steps = []*transaction.Step{
-		lock,
 		{
 			DoFunc: "vol-option.UpdateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
@@ -98,7 +99,6 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc: "quota-enable.DaemonStart",
 			Nodes:  vol.Nodes(),
 		},
-		unlock,
 	}
 
 	err = txn.Do()

--- a/plugins/quota/rest.go
+++ b/plugins/quota/rest.go
@@ -74,7 +74,7 @@ func quotaEnableHandler(w http.ResponseWriter, r *http.Request) {
 	vol.Options[quotaEnabledKey] = "on"
 
 	txn := transaction.NewTxn(ctx)
-	defer txn.Cleanup()
+	defer txn.Done()
 
 	if err := txn.Ctx.Set("volinfo", vol); err != nil {
 		logger.WithError(err).Error("failed to set volinfo in transaction context")


### PR DESCRIPTION
This PR introduces a new NewTxnWithLocks function and a (*Txn).Lock method.

With this change, support for having locking as part of transaction steps has
been removed. Doing locks within steps could lead to TOCTOU race problems, as
in several cases, volinfos would be fetched/modified in the rest handler before
the transaction steps were performed.

@prashanthpai started doing changes with regards to the TOCTOU problem with
them.

With this change, users now need to explicitly create a transaction and obtain
locks on the required IDs before fetching/modifying stored data in the rest
handlers.

The rest of the transaction framework remains as is.