### PR TITLE
e2e: Fix temp dirs used by tests

### DIFF
--- a/e2e/georep_test.go
+++ b/e2e/georep_test.go
@@ -17,7 +17,7 @@ func TestGeorepCreateDelete(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir("", "TestGeorepCreate")
+	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/glustershd_test.go
+++ b/e2e/glustershd_test.go
@@ -16,7 +16,7 @@ func TestSelfHealInfo(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir("", t.Name())
+	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/quota_enable.go
+++ b/e2e/quota_enable.go
@@ -20,7 +20,7 @@ func testQuotaEnable(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir("", t.Name())
+	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/restart_test.go
+++ b/e2e/restart_test.go
@@ -17,7 +17,7 @@ func TestRestart(t *testing.T) {
 	r.Nil(err)
 	r.True(gd.IsRunning())
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(dir)
 

--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -226,15 +226,15 @@ func TestSmartVolume(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir("", t.Name())
+	devicesDir, err := ioutil.TempDir(baseWorkdir, t.Name())
 	r.Nil(err)
-	t.Logf("Using temp dir: %s", tmpDir)
+	t.Logf("Using temp dir: %s", devicesDir)
 
 	// Device Setup
 	// Around 150MB will be reserved during pv/vg creation, create device with more size
-	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev1.img", "1", "400M"))
-	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev2.img", "2", "400M"))
-	r.Nil(prepareLoopDevice(baseWorkdir+"/gluster_dev3.img", "3", "400M"))
+	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev1.img", "1", "400M"))
+	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev2.img", "2", "400M"))
+	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev3.img", "3", "400M"))
 
 	_, err = client.DeviceAdd(gds[0].PeerID(), "/dev/gluster_loop1")
 	r.Nil(err)

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -329,7 +329,6 @@ func loopDevicesCleanup(t *testing.T) error {
 	cleanupAllBrickMounts(t)
 	cleanupAllGlusterVgs(t)
 	cleanupAllGlusterPvs(t)
-	cleanupAllGlusterPvs(t)
 
 	// Cleanup device files
 	devicefiles, err := filepath.Glob(baseWorkdir + "/*.img")


### PR DESCRIPTION
The `localstatedir` from config file contained relative path which was
not being converted to absolute path before passing as command line
argument to glusterd2. This caused localstatedirs of different glusterd2
instances to be nested under one another. 

Closes #878 

Other minor fixes/cleanups:
* Ensure all tests use isolated temp dirs based on the name of the test
* Remove duplicate call to cleanupAllGlusterPvs()
* Unexport `UpdateDirs()` as it was is only used internally.