### PR TITLE
 Add TLS support for client-bricks communication

### DIFF
--- a/glusterd2/commands/volumes/grouped-options.go
+++ b/glusterd2/commands/volumes/grouped-options.go
@@ -129,6 +129,12 @@ var defaultGroupOptions = map[string]*api.OptionGroup{
 			{Name: "features.shard", OnValue: "on"},
 			{Name: "user.cifs", OnValue: "off"}},
 		"Enable this profile, if the Gluster Volume is used to store virtual machines"},
+	"tls": {"tls",
+		[]api.VolumeOption{
+			{Name: "server.transport.socket.ssl-enabled", OnValue: "on"},
+			{Name: "client.transport.socket.ssl-enabled", OnValue: "on"},
+		},
+		"Enable TLS for the volume for both bricks and clients"},
 	"profile.test": {"profile.test",
 		[]api.VolumeOption{{Name: "afr.eager-lock", OnValue: "on"},
 			{Name: "gfproxy.afr.eager-lock", OnValue: "on"}},

--- a/glusterd2/commands/volumes/volume-option.go
+++ b/glusterd2/commands/volumes/volume-option.go
@@ -35,7 +35,7 @@ func optionSetValidate(c transaction.TxnCtx) error {
 	// validateOptions.
 
 	if err := validateOptions(options, req.Advanced, req.Experimental, req.Deprecated); err != nil {
-		return fmt.Errorf("Validation failed for volume option: %s", err.Error())
+		return fmt.Errorf("validation failed for volume option: %s", err.Error())
 	}
 
 	var volinfo volume.Volinfo
@@ -43,8 +43,8 @@ func optionSetValidate(c transaction.TxnCtx) error {
 		return err
 	}
 
-	if err := validateXlatorOptions(req.Options, &volinfo); err != nil {
-		return fmt.Errorf("Validation failed for volume option:: %s", err.Error())
+	if err := validateXlatorOptions(options, &volinfo); err != nil {
+		return fmt.Errorf("validation failed for volume option:: %s", err.Error())
 	}
 
 	for k, v := range options {

--- a/glusterd2/xlator/global.go
+++ b/glusterd2/xlator/global.go
@@ -35,6 +35,7 @@ func Load() (err error) {
 	}
 	xlMap = xls
 
+	injectTransportOptions()
 	loadOptions()
 	return
 }
@@ -53,6 +54,40 @@ func loadOptions() {
 			for _, k := range opt.Key {
 				k := xl.ID + "." + k
 				optMap[k] = opt
+			}
+		}
+	}
+}
+
+// injectTransportOptions injects options present in transport layer (socket.so
+// and rdma.so) into list of options loaded from protocol layer (server.so and
+// client.so)
+func injectTransportOptions() {
+
+	var transportNames = [...]string{"socket", "rdma"}
+	transports := make([]*Xlator, 0, 2)
+	for _, name := range transportNames {
+		if xl, ok := xlMap[name]; ok {
+			transports = append(transports, xl)
+		}
+	}
+
+	if len(transports) == 0 {
+		panic("socket.so or rdma.so not found. Please install glusterfs-server package")
+	}
+
+	for _, transport := range transports {
+		for _, option := range transport.Options {
+			// TODO:
+			// remove this once proper settable flags are set for
+			// these transport options in glusterfs source
+			option.Flags = option.Flags | options.OptionFlagSettable
+			if xl, ok := xlMap["server"]; ok {
+				xl.Options = append(xl.Options, option)
+			}
+			if xl, ok := xlMap["client"]; ok {
+				option.Flags = option.Flags | options.OptionFlagClientOpt
+				xl.Options = append(xl.Options, option)
 			}
 		}
 	}

--- a/glusterd2/xlator/load.go
+++ b/glusterd2/xlator/load.go
@@ -66,6 +66,12 @@ func structifyOption(cOpt *C.volume_option_t) *options.Option {
 	opt.SetKey = C.GoString(cOpt.setkey)
 	opt.Level = options.OptionLevel(cOpt.level)
 
+	// For boolean options, default value isn't set in xlator's option
+	// table as glusterfs code treats that case as false by default.
+	if opt.Type == options.OptionTypeBool && opt.DefaultValue == "" {
+		opt.DefaultValue = "off"
+	}
+
 	return &opt
 }
 

--- a/glusterd2/xlator/options/options.go
+++ b/glusterd2/xlator/options/options.go
@@ -247,16 +247,17 @@ func ValidateInternetAddress(o *Option, val string) error {
 	if len(val) == 0 {
 		return ErrInvalidArg
 	}
-	if !(validate.IsHost(val)) {
-		return ErrInvalidArg
-	} else if !(validate.IsIP(val)) {
-		return ErrInvalidArg
-	} else if !(validate.IsCIDR(val)) {
-		return ErrInvalidArg
-	} else if !(strings.ContainsAny(val, "* & # & ? & ^")) {
-		return ErrInvalidArg
+	if validate.IsHost(val) {
+		return nil
+	} else if validate.IsIP(val) {
+		return nil
+	} else if validate.IsCIDR(val) {
+		return nil
+	} else if strings.ContainsAny(val, "* & # & ? & ^") {
+		return nil
 	}
-	return nil
+
+	return ErrInvalidArg
 }
 
 // ValidateInternetAddressList validates the Internet Address List

--- a/glusterd2/xlator/options/utils.go
+++ b/glusterd2/xlator/options/utils.go
@@ -3,26 +3,51 @@ package options
 import (
 	"fmt"
 	"strings"
+
+	"github.com/gluster/glusterd2/pkg/utils"
 )
 
 // InvalidKeyError is returned by SplitKey if key is not of the correct form.
 type InvalidKeyError string
 
 func (e InvalidKeyError) Error() string {
-	return fmt.Sprintf("option key not in <graph>.<xlator>.<name> form: %s", string(e))
+	return fmt.Sprintf("option key not in [<graph>.]<xlator>.<option-name> form: %s", string(e))
+}
+
+var validGraphs = [...]string{
+	"brick",
+	"fuse",
+	"gfproxy",
+	"nfs",
 }
 
 // SplitKey returns three strings by breaking key of the form
-// [<graph>].<xlator>.<name> into its constituents. <graph> is optional.
+// [<graph>].<xlator>.<option-name> into its constituents. <graph> is optional.
 // Returns an InvalidKeyError if key is not of correcf form.
 func SplitKey(k string) (string, string, string, error) {
+	var graph, xlator, optName string
+
 	tmp := strings.Split(strings.TrimSpace(k), ".")
-	switch len(tmp) {
-	case 2:
-		return "", tmp[0], tmp[1], nil
-	case 3:
-		return tmp[0], tmp[1], tmp[2], nil
-	default:
-		return "", "", "", InvalidKeyError(k)
+	if len(tmp) < 2 {
+		// must at least be of the form <xlator>.<name>
+		return graph, xlator, optName, InvalidKeyError(k)
 	}
+
+	if utils.StringInSlice(tmp[0], validGraphs[:]) {
+		// valid graph present
+		if len(tmp) < 3 {
+			// must be of the form <graph>.<xlator>.<name>
+			return graph, xlator, optName, InvalidKeyError(k)
+		}
+		graph = tmp[0]
+		xlator = tmp[1]
+		optName = strings.Join(tmp[2:], ".")
+	} else {
+		// key is of the format <xlator>.<name> where <name> itself
+		// may contain dots. For example: transport.socket.ssl-enabled
+		xlator = tmp[0]
+		optName = k[len(xlator)+1:]
+	}
+
+	return graph, xlator, optName, nil
 }


### PR DESCRIPTION
This change enables setting up TLS for client to bricks communication.

Unlike glusterd1 which requires two separate options - `client.ssl` and
`server.ssl` to be turned on, turning TLS on for a volume in glusterd2
is a single volume set operation. TLS can be enabled for a volume as
follows:

    $ glustercli volume set <volname> --advanced tls on

To achieve this, when xlator shared ojects are loaded during startup,
options present in transport layer (socket.so and rdma.so) are injected
into list of options loaded from protocol layer (server.so and
client.so). The client and brick volfile expects the transport options
to be in client and server xlator sections.

This PR also tests that client authorization works as expected which can be used as follows:

```sh
$ glustercli volume set test --advanced server.ssl-allow <client-CN-name>
```
This is dependent on: https://review.gluster.org/#/c/20472

Other fixes:
* Add support for xlator options containing dots
* volume-set: Validate expanded group options (bug fix)
* Set default boolean value properly for group option
* Fix bug in validating internet addresses

Closes #214 
Closes #971 