### PR TITLE
Thin arbiter brick for afr-pending-xattr list

### DIFF
--- a/glusterd2/volgen/clustergraph.go
+++ b/glusterd2/volgen/clustergraph.go
@@ -103,6 +103,9 @@ func clusterGraph(volfile *Volfile, dht *Entry, vol *volume.Volinfo, peerid uuid
 					remotePort = taParts[2]
 				}
 
+				afrPendingXattr = append(afrPendingXattr, fmt.Sprintf("%s-ta-%d", vol.Name, clientIdx))
+				clientIdx++
+
 				name := fmt.Sprintf("%s-thin-arbiter-client", subvol.Name)
 				parent.Add("protocol/client", vol, nil).
 					SetName(name).


### PR DESCRIPTION
`option afr-pending-xattr` will contain list of xattrs names which will
be used to find bricks for which heal is pending. With this PR,
thin-arbiter brick id also added to the `afr-pending-xattr` list.

Known issue: Brick index needs to be persisted which is tracked here #925

Closes: #1006
Signed-off-by: Aravinda VK <avishwan@redhat.com>