### PR TITLE
add-brick: Fix issue while add brick without changing replica count

### DIFF
--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -234,8 +234,16 @@ func testVolumeExpand(t *testing.T) {
 	}
 
 	//expand with new brick dir which is not created
-	_, err := client.VolumeExpand(volname, expandReq)
+	volinfo, err := client.VolumeExpand(volname, expandReq)
 	r.Nil(err)
+
+	// Two subvolumes are added to the volume created by testVolumeCreate,
+	// total expected subvols is 4. Each subvol should contain two bricks
+	// since Volume type is Replica
+	r.Len(volinfo.Subvols, 4)
+	for _, subvol := range volinfo.Subvols {
+		r.Len(subvol.Bricks, 2)
+	}
 }
 
 func testVolumeDelete(t *testing.T) {
@@ -304,7 +312,7 @@ func testVolumeInfo(t *testing.T) {
 }
 
 func testVolumeStatus(t *testing.T) {
-	if _, err := os.Lstat("/dev/fuse");  os.IsNotExist(err) {
+	if _, err := os.Lstat("/dev/fuse"); os.IsNotExist(err) {
 		t.Skip("skipping mount /dev/fuse unavailable")
 	}
 	r := require.New(t)
@@ -356,7 +364,7 @@ func testVolumeMount(t *testing.T) {
 }
 
 func testMountUnmount(t *testing.T, v string) {
-	if _, err := os.Lstat("/dev/fuse");  os.IsNotExist(err) {
+	if _, err := os.Lstat("/dev/fuse"); os.IsNotExist(err) {
 		t.Skip("skipping mount /dev/fuse unavailable")
 	}
 	r := require.New(t)

--- a/glusterd2/commands/volumes/volume-expand-txn.go
+++ b/glusterd2/commands/volumes/volume-expand-txn.go
@@ -164,7 +164,7 @@ func updateVolinfoOnExpand(c transaction.TxnCtx) error {
 	// TODO: Assumption, all subvols are same
 	// If New Replica count is different than existing then add one brick to each subvolume
 	// Or if the Volume consists of only one subvolume.
-	var addNewSubvolume bool
+	addNewSubvolume := true
 	switch volinfo.Subvols[0].Type {
 	case volume.SubvolDistribute:
 		addNewSubvolume = false


### PR DESCRIPTION
If Replica count is increased during add brick then new bricks will
be added to existing sub volumes, If replica count is not changed then
new bricks should be added as new sub volume. Default behavior was
adding bricks to existing sub volumes. With this PR default behavior is
changed to add new sub volume.

Fixes: #819
Signed-off-by: Aravinda VK <avishwan@redhat.com>