### PR TITLE
events: rest client API to list gluster events

### DIFF
--- a/pkg/restclient/events.go
+++ b/pkg/restclient/events.go
@@ -3,6 +3,7 @@ package restclient
 import (
 	"net/http"
 
+	"github.com/gluster/glusterd2/pkg/api"
 	eventsapi "github.com/gluster/glusterd2/plugins/events/api"
 )
 
@@ -29,5 +30,12 @@ func (c *Client) WebhookDelete(url string) error {
 func (c *Client) Webhooks() (eventsapi.WebhookList, error) {
 	var resp eventsapi.WebhookList
 	err := c.get("/v1/events/webhook", nil, http.StatusOK, &resp)
+	return resp, err
+}
+
+// ListEvents returns the list of Gluster Events
+func (c *Client) ListEvents() ([]*api.Event, error) {
+	var resp []*api.Event
+	err := c.get("/v1/events", nil, http.StatusOK, &resp)
 	return resp, err
 }


### PR DESCRIPTION
API to list gluster events  was not there implemented in rest-client, added rest-client API for list gluster events to cover the e2e test cases 

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>