### PR TITLE
Prevent reusing bricks belonging to different volume

### DIFF
--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -146,6 +146,27 @@ func testVolumeCreate(t *testing.T) {
 	_, err = client.VolumeCreate(createReq)
 	r.NotNil(err)
 
+	testDisallowBrickReuse(t, brickPaths[0])
+}
+
+func testDisallowBrickReuse(t *testing.T, brickInUse string) {
+	r := require.New(t)
+	volname := formatVolName(t.Name())
+
+	createReq := api.VolCreateReq{
+		Name: volname,
+		Subvols: []api.SubvolReq{
+			{
+				Bricks: []api.BrickReq{
+					{PeerID: gds[0].PeerID(), Path: brickInUse},
+				},
+			},
+		},
+		Force: true,
+	}
+
+	_, err := client.VolumeCreate(createReq)
+	r.NotNil(err)
 }
 
 func testVolumeCreateWithFlags(t *testing.T) {
@@ -210,6 +231,7 @@ func testVolumeCreateWithFlags(t *testing.T) {
 	r.Nil(client.VolumeDelete(volumeName))
 
 }
+
 func testVolumeExpand(t *testing.T) {
 	r := require.New(t)
 

--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -79,7 +79,7 @@ func (b *Brickinfo) StringMap() map[string]string {
 
 // Validate checks if brick path is valid, if brick is a mount point,
 // if brick is on root partition and if it has xattr support.
-func (b *Brickinfo) Validate(check InitChecks) error {
+func (b *Brickinfo) Validate(check InitChecks, allLocalBricks []Brickinfo) error {
 
 	var (
 		brickStat unix.Stat_t
@@ -124,10 +124,15 @@ func (b *Brickinfo) Validate(check InitChecks) error {
 		return err
 	}
 
-	if check.IsInUse {
-		if err = validateBrickInUse(b.Path); err != nil {
+	if check.WasInUse {
+		if err = validateBrickWasUsed(b.Path); err != nil {
 			return err
 		}
+	}
+
+	// mandatory check that cannot be skipped forcefully
+	if err = isBrickInActiveUse(b.Path, allLocalBricks); err != nil {
+		return err
 	}
 
 	return nil

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -147,12 +147,24 @@ func validateBricks(c transaction.TxnCtx) error {
 		return err
 	}
 
+	var allBricks []brick.Brickinfo
+	if err = c.Get("all-bricks-in-cluster", &allBricks); err != nil {
+		return err
+	}
+
+	var allLocalBricks []brick.Brickinfo
+	for _, b := range allBricks {
+		if uuid.Equal(gdctx.MyUUID, b.PeerID) {
+			allLocalBricks = append(allLocalBricks, b)
+		}
+	}
+
 	for _, b := range bricks {
 		if !uuid.Equal(b.PeerID, gdctx.MyUUID) {
 			continue
 		}
 
-		if err = b.Validate(checks); err != nil {
+		if err = b.Validate(checks, allLocalBricks); err != nil {
 			c.Logger().WithError(err).WithField(
 				"brick", b.Path).Debug("Brick validation failed")
 			return err
@@ -178,7 +190,7 @@ func initBricks(c transaction.TxnCtx) error {
 	}
 
 	flags := 0
-	if checks.IsInUse {
+	if checks.WasInUse {
 		// Perform a pure replace operation, which fails if the named
 		// attribute does not already exist.
 		flags = unix.XATTR_CREATE

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -197,8 +197,18 @@ func createVolinfo(c transaction.TxnCtx) error {
 		return err
 	}
 
-	checks := brick.PrepareChecks(req.Force, req.Flags)
+	allBricks, err := volume.GetAllBricksInCluster()
+	if err != nil {
+		return err
+	}
 
+	// Used by other peers to check if proposed bricks are already in use.
+	// This check is however still prone to races. See issue #314
+	if err := c.Set("all-bricks-in-cluster", allBricks); err != nil {
+		return err
+	}
+
+	checks := brick.PrepareChecks(req.Force, req.Flags)
 	err = c.Set("brick-checks", checks)
 
 	return err

--- a/glusterd2/commands/volumes/volume-expand-txn.go
+++ b/glusterd2/commands/volumes/volume-expand-txn.go
@@ -59,8 +59,18 @@ func expandValidatePrepare(c transaction.TxnCtx) error {
 		return err
 	}
 
-	checks := brick.PrepareChecks(req.Force, req.Flags)
+	allBricks, err := volume.GetAllBricksInCluster()
+	if err != nil {
+		return err
+	}
 
+	// Used by other peers to check if proposed bricks are already in use.
+	// This check is however still prone to races. See issue #314
+	if err := c.Set("all-bricks-in-cluster", allBricks); err != nil {
+		return err
+	}
+
+	checks := brick.PrepareChecks(req.Force, req.Flags)
 	if err := c.Set("brick-checks", checks); err != nil {
 		return err
 	}

--- a/glusterd2/volume/store-utils.go
+++ b/glusterd2/volume/store-utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/gluster/glusterd2/glusterd2/brick"
 	"github.com/gluster/glusterd2/glusterd2/store"
 	gderror "github.com/gluster/glusterd2/pkg/errors"
 
@@ -168,6 +169,23 @@ func GetVolumes(filterParams ...map[string]string) ([]*Volinfo, error) {
 	}
 
 	return volumes, nil
+}
+
+// GetAllBricksInCluster returns all bricks in the cluster. These bricks
+// belong to different volumes.
+func GetAllBricksInCluster() ([]brick.Brickinfo, error) {
+
+	volumes, err := GetVolumes()
+	if err != nil {
+		return nil, err
+	}
+
+	var bricks []brick.Brickinfo
+	for _, volinfo := range volumes {
+		bricks = append(bricks, volinfo.GetBricks()...)
+	}
+
+	return bricks, nil
 }
 
 // AreReplicateVolumesRunning retrieves the volinfo objects from GetVolumes() function


### PR DESCRIPTION
During volume create and volume expand, when `--force` or `--reuse-bricks` is
used, specifying a brick used by a different volume was being allowed. Bricks
belonging to a different active volume shouldn't be reused in any case.

This is enforced by:
* Checking volume id xattr on proposed brick path against volume id of other all
  available volumes.
* Checking if proposed brick path is a nested subdir of another active brick on
  the peer.

Closes #931 
Signed-off-by: Prashanth Pai <ppai@redhat.com>