### PR TITLE
Fix 100% CPU usage after peer add

### DIFF
--- a/glusterd2/commands/peers/peer-rpc-svc.go
+++ b/glusterd2/commands/peers/peer-rpc-svc.go
@@ -157,8 +157,8 @@ func ReconfigureStore(c *StoreConfig) error {
 	// Destroy the current store first
 	log.Debug("destroying current store")
 
-	// Stop global events listener
-	events.StopGlobal()
+	// Stop events framework
+	events.Stop()
 
 	store.Destroy()
 	// TODO: Also need to destroy any old files in localstatedir (eg. volfiles)
@@ -193,8 +193,8 @@ func ReconfigureStore(c *StoreConfig) error {
 	}
 	log.Debug("added details of self to store")
 
-	// Now that new store is up, start global events listener
-	events.StartGlobal()
+	// Now that new store is up, start events framework
+	events.Start()
 
 	return nil
 }


### PR DESCRIPTION
When a peer gets a request to join a cluster, only the global events
listener was being shutdown, and not the entire events framework. This
resulted in the liveness watcher to continue running which became an
infinite loop because the etcd watch channel won't block.

```go
    wch := store.Store.Watch(...)
    for {
            select {
                case resp := <-wch: // this wouldn't block
                    ...
                case <-l.stopCh:
                    return
            }
    }
```

This change will ensure that the entire events framework including
the liveness watcher shuts down before the store access shuts down.

Closes #817 

Signed-off-by: Prashanth Pai <ppai@redhat.com>