### PR TITLE
volume-option-reset: return 204 status code on successful resetting of volume option.

### DIFF
--- a/glusterd2/commands/volumes/volume-reset.go
+++ b/glusterd2/commands/volumes/volume-reset.go
@@ -114,5 +114,5 @@ func volumeResetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusOK, volinfo.Options)
+	restutils.SendHTTPResponse(ctx, w, http.StatusNoContent, nil)
 }


### PR DESCRIPTION

instead of returning the remaining volume options left on the volume
for resetting volume options (delete operation). 
return 204 status code with empty HTTP response.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>