### PR TITLE
cli/restclient: Make client timeout configurable

### DIFF
--- a/glustercli/cmd/common.go
+++ b/glustercli/cmd/common.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gluster/glusterd2/pkg/restclient"
 )
@@ -20,6 +21,7 @@ var (
 
 func initRESTClient(hostname, user, secret, cacert string, insecure bool) {
 	client = restclient.New(hostname, user, secret, cacert, insecure)
+	client.SetTimeout(time.Duration(flagTimeout) * time.Second)
 }
 
 func isConnectionRefusedErr(err error) bool {

--- a/glustercli/cmd/root.go
+++ b/glustercli/cmd/root.go
@@ -23,6 +23,7 @@ var (
 
 const (
 	defaultLogLevel = "INFO"
+	defaultTimeout  = 30 // in seconds
 )
 
 // RootCmd represents main command
@@ -84,14 +85,15 @@ var (
 	// set by command line flags
 	flagXMLOutput  bool
 	flagJSONOutput bool
-	flagEndpoints  []string
-	flagCacert     string
 	flagInsecure   bool
-	flagLogLevel   string
 	verbose        bool
+	flagCacert     string
+	flagLogLevel   string
 	flagUser       string
 	flagSecret     string
 	flagSecretFile string
+	flagEndpoints  []string
+	flagTimeout    uint
 )
 
 func init() {
@@ -100,6 +102,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&flagJSONOutput, "json", "", false, "JSON Output")
 	RootCmd.PersistentFlags().StringSliceVar(&flagEndpoints, "endpoints", []string{"http://127.0.0.1:24007"}, "glusterd2 endpoints")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	RootCmd.PersistentFlags().UintVar(&flagTimeout, "timeout", defaultTimeout,
+		"overall client timeout (in seconds) which includes time taken to read the response body")
 
 	//user and secret for token authentication
 	RootCmd.PersistentFlags().StringVar(&flagUser, "user", "glustercli", "Username for authentication")


### PR DESCRIPTION
The client timeout is now configurable at the restclient layer and also
in the CLI. The client timeout defaults to 30 seconds in both restclient
and CLI.

Timeout can be configured in:
  * restclient using SetTimeout() API.
  * CLI using --timeout command line flag.

This client timeout is the overall timeout which includes the time taken
from setting up TCP connection till client finishes reading the response
body from glusterd2.

Closes #1027 
Signed-off-by: Prashanth Pai <ppai@redhat.com>