### PR TITLE
txn: Return detailed error to client

### DIFF
--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -77,7 +77,7 @@ func (g *gdProcess) PeerID() string {
 	}
 
 	// Endpoint doesn't matter here. All responses include a
-	// X-Gluster-Node-Id response header.
+	// X-Gluster-Peer-Id response header.
 	endpoint := fmt.Sprintf("http://%s/version", g.ClientAddress)
 	resp, err := http.Get(endpoint)
 	if err != nil {
@@ -85,7 +85,7 @@ func (g *gdProcess) PeerID() string {
 	}
 	defer resp.Body.Close()
 
-	g.uuid = resp.Header.Get("X-Gluster-Node-Id")
+	g.uuid = resp.Header.Get("X-Gluster-Peer-Id")
 	return g.uuid
 }
 

--- a/glusterd2/middleware/request_id.go
+++ b/glusterd2/middleware/request_id.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
+
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -17,8 +18,10 @@ func ReqIDGenerator(next http.Handler) http.Handler {
 		reqID := uuid.NewRandom()
 		ctx := gdctx.WithReqID(r.Context(), reqID)
 
-		// Also set request ID in the response headers
-		w.Header().Set("X-Request-ID", reqID.String())
+		// Set request ID, peer ID and cluster ID in the response headers
+		w.Header().Set("X-Request-Id", reqID.String())
+		w.Header().Set("X-Gluster-Peer-Id", gdctx.MyUUID.String())
+		w.Header().Set("X-Gluster-Cluster-Id", gdctx.MyClusterID.String())
 
 		// Create request-scoped logger and set in request context
 		reqLoggerEntry := log.WithField("reqid", reqID.String())

--- a/glusterd2/servers/rest/utils/utils.go
+++ b/glusterd2/servers/rest/utils/utils.go
@@ -26,9 +26,6 @@ func SendHTTPResponse(ctx context.Context, w http.ResponseWriter, statusCode int
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	}
 
-	w.Header().Set("X-Gluster-Node-Id", gdctx.MyUUID.String())
-	w.Header().Set("X-Gluster-Cluster-Id", gdctx.MyClusterID.String())
-
 	w.WriteHeader(statusCode)
 
 	if resp != nil {
@@ -49,8 +46,6 @@ func SendHTTPError(ctx context.Context, w http.ResponseWriter, statusCode int,
 	err interface{}, errCodes ...api.ErrorCode) {
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.Header().Set("X-Gluster-Node-Id", gdctx.MyUUID.String())
-	w.Header().Set("X-Gluster-Cluster-Id", gdctx.MyClusterID.String())
 
 	var resp api.ErrorResp
 	if v, ok := err.(api.ErrorResponse); ok {

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -43,6 +43,8 @@ type Tctx struct {
 	writeSet       map[string]string // to be written to store
 }
 
+// txnCtxConfig is marshalled and sent on wire and is used to reconstruct Tctx
+// on receiver's end.
 type txnCtxConfig struct {
 	LogFields   log.Fields
 	StorePrefix string
@@ -198,10 +200,7 @@ func (c *Tctx) UnmarshalJSON(d []byte) error {
 		return err
 	}
 
-	c.logger = log.StandardLogger().WithFields(c.config.LogFields)
-	c.readSet = make(map[string][]byte)
-	c.writeSet = make(map[string]string)
-	c.readCacheDirty = true
+	*c = *(newCtx(c.config))
 
 	return nil
 }

--- a/glusterd2/transaction/rpc-service.go
+++ b/glusterd2/transaction/rpc-service.go
@@ -45,12 +45,12 @@ func (p *txnSvc) RunStep(rpcCtx context.Context, req *TxnStepReq) (*TxnStepResp,
 
 	logger.Debug("executing step function")
 	if err = f(&ctx); err != nil {
-		logger.WithError(err).Debug("step function failed")
+		logger.WithError(err).Error("step function failed")
 		goto End
 	}
 
 	if err = ctx.commit(); err != nil {
-		logger.WithError(err).Debug("failed to commit txn context to store")
+		logger.WithError(err).Error("failed to commit txn context to store")
 	}
 
 End:

--- a/glusterd2/transaction/step.go
+++ b/glusterd2/transaction/step.go
@@ -3,8 +3,10 @@ package transaction
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
+	"github.com/gluster/glusterd2/pkg/api"
 
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
@@ -31,31 +33,68 @@ var (
 )
 
 // do runs the DoFunc on the nodes
-func (s *Step) do(c TxnCtx) error {
-	return runStepFuncOnNodes(s.DoFunc, c, s.Nodes)
+func (s *Step) do(ctx TxnCtx) error {
+	return runStepFuncOnNodes(s.DoFunc, ctx, s.Nodes)
 }
 
 // undo runs the UndoFunc on the nodes
-func (s *Step) undo(c TxnCtx) error {
+func (s *Step) undo(ctx TxnCtx) error {
 	if s.UndoFunc != "" {
-		return runStepFuncOnNodes(s.UndoFunc, c, s.Nodes)
+		return runStepFuncOnNodes(s.UndoFunc, ctx, s.Nodes)
 	}
 	return nil
 }
 
-type stepResp struct {
-	node uuid.UUID
-	step string
-	err  error
+// stepPeerResp is response from a single peer that runs a step
+type stepPeerResp struct {
+	PeerID uuid.UUID
+	Error  error
 }
 
-func runStepFuncOnNodes(stepName string, c TxnCtx, nodes []uuid.UUID) error {
+// stepResp contains response from multiple peers that run a step and the type
+// implements the `api.ErrorResponse` interface
+type stepResp struct {
+	Step     string
+	Resps    []stepPeerResp
+	ErrCount int
+}
 
-	respCh := make(chan stepResp, len(nodes))
+func (r stepResp) Error() string {
+	return fmt.Sprintf("Step %s failed on %d nodes", r.Step, r.ErrCount)
+}
+
+func (r stepResp) Response() api.ErrorResp {
+
+	apiResp := api.ErrorResp{
+		Errors: make([]api.HTTPError, r.ErrCount),
+	}
+
+	i := 0
+	for _, resp := range r.Resps {
+		if resp.Error == nil {
+			continue
+		}
+		apiResp.Errors[i] = api.HTTPError{
+			Code: int(api.ErrTxnStepFailed),
+			Message: fmt.Sprintf("Step %s failed on peer %s with error: %s",
+				r.Step, resp.PeerID, resp.Error)}
+		i++
+	}
+
+	return apiResp
+}
+
+func (r stepResp) Status() int {
+	return http.StatusInternalServerError
+}
+
+func runStepFuncOnNodes(stepName string, ctx TxnCtx, nodes []uuid.UUID) error {
+
+	respCh := make(chan stepPeerResp, len(nodes))
 	defer close(respCh)
 
 	for _, node := range nodes {
-		go runStepFuncOnNode(stepName, c, node, respCh)
+		go runStepFuncOnNode(stepName, ctx, node, respCh)
 	}
 
 	// Ideally, we have to cancel the pending go-routines on first error
@@ -63,30 +102,31 @@ func runStepFuncOnNodes(stepName string, c TxnCtx, nodes []uuid.UUID) error {
 	// to do. Serializing sequentially is the easiest fix but we lose
 	// concurrency. Instead, we let the do() function run on all nodes.
 
-	var lastErrResp stepResp
-	errCount := 0
-	var resp stepResp
-	for range nodes {
-		resp = <-respCh
-		if resp.err != nil {
-			errCount++
-			c.Logger().WithFields(log.Fields{
-				"step": resp.step, "node": resp.node,
-			}).WithError(resp.err).Error("Step failed on node.")
-			lastErrResp = resp
-		}
+	resp := stepResp{
+		Step:  stepName,
+		Resps: make([]stepPeerResp, len(nodes)),
 	}
 
-	if errCount != 0 {
-		return fmt.Errorf("Step %s failed on %d nodes. "+
-			"Last error: Step func %s failed on %s with error: %s",
-			stepName, errCount, lastErrResp.step, lastErrResp.node, lastErrResp.err)
+	var peerResp stepPeerResp
+	for range nodes {
+		peerResp = <-respCh
+		if peerResp.Error != nil {
+			resp.ErrCount++
+			ctx.Logger().WithFields(log.Fields{
+				"step": stepName, "node": peerResp.PeerID,
+			}).WithError(peerResp.Error).Error("Step failed on node.")
+		}
+		resp.Resps = append(resp.Resps, peerResp)
+	}
+
+	if resp.ErrCount != 0 {
+		return resp
 	}
 
 	return nil
 }
 
-func runStepFuncOnNode(stepName string, ctx TxnCtx, node uuid.UUID, respCh chan<- stepResp) {
+func runStepFuncOnNode(stepName string, ctx TxnCtx, node uuid.UUID, respCh chan<- stepPeerResp) {
 
 	ctx.Logger().WithFields(log.Fields{
 		"step": stepName, "node": node,
@@ -100,7 +140,7 @@ func runStepFuncOnNode(stepName string, ctx TxnCtx, node uuid.UUID, respCh chan<
 		err = runStepOn(stepName, node, ctx)
 	}
 
-	respCh <- stepResp{node, stepName, err}
+	respCh <- stepPeerResp{node, err}
 }
 
 func runStepFuncLocally(stepName string, ctx TxnCtx) error {

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -73,16 +73,6 @@ func NewTxnWithLocks(ctx context.Context, lockIDs ...string) (*Txn, error) {
 	return t, nil
 }
 
-// Cleanup cleans the leftovers after a transaction ends
-// TODO: Remove this function
-func (t *Txn) Cleanup() {
-	if _, err := store.Delete(context.TODO(), t.storePrefix, clientv3.WithPrefix()); err != nil {
-		t.Ctx.Logger().WithError(err).WithField("key",
-			t.storePrefix).Error("Failed to remove transaction namespace from store")
-	}
-	expTxn.Add("initiated_txn_in_progress", -1)
-}
-
 // Done releases any obtained locks and cleans up the transaction namespace
 // Done must be called after a transaction ends
 func (t *Txn) Done() {
@@ -90,7 +80,14 @@ func (t *Txn) Done() {
 	for _, locker := range t.locks {
 		locker.Unlock(context.Background())
 	}
-	t.Cleanup()
+
+	// Wipe txn namespace
+	if _, err := store.Delete(context.TODO(), t.storePrefix, clientv3.WithPrefix()); err != nil {
+		t.Ctx.Logger().WithError(err).WithField("key",
+			t.storePrefix).Error("Failed to remove transaction namespace from store")
+	}
+
+	expTxn.Add("initiated_txn_in_progress", -1)
 }
 
 func (t *Txn) checkAlive() error {

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -18,9 +18,21 @@ type ErrorCode uint16
 const (
 	// ErrCodeGeneric represents generic error code for API responses
 	ErrCodeGeneric ErrorCode = iota + 1
+	// ErrTxnStepFailed represents failure of a txn step
+	ErrTxnStepFailed
 )
 
 // ErrorCodeMap maps error code to it's textual message
 var ErrorCodeMap = map[ErrorCode]string{
-	ErrCodeGeneric: "generic error",
+	ErrCodeGeneric:   "generic error",
+	ErrTxnStepFailed: "a txn step failed",
+}
+
+// ErrorResponse is an interface that types can implement on custom errors.
+type ErrorResponse interface {
+	error
+	// Response returns the error response to be returned to client.
+	Response() ErrorResp
+	// Status returns the HTTP status code to be returned to client.
+	Status() int
 }

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -3,8 +3,9 @@ package api
 // HTTPError contains an error code and corresponding text which briefly
 // describes the error in short.
 type HTTPError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code    int               `json:"code"`
+	Message string            `json:"message"`
+	Fields  map[string]string `json:"fields,omitempty"`
 }
 
 // ErrorResp is an error response which may contain one or more error responses


### PR DESCRIPTION
The txn framework now returns detailed error to the client i.e which step
failed on which peer and with what error.

Bonus cleanup and fix (separate commits) included in the PR:
* txn context: Reuse newCtx() when unmarshalling.
* Log txn step failure on remote node as Error.
* Ensure that response headers are always sent to client in all responses.
* txn: Remove Cleanup() and use Done()