### PR TITLE
e2e: establish a common approach to creating per-test temp dirs

### DIFF
--- a/e2e/bitrot_test.go
+++ b/e2e/bitrot_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/gluster/glusterd2/pkg/api"
@@ -21,10 +20,6 @@ func TestBitrot(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
-	r.Nil(err)
-	t.Logf("Using temp dir: %s", tmpDir)
-
 	// test Bitrot on dist-rep volume
 	t.Run("Replica-volume", testBitrotOnReplicaVolume)
 	// test Bitrot on pure distribute volume
@@ -38,8 +33,7 @@ func testBitrotOnReplicaVolume(t *testing.T) {
 	var brickPaths []string
 
 	for i := 1; i <= 4; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 
@@ -81,8 +75,7 @@ func testBitrotOnDistVolume(t *testing.T) {
 	var brickPaths []string
 
 	for i := 1; i <= 4; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -365,3 +365,19 @@ func isProcessRunning(pidpath string) bool {
 
 	return true
 }
+
+// testTempDir returns a temporary directory path that will exist
+// on the system. This path is based on the name of the test and
+// a unique final directory, determined by prefix.
+// On encountering an error this function will panic.
+func testTempDir(t *testing.T, prefix string) string {
+	base := path.Join(baseLocalStateDir, t.Name())
+	if err := os.MkdirAll(base, 0755); err != nil {
+		panic(err)
+	}
+	d, err := ioutil.TempDir(base, prefix)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -27,7 +27,6 @@ const (
 var (
 	gds    []*gdProcess
 	client *restclient.Client
-	tmpDir string
 )
 
 // TestVolume creates a volume and starts it, runs further tests on it and
@@ -42,11 +41,6 @@ func TestVolume(t *testing.T) {
 	defer teardownCluster(gds)
 
 	client = initRestclient(gds[0].ClientAddress)
-
-	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
-	r.Nil(err)
-	t.Logf("Using temp dir: %s", tmpDir)
-	//defer os.RemoveAll(tmpDir)
 
 	t.Run("CreateWithoutName", testVolumeCreateWithoutName)
 
@@ -79,8 +73,7 @@ func testVolumeCreateWithoutName(t *testing.T) {
 
 	var brickPaths []string
 	for i := 1; i <= 2; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 
@@ -107,8 +100,7 @@ func testVolumeCreate(t *testing.T) {
 
 	var brickPaths []string
 	for i := 1; i <= 4; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 
@@ -391,15 +383,14 @@ func testMountUnmount(t *testing.T, v string) {
 	}
 	r := require.New(t)
 
-	mntPath, err := ioutil.TempDir(tmpDir, "mnt")
-	r.Nil(err)
+	mntPath := testTempDir(t, "mnt")
 	defer os.RemoveAll(mntPath)
 
 	host, _, _ := net.SplitHostPort(gds[0].ClientAddress)
 	mntCmd := exec.Command("mount", "-t", "glusterfs", host+":"+v, mntPath)
 	umntCmd := exec.Command("umount", mntPath)
 
-	err = mntCmd.Run()
+	err := mntCmd.Run()
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
 	err = umntCmd.Run()
@@ -563,8 +554,7 @@ func testDisperse(t *testing.T) {
 
 	var brickPaths []string
 	for i := 1; i <= 3; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,10 +26,6 @@ func TestWebhook(t *testing.T) {
 
 	client = initRestclient(gds[0].ClientAddress)
 
-	tmpDir, err = ioutil.TempDir(baseLocalStateDir, t.Name())
-	r.Nil(err)
-	t.Logf("Using temp dir: %s", tmpDir)
-
 	t.Run("Register-webhook", testAddWebhook)
 	t.Run("List-webhook", testGetWebhook)
 	t.Run("Delete-webhook", testDeleteWebhook)
@@ -54,8 +49,7 @@ func testAddWebhook(t *testing.T) {
 	var brickPaths []string
 
 	for i := 1; i <= 4; i++ {
-		brickPath, err := ioutil.TempDir(tmpDir, "brick")
-		r.Nil(err)
+		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
 


### PR DESCRIPTION
Add a helper function for tests that need unique test dirs that
creates test directories like /[base]/[testname]/[unique].

Fixes #927

Signed-off-by: John Mulligan <jmulligan@redhat.com>