### PR TITLE
Setup Jaeger tracing for glusterd2 volume create command.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -403,8 +403,16 @@
     "exporter/jaeger",
     "exporter/jaeger/internal/gen-go/jaeger",
     "internal",
+    "internal/tagencoding",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
     "trace",
-    "trace/internal"
+    "trace/internal",
+    "trace/propagation"
   ]
   revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
   version = "v0.11.0"
@@ -493,6 +501,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a0509fa7d375ad81b53fba87ae5359c779416fb6645ae9c647a2929e8058aef2"
+  inputs-digest = "864479ae2627b7c7059d263289670672425e96e76e8c4861c0c266b4e8e29d2a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -403,16 +403,8 @@
     "exporter/jaeger",
     "exporter/jaeger/internal/gen-go/jaeger",
     "internal",
-    "internal/tagencoding",
-    "plugin/ochttp",
-    "plugin/ochttp/propagation/b3",
-    "stats",
-    "stats/internal",
-    "stats/view",
-    "tag",
     "trace",
-    "trace/internal",
-    "trace/propagation"
+    "trace/internal"
   ]
   revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
   version = "v0.11.0"
@@ -501,6 +493,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1c93d91c481db0329aa839cd2ac77aa8e7bb51a5c2249ffd519f5bdb70588f8b"
+  inputs-digest = "a0509fa7d375ad81b53fba87ae5359c779416fb6645ae9c647a2929e8058aef2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -403,16 +403,8 @@
     "exporter/jaeger",
     "exporter/jaeger/internal/gen-go/jaeger",
     "internal",
-    "internal/tagencoding",
-    "plugin/ochttp",
-    "plugin/ochttp/propagation/b3",
-    "stats",
-    "stats/internal",
-    "stats/view",
-    "tag",
     "trace",
-    "trace/internal",
-    "trace/propagation"
+    "trace/internal"
   ]
   revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
   version = "v0.11.0"
@@ -501,6 +493,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "864479ae2627b7c7059d263289670672425e96e76e8c4861c0c266b4e8e29d2a"
+  inputs-digest = "f813be9ec08c313a227bef308c6ff9014b91f61ac36aa3ade6a180a124dacd1c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -403,8 +403,16 @@
     "exporter/jaeger",
     "exporter/jaeger/internal/gen-go/jaeger",
     "internal",
+    "internal/tagencoding",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
     "trace",
-    "trace/internal"
+    "trace/internal",
+    "trace/propagation"
   ]
   revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
   version = "v0.11.0"
