### PR TITLE
nightly-rpms: Use /usr/bin/mock instead of mock

### DIFF
--- a/extras/nightly-rpms.sh
+++ b/extras/nightly-rpms.sh
@@ -73,7 +73,7 @@ SRPM=$(rpmbuild --define "_topdir $PWD/rpmbuild" -bs rpmbuild/SPECS/$SPEC | cut 
 
 # Build RPM from SRPM using mock
 mkdir -p "$RESULTDIR"
-mock -r epel-7-x86_64 --resultdir="$RESULTDIR" --rebuild "$SRPM"
+/usr/bin/mock -r epel-7-x86_64 --resultdir="$RESULTDIR" --rebuild "$SRPM"
 
 popd #BUILDDIR
 


### PR DESCRIPTION
Using `mock` on CentOS/Fedora as root resolves it to /sbin/mock, which
only works if a mock user has been setup. Forcing the use of
/usr/bin/mock makes this work always.