### PR TITLE
Volume: Add auto provision flag to brick info

### DIFF
--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -12,6 +12,9 @@ import (
 //go:generate stringer -type=Type
 type Type uint16
 
+//ProvisionType is the way a brick is provisioned
+type ProvisionType string
+
 const (
 	// Brick represents default type of brick
 	Brick Type = iota
@@ -38,6 +41,7 @@ type Brickinfo struct {
 	VolumeID       uuid.UUID
 	Type           Type
 	Decommissioned bool
+	PType          ProvisionType
 	MountInfo
 }
 
@@ -58,6 +62,33 @@ type Brickstatus struct {
 	MountOpts string
 	Device    string
 	Size      SizeInfo
+}
+
+const (
+	//ProvisionKey is used to set the type of provisioning in volume metadata
+	ProvisionKey string = "_brick-provision-type"
+
+	//ManuallyProvisioned bricks will be provisioned by a user
+	ManuallyProvisioned ProvisionType = ""
+	//AutoProvisioned bricks will be provsioned by device manager from glusterd2
+	AutoProvisioned ProvisionType = "auto"
+	//SnapshotProvisioned bricks will be created by performing a snapshot of a gluster brick
+	SnapshotProvisioned ProvisionType = "snapshot"
+)
+
+//IsManuallyProvisioned will return true if manually provisioned
+func (p ProvisionType) IsManuallyProvisioned() bool {
+	return p == ManuallyProvisioned
+}
+
+//IsAutoProvisioned will return true if auto provisioned
+func (p ProvisionType) IsAutoProvisioned() bool {
+	return p == AutoProvisioned
+}
+
+//IsSnapshotProvisioned will return true if provisioned via snapshot operation
+func (p ProvisionType) IsSnapshotProvisioned() bool {
+	return p == SnapshotProvisioned
 }
 
 func (b *Brickinfo) String() string {

--- a/glusterd2/commands/snapshot/snapshot-create.go
+++ b/glusterd2/commands/snapshot/snapshot-create.go
@@ -504,7 +504,7 @@ func createSnapSubvols(newVolinfo, origVolinfo *volume.Volinfo, nodeData map[str
 
 				bricks = append(bricks, brick)
 			}
-			s.Bricks, err = volume.NewBrickEntriesFunc(bricks, newVolinfo.Name, newVolinfo.VolfileID, newVolinfo.ID)
+			s.Bricks, err = volume.NewBrickEntriesFunc(bricks, newVolinfo.Name, newVolinfo.VolfileID, newVolinfo.ID, brick.SnapshotProvisioned)
 			if err != nil {
 				return err
 			}
@@ -563,6 +563,7 @@ func createSnapinfo(c transaction.TxnCtx) error {
 	snapInfo := new(snapshot.Snapinfo)
 	snapVolinfo := &snapInfo.SnapVolinfo
 	duplicateVolinfo(volinfo, snapVolinfo)
+	snapVolinfo.Metadata[brick.ProvisionKey] = string(brick.SnapshotProvisioned)
 
 	snapInfo.OptionChange = make(map[string]string)
 	snapInfo.CreatedAt = data.CreatedAt

--- a/glusterd2/commands/volumes/volume-create_test.go
+++ b/glusterd2/commands/volumes/volume-create_test.go
@@ -37,7 +37,7 @@ func TestCreateVolinfo(t *testing.T) {
 	assert.NotNil(t, vol)
 
 	// Mock failure in NewBrickEntries(), createVolume() should fail
-	defer testutils.Patch(&volume.NewBrickEntriesFunc, func(bricks []api.BrickReq, volName, volfileID string, volID uuid.UUID) ([]brick.Brickinfo, error) {
+	defer testutils.Patch(&volume.NewBrickEntriesFunc, func(bricks []api.BrickReq, volName, volfileID string, volID uuid.UUID, pT brick.ProvisionType) ([]brick.Brickinfo, error) {
 		return nil, errBad
 	}).Restore()
 	_, e = newVolinfo(msg)

--- a/glusterd2/commands/volumes/volume-delete.go
+++ b/glusterd2/commands/volumes/volume-delete.go
@@ -72,18 +72,13 @@ func volumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bricksAutoProvisioned := false
-	// TODO: Replace this with volinfo.Metadata["ProvisionState"] once available
-	if len(volinfo.Subvols) > 0 && len(volinfo.Subvols[0].Bricks) > 0 {
-		bricksAutoProvisioned = volinfo.Subvols[0].Bricks[0].DevicePath != ""
-	}
-
 	if len(volinfo.SnapList) > 0 {
 		errMsg := fmt.Sprintf("Cannot delete Volume %s ,as it has %d snapshots.", volname, len(volinfo.SnapList))
 		restutils.SendHTTPError(ctx, w, http.StatusFailedDependency, errMsg)
 		return
 	}
 
+	bricksAutoProvisioned := volinfo.IsAutoProvisioned() || volinfo.IsSnapshotProvisioned()
 	txn.Steps = []*transaction.Step{
 		{
 			DoFunc: "vol-delete.CleanBricks",

--- a/glusterd2/commands/volumes/volume-expand-txn.go
+++ b/glusterd2/commands/volumes/volume-expand-txn.go
@@ -27,6 +27,9 @@ func expandValidatePrepare(c transaction.TxnCtx) error {
 		return err
 	}
 
+	//As of now volume expand doesn't support auto provisioned bricks
+	provisionType := brick.ManuallyProvisioned
+
 	volinfo, err := volume.GetVolume(volname)
 	if err != nil {
 		return err
@@ -49,7 +52,7 @@ func expandValidatePrepare(c transaction.TxnCtx) error {
 		}
 	}
 
-	newBricks, err := volume.NewBrickEntriesFunc(req.Bricks, volinfo.Name, volinfo.VolfileID, volinfo.ID)
+	newBricks, err := volume.NewBrickEntriesFunc(req.Bricks, volinfo.Name, volinfo.VolfileID, volinfo.ID, provisionType)
 	if err != nil {
 		c.Logger().WithError(err).Error("failed to create new brick entries")
 		return err

--- a/glusterd2/utils/mount.go
+++ b/glusterd2/utils/mount.go
@@ -38,8 +38,9 @@ func MountLocalBricks() error {
 
 	for _, v := range volumes {
 		for _, b := range v.GetLocalBricks() {
-			// Mount all local Bricks if they are auto provisioned
-			if b.MountInfo.DevicePath != "" {
+			// Mount all local bricks if they are auto provisioned or inherited via snapshot creation
+			provisionType := b.PType
+			if provisionType.IsAutoProvisioned() || provisionType.IsSnapshotProvisioned() {
 				mountRoot := strings.TrimSuffix(b.Path, b.MountInfo.Mountdir)
 				if _, exists := mounts[mountRoot]; exists {
 					continue

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -124,7 +124,7 @@ func (v *Volinfo) StringMap() map[string]string {
 }
 
 // NewBrickEntries creates the brick list
-func NewBrickEntries(bricks []api.BrickReq, volName, volfileID string, volID uuid.UUID) ([]brick.Brickinfo, error) {
+func NewBrickEntries(bricks []api.BrickReq, volName, volfileID string, volID uuid.UUID, ptype brick.ProvisionType) ([]brick.Brickinfo, error) {
 	var brickInfos []brick.Brickinfo
 	var binfo brick.Brickinfo
 
@@ -161,8 +161,9 @@ func NewBrickEntries(bricks []api.BrickReq, volName, volfileID string, volID uui
 		binfo.VolumeID = volID
 		binfo.ID = uuid.NewRandom()
 
-		// Auto provisioned bricks
-		if b.VgName != "" && b.LvName != "" {
+		binfo.PType = ptype
+		if ptype.IsAutoProvisioned() {
+			// Auto provisioned bricks
 			binfo.MountInfo = brick.MountInfo{
 				Mountdir:   b.Mountdir,
 				DevicePath: b.DevicePath,

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -223,3 +223,27 @@ func CreateVolumeInfoResp(v *Volinfo) *api.VolumeInfo {
 
 	return resp
 }
+
+//IsSnapshotProvisioned will return true if volume is provisioned through snapshot creation
+func (v *Volinfo) IsSnapshotProvisioned() bool {
+	return (v.GetProvisionType().IsSnapshotProvisioned())
+}
+
+//IsAutoProvisioned will return true if volume is automatically provisioned
+func (v *Volinfo) IsAutoProvisioned() bool {
+	return (v.GetProvisionType().IsAutoProvisioned())
+}
+
+//GetProvisionType will return true the type of provision state
+func (v *Volinfo) GetProvisionType() brick.ProvisionType {
+
+	var provisionType brick.ProvisionType
+
+	provisionValue, ok := v.Metadata[brick.ProvisionKey]
+	if !ok {
+		provisionType = brick.ManuallyProvisioned
+	} else {
+		provisionType = brick.ProvisionType(provisionValue)
+	}
+	return provisionType
+}

--- a/glusterd2/volume/volume_test.go
+++ b/glusterd2/volume/volume_test.go
@@ -42,7 +42,7 @@ func TestNewBrickEntry(t *testing.T) {
 	bricks := getSampleBricks("/tmp/b1", "/tmp/b2")
 	brickPaths := []string{"/tmp/b1", "/tmp/b2"}
 
-	b, err := NewBrickEntriesFunc(bricks, "volume", "volume", nil)
+	b, err := NewBrickEntriesFunc(bricks, "volume", "volume", nil, "")
 	assert.Nil(t, err)
 	assert.NotNil(t, b)
 	for _, brick := range b {
@@ -54,7 +54,7 @@ func TestNewBrickEntry(t *testing.T) {
 		{PeerID: "", Path: "/tmp/b1"},
 		{PeerID: "", Path: "/tmp/b2"},
 	} //with out IPs
-	_, err = NewBrickEntriesFunc(mockBricks, "volume", "volume", nil)
+	_, err = NewBrickEntriesFunc(mockBricks, "volume", "volume", nil, "")
 	assert.NotNil(t, err)
 
 	//Now mock filepath.Abs()
@@ -62,7 +62,7 @@ func TestNewBrickEntry(t *testing.T) {
 		return "", errors.ErrBrickPathConvertFail
 	}).Restore()
 
-	_, err = NewBrickEntriesFunc(bricks, "volume", "volume", nil)
+	_, err = NewBrickEntriesFunc(bricks, "volume", "volume", nil, "")
 	assert.Equal(t, errors.ErrBrickPathConvertFail, err)
 
 }


### PR DESCRIPTION
Brick should be able to identify whether it is auto provisioned
or not. This is required for cases like

* Mounting of a brick in glusterd restart
* Umounting of a brick on volume stop/delete
* delete brick directoroy when volume is deleted
* delete vg/lv during volume delete
* To smoothly handle replace brick/reset brick on auto provisioned bricks

Signed-off-by: Mohammed Rafi KC <rkavunga@redhat.com>