### PR TITLE
arbiter: Support replica 2 arbiter 1 usage

### DIFF
--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -106,7 +106,7 @@ func testSmartVolumeArbiter(t *testing.T) {
 	createReq := api.VolCreateReq{
 		Name:         smartvolname,
 		Size:         20,
-		ReplicaCount: 3,
+		ReplicaCount: 2,
 		ArbiterCount: 1,
 	}
 	volinfo, err := client.VolumeCreate(createReq)

--- a/glusterd2/bricksplanner/subvoltype_replicate.go
+++ b/glusterd2/bricksplanner/subvoltype_replicate.go
@@ -22,11 +22,11 @@ func (s *replicaSubvolPlanner) Init(req *api.VolCreateReq, subvolSize uint64) {
 }
 
 func (s *replicaSubvolPlanner) BricksCount() int {
-	return s.replicaCount
+	return s.replicaCount + s.arbiterCount
 }
 
 func (s *replicaSubvolPlanner) BrickSize(idx int) uint64 {
-	if idx == (s.replicaCount-1) && s.arbiterCount > 0 {
+	if idx == (s.replicaCount) && s.arbiterCount > 0 {
 		return s.arbiterBrickSize
 	}
 
@@ -34,7 +34,7 @@ func (s *replicaSubvolPlanner) BrickSize(idx int) uint64 {
 }
 
 func (s *replicaSubvolPlanner) BrickType(idx int) string {
-	if idx == (s.replicaCount-1) && s.arbiterCount > 0 {
+	if idx == (s.replicaCount) && s.arbiterCount > 0 {
 		return "arbiter"
 	}
 

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -65,8 +65,8 @@ func populateSubvols(volinfo *volume.Volinfo, req *api.VolCreateReq) error {
 			return errors.New("replica count not specified")
 		}
 
-		if subvolreq.ReplicaCount > 0 && subvolreq.ReplicaCount != len(subvolreq.Bricks) {
-			return errors.New("invalid number of bricks")
+		if subvolreq.ReplicaCount > 0 && (subvolreq.ReplicaCount+subvolreq.ArbiterCount) != len(subvolreq.Bricks) {
+			return errors.New("invalid number of bricks specified. Number of bricks must be a multiple of replica (+arbiter) count")
 		}
 
 		name := fmt.Sprintf("%s-%s-%d", volinfo.Name, strings.ToLower(subvolreq.Type), idx)
@@ -88,8 +88,8 @@ func populateSubvols(volinfo *volume.Volinfo, req *api.VolCreateReq) error {
 		}
 
 		if subvolreq.ArbiterCount != 0 {
-			if subvolreq.ReplicaCount != 3 || subvolreq.ArbiterCount != 1 {
-				return errors.New("for arbiter configuration, replica count must be 3 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter")
+			if subvolreq.ReplicaCount != 2 || subvolreq.ArbiterCount != 1 {
+				return errors.New("for arbiter configuration, replica count must be 2 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter")
 			}
 			s.ArbiterCount = 1
 		}


### PR DESCRIPTION
Change syntax for creation of arbiter volumes from:
`replica 3 arbiter `
to
`replica 2 arbiter 1`

Closes #515 
Signed-off-by: Prashanth Pai <ppai@redhat.com>