### PR TITLE
Xlator mismatch in brick volfile

### DIFF
--- a/glusterd2/volgen/volfile_brick.go
+++ b/glusterd2/volgen/volfile_brick.go
@@ -18,8 +18,8 @@ func generateBrickVolfile(volfile *Volfile, b *brick.Brickinfo, vol *volume.Voli
 	last := volfile.RootEntry.
 		Add("protocol/server", vol, b).
 		Add("performance/decompounder", vol, b).SetName(b.Path).
-		Add("features/sdfs", vol, b).
 		Add("debug/io-stats", vol, b).
+		Add("features/sdfs", vol, b).
 		Add("features/quota", vol, b).
 		Add("features/index", vol, b).
 		Add("features/barrier", vol, b).


### PR DESCRIPTION
Fixes [#1038](https://github.com/gluster/glusterd2/issues/1038)

Change ordering of sdfs and io-stats in brick volfile.