@@ -493,6 +501,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f813be9ec08c313a227bef308c6ff9014b91f61ac36aa3ade6a180a124dacd1c"
+  inputs-digest = "1c93d91c481db0329aa839cd2ac77aa8e7bb51a5c2249ffd519f5bdb70588f8b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,13 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "git.apache.org/thrift.git"
+  packages = ["lib/go/thrift"]
+  revision = "f5f430df56871bc937950274b2c86681d3db6e59"
+  source = "github.com/apache/thrift"
+
+[[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
@@ -391,6 +398,18 @@
   version = "0.0.1"
 
 [[projects]]
+  name = "go.opencensus.io"
+  packages = [
+    "exporter/jaeger",
+    "exporter/jaeger/internal/gen-go/jaeger",
+    "internal",
+    "trace",
+    "trace/internal"
+  ]
+  revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
+  version = "v0.11.0"
+
+[[projects]]
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -412,6 +431,12 @@
     "trace"
   ]
   revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["semaphore"]
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
@@ -438,6 +463,12 @@
   revision = "0ad425fe45e885577bef05dc1c50f72e33188b16"
 
 [[projects]]
+  branch = "master"
+  name = "google.golang.org/api"
+  packages = ["support/bundler"]
+  revision = "2eea9ba0a3d94f6ab46508083e299a00bbbc65f6"
+
+[[projects]]
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -462,6 +493,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "19dda7f9b0c842a769bea1b5d69e3a41f5b7de536176724a9cdebc241dd0e96c"
+  inputs-digest = "a0509fa7d375ad81b53fba87ae5359c779416fb6645ae9c647a2929e8058aef2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,3 +89,7 @@
 [[constraint]]
   name = "github.com/asaskevich/govalidator"
   version = "v8"
+
+[[constraint]]
+  name = "go.opencensus.io"
+  version = "0.11.0"

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -14,6 +14,7 @@ import (
 	gderrors "github.com/gluster/glusterd2/pkg/errors"
 
 	"github.com/pborman/uuid"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -79,6 +80,9 @@ func registerVolCreateStepFuncs() {
 func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
+	ctx, span := trace.StartSpan(ctx, "/volumeCreateHandler")
+	defer span.End()
+
 	logger := gdctx.GetReqLogger(ctx)
 	var err error
 

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -24,6 +24,8 @@ import (
 	flag "github.com/spf13/pflag"
 	config "github.com/spf13/viper"
 	"github.com/thejerf/suture"
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
 	"golang.org/x/sys/unix"
 
 	"go.opencensus.io/exporter/jaeger"

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -25,6 +25,9 @@ import (
 	config "github.com/spf13/viper"
 	"github.com/thejerf/suture"
 	"golang.org/x/sys/unix"
+
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
 )
 
 func main() {
@@ -117,6 +120,29 @@ func main() {
 	// If REST API Auth is enabled, Generate Auth file with random secret in localstatedir
 	if err := gdctx.GenerateLocalAuthToken(); err != nil {
 		log.WithError(err).Fatal("Failed to generate local auth token")
+	}
+
+	// Get the Jaeger endpoints from config file
+	jaegerEndpoint := config.GetString("jaegerendpoint")
+	jaegerAgentEndpoint := config.GetString("jaegeragentendpoint")
+
+	// Create the Opencensus Jaeger exporter endpoints to log traces and spans
+	exporter, err := jaeger.NewExporter(jaeger.Options{
+		Endpoint:      jaegerEndpoint,
+		AgentEndpoint: jaegerAgentEndpoint,
+		ServiceName:   gdctx.HostName,
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Warning("Unable to create jaeger exporter")
+	} else {
+		defer exporter.Flush()
+		// Register the Jaeger exporter
+		trace.RegisterExporter(exporter)
+		// TODO: Change to probability sampler. Use always sample for now.
+		trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+		log.Info("Registered opencensus exporter for traces and stats")
 	}
 
 	// Start all servers (rest, peerrpc, sunrpc) managed by suture supervisor

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -23,6 +23,8 @@ type TxnCtx interface {
 	Get(key string, value interface{}) error
 	// GetNodeResult is similar to Get but prefixes the key with node UUID specified.
 	GetNodeResult(peerID uuid.UUID, key string, value interface{}) error
+	// GetTxnReqID gets the reqID string saved in the transaction.
+	GetTxnReqID() string
 	// Delete deletes the key and value
 	Delete(key string) error
 	// Logger returns the Logrus logger associated with the context
@@ -163,6 +165,12 @@ func (c *Tctx) Get(key string, value interface{}) error {
 func (c *Tctx) GetNodeResult(peerID uuid.UUID, key string, value interface{}) error {
 	storeKey := peerID.String() + "/" + key
 	return c.Get(storeKey, value)
+}
+
+// GetTxnReqID gets the reqID string saved within the txnCtxConfig.
+func (c *Tctx) GetTxnReqID() string {
+	logFields := c.config.LogFields
+	return logFields["reqid"].(string)
 }
 
 // Delete deletes the key and attached value

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -127,12 +127,14 @@ func (t *Txn) Do() error {
 		return err
 	}
 
+	var origCtx []context.Context
+	origCtx = []context.Context{t.OrigCtx}
 	for i, s := range t.Steps {
 		if s.Skip {
 			continue
 		}
 
-		if err := s.do(t.Ctx); err != nil {
+		if err := s.do(t.Ctx, origCtx...); err != nil {
 			expTxn.Add("initiated_txn_failure", 1)
 			if !t.DisableRollback {
 				t.Ctx.Logger().WithError(err).Error("Transaction failed, rolling back changes")

--- a/glusterd2/transaction/transaction.go
+++ b/glusterd2/transaction/transaction.go
@@ -35,7 +35,8 @@ type Txn struct {
 	// Nodes is the union of the all the TxnStep.Nodes and is implicitly
 	// set in Txn.Do(). This list is used to determine liveness of the
 	// nodes before running the transaction steps.
-	Nodes []uuid.UUID
+	Nodes   []uuid.UUID
+	OrigCtx context.Context
 }
 
 // NewTxn returns an initialized Txn without any steps
@@ -55,6 +56,7 @@ func NewTxn(ctx context.Context) *Txn {
 	}
 	t.Ctx = newCtx(config)
 
+	t.OrigCtx = ctx
 	t.Ctx.Logger().Debug("new transaction created")
 	return t
 }


### PR DESCRIPTION
This change sets up Jaeger tracing for volume create path. This initial changeset only traces calls locally and not across rpc boundaries. Therefore, the traces are only visible on the node which handled the volume create request.

None of the code changes modifies the original functionality and therefore UTs and functional tests are not added. But all existing UTs, functional tests and testing on VM with 1 node succeeded.

github issue #941 tracks this change.