### PR TITLE
Filter Volume options based on CLI flags

### DIFF
--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -46,6 +46,11 @@ var (
 	flagCmdFilterKey   string
 	flagCmdFilterValue string
 
+	//Filter Volume Get command flags
+	flagGetAdv bool
+	flagGetBsc bool
+	flagGetMdf bool
+
 	// Edit Command Flags
 	flagCmdMetadataKey    string
 	flagCmdMetadataValue  string
@@ -66,6 +71,9 @@ func init() {
 	// Volume Delete
 	volumeCmd.AddCommand(volumeDeleteCmd)
 
+	volumeGetCmd.Flags().BoolVar(&flagGetAdv, "advanced", false, "Get advanced options")
+	volumeGetCmd.Flags().BoolVar(&flagGetBsc, "basic", true, "Get basic options")
+	volumeGetCmd.Flags().BoolVar(&flagGetMdf, "modified", false, "Get modified options")
 	volumeCmd.AddCommand(volumeGetCmd)
 	volumeCmd.AddCommand(volumeResetCmd)
 	volumeCmd.AddCommand(volumeSizeCmd)
@@ -247,7 +255,17 @@ var volumeGetCmd = &cobra.Command{
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
 		for _, opt := range opts {
-			table.Append([]string{opt.OptName, formatBoolYesNo(opt.Modified), opt.Value, opt.DefaultValue, opt.OptionLevel})
+			//if modified flag is set, discard unmodified options
+			if flagGetMdf && !opt.Modified {
+				continue
+			}
+			if flagGetBsc && opt.OptionLevel == "Basic" {
+				table.Append([]string{opt.OptName, formatBoolYesNo(opt.Modified), opt.Value, opt.DefaultValue, opt.OptionLevel})
+			}
+			if flagGetAdv && opt.OptionLevel == "Advanced" {
+				table.Append([]string{opt.OptName, formatBoolYesNo(opt.Modified), opt.Value, opt.DefaultValue, opt.OptionLevel})
+
+			}
 		}
 		table.Render()
 


### PR DESCRIPTION
Partial: #503 

**sample output**

```
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 all --modified --basic
+---------------------+----------+-------+---------------+--------------+
|        NAME         | MODIFIED | VALUE | DEFAULT VALUE | OPTION LEVEL |
+---------------------+----------+-------+---------------+--------------+
| changelog.changelog | yes      | on    | off           | Basic        |
+---------------------+----------+-------+---------------+--------------+
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 all --modified --advanced
+----------------------------+----------+--------------------------------------+-----------------+--------------+
|            NAME            | MODIFIED |                VALUE                 |  DEFAULT VALUE  | OPTION LEVEL |
+----------------------------+----------+--------------------------------------+-----------------+--------------+
| marker.volume-uuid         | yes      | 8efbb3a3-7e97-451b-9c2d-4d75faa4dbaa | {{ volume.id }} | Advanced     |
| marker.xtime               | yes      | on                                   |                 | Advanced     |
| marker.gsync-force-xtime   | yes      | on                                   |                 | Advanced     |
| replicate.self-heal-daemon | yes      | off                                  | on              | Advanced     |
| afr.eager-lock             | yes      | off                                  | on              | Advanced     |
+----------------------------+----------+--------------------------------------+-----------------+--------------+
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 all --modified --advanced --basic
+----------------------------+----------+--------------------------------------+-----------------+--------------+
|            NAME            | MODIFIED |                VALUE                 |  DEFAULT VALUE  | OPTION LEVEL |
+----------------------------+----------+--------------------------------------+-----------------+--------------+
| afr.eager-lock             | yes      | off                                  | on              | Advanced     |
| marker.volume-uuid         | yes      | 8efbb3a3-7e97-451b-9c2d-4d75faa4dbaa | {{ volume.id }} | Advanced     |
| marker.xtime               | yes      | on                                   |                 | Advanced     |
| marker.gsync-force-xtime   | yes      | on                                   |                 | Advanced     |
| changelog.changelog        | yes      | on                                   | off             | Basic        |
| replicate.self-heal-daemon | yes      | off                                  | on              | Advanced     |
+----------------------------+----------+--------------------------------------+-----------------+--------------+
[root@dhcp42-235 glusterd2]# 
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 replicate.self-heal-daemon --modified --advanced --basic
+----------------------------+----------+-------+---------------+--------------+
|            NAME            | MODIFIED | VALUE | DEFAULT VALUE | OPTION LEVEL |
+----------------------------+----------+-------+---------------+--------------+
| replicate.self-heal-daemon | yes      | off   | on            | Advanced     |
+----------------------------+----------+-------+---------------+--------------+
[root@dhcp42-235 glusterd2]# 
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 replicate.self-heal-daemon  --basic
+------+----------+-------+---------------+--------------+
| NAME | MODIFIED | VALUE | DEFAULT VALUE | OPTION LEVEL |
+------+----------+-------+---------------+--------------+
+------+----------+-------+---------------+--------------+
[root@dhcp42-235 glusterd2]# 
[root@dhcp42-235 glusterd2]# ./build/glustercli --endpoints=http://10.70.43.235:24009 volume get test1 replicate.self-heal-daemon  --advanced
+----------------------------+----------+-------+---------------+--------------+
|            NAME            | MODIFIED | VALUE | DEFAULT VALUE | OPTION LEVEL |
+----------------------------+----------+-------+---------------+--------------+
| replicate.self-heal-daemon | yes      | off   | on            | Advanced     |
+----------------------------+----------+-------+---------------+--------------+

```
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>