### PR TITLE
Regenerating Volfiles on Volume Start and Stop

### DIFF
--- a/glusterd2/volgen/volfile_bitd.go
+++ b/glusterd2/volgen/volfile_bitd.go
@@ -14,6 +14,9 @@ func generateBitdVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, peerid
 	bitd := volfile.RootEntry.Add("debug/io-stats", nil, nil).SetName("bitd")
 
 	for volIdx, vol := range clusterinfo {
+		if vol.State != volume.VolStarted {
+			continue
+		}
 
 		//If bitrot not enabled for volume, then skip those bricks
 		val, exists := vol.Options["bitrot-stub.bitrot"]

--- a/glusterd2/volgen/volfile_quotad.go
+++ b/glusterd2/volgen/volfile_quotad.go
@@ -18,6 +18,10 @@ func generateQuotadVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, peer
 	quota := volfile.RootEntry.Add("features/quotad", nil, nil).SetName("quotad").SetExtraOptions(quotaOpts)
 
 	for _, v := range clusterinfo {
+		if v.State != volume.VolStarted {
+			continue
+		}
+
 		//If quota is not enabled for volume, then skip those volumes
 		val, exists := v.Options["quota.enable"]
 		if exists && val == "on" {

--- a/glusterd2/volgen/volfile_scrub.go
+++ b/glusterd2/volgen/volfile_scrub.go
@@ -14,6 +14,10 @@ func generateScrubVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, peeri
 	scrub := volfile.RootEntry.Add("debug/io-stats", nil, nil).SetName("scrub")
 
 	for volIdx, vol := range clusterinfo {
+		if vol.State != volume.VolStarted {
+			continue
+		}
+
 		//If bitrot not enabled for volume, then skip those bricks
 		val, exists := vol.Options["bitrot-stub.bitrot"]
 		if exists && val == "on" {

--- a/glusterd2/volgen/volfile_shd.go
+++ b/glusterd2/volgen/volfile_shd.go
@@ -11,6 +11,9 @@ func generateShdVolfile(volfile *Volfile, clusterinfo []*volume.Volinfo, peerid 
 	shd := volfile.RootEntry.Add("debug/io-stats", nil, nil).SetName("glustershd")
 
 	for _, vol := range clusterinfo {
+		if vol.State != volume.VolStarted {
+			continue
+		}
 
 		filters := clusterGraphFilters{subvolTypes: []volume.SubvolType{
 			volume.SubvolReplicate,


### PR DESCRIPTION
Cluster level volfiles should not contain the information about Stopped
Volumes. Added checks for the same while generating Cluster level
volfiles. But when Volume starts, these volfiles will not contain the
started Volume's info. iTo address this issue added Volfiles re-generation
after Volume Stop and Start.

Closes: #1005
Signed-off-by: Aravinda VK <avishwan@redhat.com>