### PR TITLE
cli: Add support for reading secret from ENV

### DIFF
--- a/e2e/config/1.toml
+++ b/e2e/config/1.toml
@@ -7,5 +7,4 @@ peeraddress = "127.0.0.1:24008"
 clientaddress = "127.0.0.1:24007"
 etcdcurls = "http://127.0.0.1:2479"
 etcdpurls = "http://127.0.0.1:2480"
-#restauth should be set to false to disable REST authentication in glusterd2
-#restauth = false
+restauth = true

--- a/e2e/config/2.toml
+++ b/e2e/config/2.toml
@@ -7,5 +7,4 @@ peeraddress = "127.0.0.1:23008"
 clientaddress = "127.0.0.1:23007"
 etcdcurls = "http://127.0.0.1:2379"
 etcdpurls = "http://127.0.0.1:2380"
-#restauth should be set to false to disable REST authentication in glusterd2
 restauth = true

--- a/e2e/config/3.toml
+++ b/e2e/config/3.toml
@@ -7,5 +7,4 @@ peeraddress = "127.0.0.1:22008"
 clientaddress = "127.0.0.1:22007"
 etcdcurls = "http://127.0.0.1:2279"
 etcdpurls = "http://127.0.0.1:2280"
-#restauth should be set to false to disable REST authentication in glusterd2
 restauth = true

--- a/e2e/config/4.toml
+++ b/e2e/config/4.toml
@@ -7,5 +7,4 @@ peeraddress = "127.0.0.1:21008"
 clientaddress = "127.0.0.1:21007"
 etcdcurls = "http://127.0.0.1:2179"
 etcdpurls = "http://127.0.0.1:2180"
-#restauth should be set to false to disable REST authentication in glusterd2
 restauth = true

--- a/glusterd2.toml.example
+++ b/glusterd2.toml.example
@@ -1,5 +1,5 @@
 localstatedir = "/var/lib/glusterd"
 peeraddress = ":24008"
 clientaddress = ":24007"
-#restauth should be set to false to disable REST authentication in glusterd2
-#restauth = false
+#restauth enables/disables REST authentication in glusterd2
+#restauth = true


### PR DESCRIPTION
With this change, secret is taken by CLI in following order of precedence (highest to lowest):
```
--secret
--secret-file
GLUSTERD2_AUTH_SECRET (environment variable)
--secret-file (default path)
```    

Other changes:

* The command-line flag `--authfile` has been renamed to `--secret-file` to be consistent with the flag `--secret`.
* This change also illustrates default value of restauth in sample config and removes examples from e2e test configurations.

Closes #994 