### PR TITLE
Remove 'workdir' config in favour of 'localstatedir'

### DIFF
--- a/doc/quick-start-user-guide.md
+++ b/doc/quick-start-user-guide.md
@@ -57,7 +57,7 @@ Glusterd2 will also pick up conf file named `glusterd2.toml` if available in `/e
 
 ```toml
 $ cat conf.toml
-workdir = "/var/lib/gd2"
+localstatedir = "/var/lib/gd2"
 peeraddress = "192.168.56.101:24008"
 clientaddress = "192.168.56.101:24007"
 etcdcurls = "http://192.168.56.101:2379"

--- a/e2e/bitrot_test.go
+++ b/e2e/bitrot_test.go
@@ -21,7 +21,7 @@ func TestBitrot(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir(baseWorkdir, t.Name())
+	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	t.Logf("Using temp dir: %s", tmpDir)
 

--- a/e2e/config/1.toml
+++ b/e2e/config/1.toml
@@ -1,4 +1,3 @@
-workdir = "w1"
 localstatedir = "w1"
 logdir = "w1/log"
 loglevel = "DEBUG"

--- a/e2e/config/2.toml
+++ b/e2e/config/2.toml
@@ -1,4 +1,3 @@
-workdir = "w2"
 localstatedir = "w2"
 logdir = "w2/log"
 loglevel = "DEBUG"

--- a/e2e/config/3.toml
+++ b/e2e/config/3.toml
@@ -1,4 +1,3 @@
-workdir = "w3"
 localstatedir = "w3"
 logdir = "w3/log"
 loglevel = "DEBUG"

--- a/e2e/config/4.toml
+++ b/e2e/config/4.toml
@@ -1,4 +1,3 @@
-workdir = "w4"
 localstatedir = "w4"
 logdir = "w4/log"
 loglevel = "DEBUG"

--- a/e2e/georep_test.go
+++ b/e2e/georep_test.go
@@ -17,7 +17,7 @@ func TestGeorepCreateDelete(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	brickDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/glustershd_test.go
+++ b/e2e/glustershd_test.go
@@ -16,7 +16,7 @@ func TestSelfHealInfo(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	brickDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	binDir      string
-	baseWorkdir = "/tmp/gd2_func_test"
-	functest    bool
+	binDir            string
+	baseLocalStateDir = "/tmp/gd2_func_test"
+	functest          bool
 )
 
 func TestMain(m *testing.M) {
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 
 	flag.BoolVar(&functest, "functest", false, "Run or skip functional test")
 	flag.StringVar(&binDir, "bindir", defBinDir, "The directory containing glusterd2 binary")
-	flag.StringVar(&baseWorkdir, "workdir", baseWorkdir, "The base directory for test working directories")
+	flag.StringVar(&baseLocalStateDir, "basedir", baseLocalStateDir, "The base directory for test local state directories")
 	flag.Parse()
 
 	if !functest {
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	loopDevicesCleanup(nil)
 
 	// Cleanup leftovers from previous test runs. But don't cleanup after.
-	os.RemoveAll(baseWorkdir)
+	os.RemoveAll(baseLocalStateDir)
 
 	v := m.Run()
 	os.Exit(v)

--- a/e2e/quota_enable.go
+++ b/e2e/quota_enable.go
@@ -20,7 +20,7 @@ func testQuotaEnable(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	brickDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 

--- a/e2e/restapi_auth_test.go
+++ b/e2e/restapi_auth_test.go
@@ -17,7 +17,7 @@ func TestRESTAPIAuth(t *testing.T) {
 	defer g1.Stop()
 	r.True(g1.IsRunning())
 
-	secret, err := ioutil.ReadFile(g1.Workdir + "/auth")
+	secret, err := ioutil.ReadFile(g1.LocalStateDir + "/auth")
 	r.Nil(err)
 
 	client := restclient.New("http://"+g1.ClientAddress, "glustercli", string(secret), "", false)

--- a/e2e/restart_test.go
+++ b/e2e/restart_test.go
@@ -17,7 +17,7 @@ func TestRestart(t *testing.T) {
 	r.Nil(err)
 	r.True(gd.IsRunning())
 
-	dir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	dir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	defer os.RemoveAll(dir)
 

--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -238,7 +238,7 @@ func TestSmartVolume(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	devicesDir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	devicesDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	t.Logf("Using temp dir: %s", devicesDir)
 

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -43,7 +43,7 @@ func TestVolume(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir(baseWorkdir, t.Name())
+	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	t.Logf("Using temp dir: %s", tmpDir)
 	//defer os.RemoveAll(tmpDir)
@@ -175,7 +175,7 @@ func testVolumeCreateWithFlags(t *testing.T) {
 	var brickPaths []string
 
 	for i := 1; i <= 4; i++ {
-		brickPaths = append(brickPaths, fmt.Sprintf(baseWorkdir+"/"+t.Name()+"/%d", i))
+		brickPaths = append(brickPaths, fmt.Sprintf(baseLocalStateDir+"/"+t.Name()+"/%d", i))
 	}
 
 	flags := make(map[string]bool)
@@ -237,7 +237,7 @@ func testVolumeExpand(t *testing.T) {
 
 	var brickPaths []string
 	for i := 1; i <= 4; i++ {
-		brickPaths = append(brickPaths, fmt.Sprintf(fmt.Sprintf(baseWorkdir+"/"+t.Name()+"/%d/", i)))
+		brickPaths = append(brickPaths, fmt.Sprintf(fmt.Sprintf(baseLocalStateDir+"/"+t.Name()+"/%d/", i)))
 	}
 
 	flags := make(map[string]bool)
@@ -421,7 +421,7 @@ func TestVolumeOptions(t *testing.T) {
 	r.Nil(err)
 	defer teardownCluster(gds)
 
-	brickDir, err := ioutil.TempDir(baseWorkdir, t.Name())
+	brickDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
 	defer os.RemoveAll(brickDir)
 
 	brickPath, err := ioutil.TempDir(brickDir, "brick")

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -27,7 +27,7 @@ func TestWebhook(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir(baseWorkdir, t.Name())
+	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
 	r.Nil(err)
 	t.Logf("Using temp dir: %s", tmpDir)
 

--- a/glusterd2/config.go
+++ b/glusterd2/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"expvar"
 	"net"
-	"os"
 	"path"
 
 	"github.com/gluster/glusterd2/glusterd2/gdctx"
@@ -39,7 +38,6 @@ var (
 
 // parseFlags sets up the flags and parses them, this needs to be called before any other operation
 func parseFlags() {
-	flag.String("workdir", "", "Working directory for GlusterD. (default: current directory)")
 	flag.String("localstatedir", defaultlocalstatedir, "Directory to store local state information.")
 	flag.String("rundir", defaultrundir, "Directory to store runtime data.")
 	flag.String("config", "", "Configuration file for GlusterD.")
@@ -69,14 +67,6 @@ func parseFlags() {
 // setDefaults sets defaults values for config options not available as a flag,
 // and flags which don't have default values
 func setDefaults() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	if config.GetString("workdir") == "" {
-		config.SetDefault("workdir", cwd)
-	}
 
 	config.SetDefault("hooksdir", config.GetString("localstatedir")+"/hooks")
 

--- a/glusterd2/gdctx/global.go
+++ b/glusterd2/gdctx/global.go
@@ -62,8 +62,7 @@ func GenerateLocalAuthToken() error {
 	}
 
 	RESTAPIAuthEnabled = true
-	workdir := config.GetString("workdir")
-	authFile := path.Join(workdir, "auth")
+	authFile := path.Join(config.GetString("localstatedir"), "auth")
 
 	_, err := os.Stat(authFile)
 	if os.IsNotExist(err) {

--- a/glusterd2/gdctx/global_test.go
+++ b/glusterd2/gdctx/global_test.go
@@ -18,11 +18,11 @@ func TestGenerateLocalAuthToken(t *testing.T) {
 	assert.Nil(t, err)
 
 	config.Set("restauth", true)
-	config.Set("workdir", "/tmp/gd2test/")
+	config.Set("localstatedir", "/tmp/gd2test/")
 	err = GenerateLocalAuthToken()
 	assert.NotNil(t, err)
 
-	config.Set("workdir", "")
+	config.Set("localstatedir", "")
 	err = GenerateLocalAuthToken()
 	assert.Nil(t, err)
 	os.Remove("auth")

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -71,12 +71,12 @@ func main() {
 
 	dumpConfigToLog()
 
-	workdir := config.GetString("workdir")
+	workdir := config.GetString("localstatedir")
 	if err := os.Chdir(workdir); err != nil {
 		log.WithError(err).Fatalf("Failed to change working directory to %s", workdir)
 	}
 
-	// Create directories inside workdir - run dir, logdir etc
+	// Create directories inside localstatedir - run dir, logdir etc
 	if err := createDirectories(); err != nil {
 		log.WithError(err).Fatal("Failed to create or access directories")
 	}
@@ -114,7 +114,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to load the default group options")
 	}
 
-	// If REST API Auth is enabled, Generate Auth file with random secret in workdir
+	// If REST API Auth is enabled, Generate Auth file with random secret in localstatedir
 	if err := gdctx.GenerateLocalAuthToken(); err != nil {
 		log.WithError(err).Fatal("Failed to generate local auth token")
 	}

--- a/glusterd2/middleware/auth_test.go
+++ b/glusterd2/middleware/auth_test.go
@@ -20,7 +20,7 @@ func TestGetAuthSecret(t *testing.T) {
 	assert.Empty(t, secret)
 
 	config.Set("restauth", true)
-	config.Set("workdir", "")
+	config.Set("localstatedir", "")
 	err := gdctx.GenerateLocalAuthToken()
 	assert.Nil(t, err)
 	os.Remove("auth")
@@ -47,7 +47,7 @@ func getAuthToken(username string, password string) string {
 func generateLocalauthtoken() {
 
 	config.Set("restauth", true)
-	config.Set("workdir", "")
+	config.Set("localstatedir", "")
 	gdctx.GenerateLocalAuthToken()
 
 }

--- a/glusterd2/volgen/config.go
+++ b/glusterd2/volgen/config.go
@@ -14,14 +14,14 @@ const (
 
 // InitFlags intializes the commandline options for volgen
 func InitFlags() {
-	flag.String(templateDirOpt, "", "Directory to search for templates. (default: workdir/templates)")
+	flag.String(templateDirOpt, "", "Directory to search for templates. (default: localstatedir/templates)")
 }
 
 // SetDefaults sets the default values for the volgen commandline options
 func SetDefaults() {
 	td := config.GetString(templateDirOpt)
 	if td == "" {
-		wd := config.GetString("workdir")
+		wd := config.GetString("localstatedir")
 		config.SetDefault(templateDirOpt, path.Join(wd, templateDir))
 	}
 }

--- a/scripts/gen-gd2conf.sh
+++ b/scripts/gen-gd2conf.sh
@@ -8,7 +8,6 @@ OUTPUT=$OUTDIR/$GD2.toml
 
 cat >"$OUTPUT" <<EOF
 
-workdir = "$GD2STATEDIR"
 localstatedir = "$GD2STATEDIR"
 logdir = "$GD2LOGDIR"
 logfile = "$GD2.log"


### PR DESCRIPTION
For all practical purposes, in real usage and in tests, the configurable
paths `workdir` and `localstatedir` are set to the same directory which
defaults to `/var/lib/glusterd2` or `/user/local/var/lib/glusterd2`

Unlike glusterd1, glusterd2 does not daemonize itself. The working
directory of the process can be meaningfully set to either current
working directory from where glusterd2 process is started or to
`localstatedir` where glusterd2 stores all its data. We choose the
latter.

This change also reduces ambiguity for users and one less thing to
configure.

Closes #888 

Signed-off-by: Prashanth Pai <ppai@redhat.com>