### PR TITLE
volume-options: dont start daemons if volume state is  stopped or created

### DIFF
--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -292,8 +292,11 @@ func validateVolumeFlags(flag map[string]bool) error {
 	return nil
 }
 
-func isActionStepRequired(opt map[string]string) bool {
+func isActionStepRequired(opt map[string]string, volinfo *volume.Volinfo) bool {
 
+	if volinfo.State != volume.VolStarted {
+		return false
+	}
 	for k := range opt {
 		_, xl, _, err := options.SplitKey(k)
 		if err != nil {

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -208,7 +208,7 @@ func volumeOptionsHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc:   "vol-option.XlatorActionDoSet",
 			UndoFunc: "vol-option.XlatorActionUndoSet",
 			Nodes:    volinfo.Nodes(),
-			Skip:     !isActionStepRequired(req.Options),
+			Skip:     !isActionStepRequired(req.Options, volinfo),
 		},
 		{
 			DoFunc:   "vol-option.UpdateVolinfo",

--- a/glusterd2/commands/volumes/volume-reset.go
+++ b/glusterd2/commands/volumes/volume-reset.go
@@ -117,7 +117,7 @@ func volumeResetHandler(w http.ResponseWriter, r *http.Request) {
 			DoFunc:   "vol-option.XlatorActionDoReset",
 			UndoFunc: "vol-option.XlatorActionUndoReset",
 			Nodes:    volinfo.Nodes(),
-			Skip:     !isActionStepRequired(opt),
+			Skip:     !isActionStepRequired(opt, volinfo),
 		},
 		{
 			DoFunc:   "vol-option.UpdateVolinfo",


### PR DESCRIPTION
Allow to set options on volumes if volume state is stopped or created, don't start daemons.
if volume state is started then set options on volume and also start daemons.

Fixes: #934 

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>