### PR TITLE
added undo function  to revert back volinfo changes

### DIFF
--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -232,9 +232,13 @@ func undoInitBricks(c transaction.TxnCtx) error {
 
 // StoreVolume uses to store the volinfo and to generate client volfile
 func storeVolume(c transaction.TxnCtx) error {
+	return storeVolInfo(c, "volinfo")
+}
 
+// storeVolInfo uses to store the volinfo based on key and to generate client volfile
+func storeVolInfo(c transaction.TxnCtx, key string) error {
 	var volinfo volume.Volinfo
-	if err := c.Get("volinfo", &volinfo); err != nil {
+	if err := c.Get(key, &volinfo); err != nil {
 		c.Logger().WithError(err).WithField(
 			"key", "volinfo").Debug("Failed to get key from store")
 		return err
@@ -253,6 +257,11 @@ func storeVolume(c transaction.TxnCtx) error {
 	}
 
 	return nil
+}
+
+// undoStoreVolume revert back volinfo and to generate client volfile
+func undoStoreVolume(c transaction.TxnCtx) error {
+	return storeVolInfo(c, "oldvolinfo")
 }
 
 // LoadDefaultGroupOptions loads the default group option map into the store

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -139,6 +139,7 @@ func registerVolOptionStepFuncs() {
 		{"vol-option.XlatorActionDoSet", xlatorActionDoSet},
 		{"vol-option.XlatorActionUndoSet", xlatorActionUndoSet},
 		{"vol-option.UpdateVolinfo", storeVolume},
+		{"vol-option.UpdateVolinfo.Undo", undoStoreVolume},
 		{"vol-option.NotifyVolfileChange", notifyVolfileChange},
 	}
 	for _, sf := range sfs {

--- a/plugins/bitrot/rest.go
+++ b/plugins/bitrot/rest.go
@@ -58,7 +58,12 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrBitrotAlreadyEnabled)
 		return
 	}
-
+	//save volume information for transaction failure scenario
+	if err := txn.Ctx.Set("oldvolinfo", volinfo); err != nil {
+		logger.WithError(err).Error("failed to set oldvolinfo in transaction context")
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
 	// Enable bitrot-stub
 	volinfo.Options[keyFeaturesBitrot] = "on"
 
@@ -75,8 +80,9 @@ func bitrotEnableHandler(w http.ResponseWriter, r *http.Request) {
 	txn.Nodes = volinfo.Nodes()
 	txn.Steps = []*transaction.Step{
 		{
-			DoFunc: "vol-option.UpdateVolinfo",
-			Nodes:  []uuid.UUID{gdctx.MyUUID},
+			DoFunc:   "vol-option.UpdateVolinfo",
+			UndoFunc: "vol-option.UpdateVolinfo.Undo",
+			Nodes:    []uuid.UUID{gdctx.MyUUID},
 		},
 		{
 			// Required because bitrot-stub should be enabled on brick side


### PR DESCRIPTION
In case of bitrot enable transaction failure, we need to revert back the updated volume
information.

Updates #815 

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>