### PR TITLE
txn context: Add store access counters

### DIFF
--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -163,8 +163,6 @@ func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
 
 func createVolinfo(c transaction.TxnCtx) error {
 
-	// TODO: Reduce the number of txn.Set calls.
-
 	var req api.VolCreateReq
 	if err := c.Get("req", &req); err != nil {
 		return err
@@ -187,10 +185,6 @@ func createVolinfo(c transaction.TxnCtx) error {
 		return err
 	}
 
-	// TODO: Volinfo already has this info. Right now, the key "bricks"
-	// is set separately to reuse the same step function (validateBricks)
-	// later in volume expand. Consider duplicating that code if store
-	// access turns out to be expensive.
 	if err := c.Set("bricks", volinfo.GetBricks()); err != nil {
 		return err
 	}

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -109,6 +109,8 @@ func (c *Tctx) commit() error {
 		return err
 	}
 
+	expTxn.Add("txn_ctx_store_commit", 1)
+
 	c.readCacheDirty = true
 
 	return nil
@@ -133,6 +135,7 @@ func (c *Tctx) Get(key string, value interface{}) error {
 			c.logger.WithError(err).WithField("key", key).Error("failed to get key from transaction context")
 			return err
 		}
+		expTxn.Add("txn_ctx_store_get", 1)
 		for _, kv := range resp.Kvs {
 			c.readSet[string(kv.Key)] = kv.Value
 		}
@@ -174,6 +177,7 @@ func (c *Tctx) Delete(key string) error {
 			"failed to delete key")
 		return err
 	}
+	expTxn.Add("txn_ctx_store_delete", 1)
 	return nil
 }
 

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -134,6 +134,7 @@ func (t *Txn) Do() error {
 		}
 
 		if err := s.do(t.Ctx); err != nil {
+			expTxn.Add("initiated_txn_failure", 1)
 			if !t.DisableRollback {
 				t.Ctx.Logger().WithError(err).Error("Transaction failed, rolling back changes")
 				t.undo(i)
@@ -142,6 +143,7 @@ func (t *Txn) Do() error {
 		}
 	}
 
+	expTxn.Add("initiated_txn_success", 1)
 	return nil
 }
 


### PR DESCRIPTION
Use expvar package to add metrics about how many times the txn context
accesses store for get and commit (etcd put txn) operations. This
metric is stored on a per instance basis and can be seen via /statedump
API.

Example:
```sh
$ curl -s -X GET http://127.0.0.1:23007/statedump | grep txn
"txn": {"txn_ctx_store_get": 5},

$ curl -s -X GET http://127.0.0.1:24007/statedump | grep txn
"txn": {"initiated_txn_in_progress": 0, "initiated_txn_success": 4, "txn_ctx_store_commit": 12, "txn_ctx_store_get": 8},

$ curl -s -X GET http://127.0.0.1:25007/statedump | grep txn
"txn": {"txn_ctx_store_get": 5},
```
The above example is from a run (create,start,stop,delete volume) on a
3 peer cluster. The second peer (127.0.0.1:24007) is the initiator node
which does most of puts to etcd.

Signed-off-by: Prashanth Pai <ppai@redhat.com>