### PR TITLE
cli: Add additional fields to volume list command output

### DIFF
--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -330,9 +330,18 @@ func volumeInfoHandler2(cmd *cobra.Command, isInfo bool) error {
 		}
 	} else {
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"ID", "Name"})
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetHeader([]string{"ID", "Name", "Type", "State", "Transport", "Bricks"})
 		for _, vol := range vols {
-			table.Append([]string{vol.ID.String(), vol.Name})
+			brickCount := 0
+			for _, subvol := range vol.Subvols {
+				for range subvol.Bricks {
+					brickCount++
+				}
+			}
+
+			table.Append([]string{vol.ID.String(), vol.Name, vol.Type.String(),
+				vol.State.String(), vol.Transport, strconv.Itoa(brickCount)})
 		}
 		table.Render()
 	}


### PR DESCRIPTION
Add type, state, transport and number of bricks as fields to table
shown in output of `glustercli volume list` command.

Closes #935 
Signed-off-by: Prashanth Pai <ppai@redhat.com>