### PR TITLE
doc: fix install instructions on gluster centos nightly pkgs

### DIFF
--- a/doc/quick-start-user-guide.md
+++ b/doc/quick-start-user-guide.md
@@ -26,11 +26,13 @@ Install rpcbind:
 
 **Installing glusterfs from nightly RPMs (CentOS 7):**
 
+These packages require dependencies present in [EPEL](https://fedoraproject.org/wiki/EPEL). Enable the EPEL repositories before enabling gluster nightly packages repo below.
+
 Install packages that provide GlusterFS server (brick process) and client (fuse, libgfapi):
 
 ```sh
 # curl -o /etc/yum.repos.d/glusterfs-nighthly-master.repo http://artifacts.ci.centos.org/gluster/nightly/master.repo
-# dnf install glusterfs-server glusterfs-fuse glusterfs-api
+# yum install glusterfs-server glusterfs-fuse glusterfs-api
 ```
 
 ### Download glusterd2


### PR DESCRIPTION
The instructions now note that the packages require epel and refer to yum rather than dnf (this is for centos after all)