### PR TITLE
geo-rep: Fixes for remote authentication and gsyncd path

### DIFF
--- a/glustercli/cmd/root.go
+++ b/glustercli/cmd/root.go
@@ -95,7 +95,7 @@ func (gOpt *GlustercliOption) AddPersistentFlag(flagSet *pflag.FlagSet) {
 	// SSL/TLS options
 	flagSet.StringVarP(&gOpt.Cacert, "cacert", "", "", "Path to CA certificate")
 	flagSet.BoolVarP(&gOpt.Insecure, "insecure", "", false,
-		"Accepts any certificate presented by the server and any host name in that certificate.")
+		"Skip server certificate validation")
 }
 
 //Init will initialize logging, secret and rest client

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -174,6 +174,12 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// Workaround till {{ volume.id }} added to the marker options table
 	vol.Options["marker.volume-uuid"] = vol.ID.String()
 
+	// Workaround till {{ workdir }} added to the marker options table
+	vol.Options["marker.timestamp-file"] = path.Join(
+		config.GetString("localstatedir"),
+		"{{ volume.name }}.marker.tstamp",
+	)
+
 	//save volume information for transaction failure scenario
 	if err := txn.Ctx.Set("oldvolinfo", oldvolinfo); err != nil {
 		logger.WithError(err).Error("failed to set oldvolinfo in transaction context")
@@ -610,7 +616,7 @@ func checkConfig(name string, value string) error {
 	if value != "" {
 		args = append(args, "--value", value)
 	}
-	return utils.ExecuteCommandRun(gsyncdCommand, args...)
+	return utils.ExecuteCommandRun(getGsyncdCommand(), args...)
 }
 
 func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
@@ -646,7 +652,7 @@ func georepConfigGetHandler(w http.ResponseWriter, r *http.Request) {
 		"--show-defaults",
 		"--json",
 	}
-	out, err := utils.ExecuteCommandOutput(gsyncdCommand, args...)
+	out, err := utils.ExecuteCommandOutput(getGsyncdCommand(), args...)
 	if err != nil {
 		logger.WithError(err).WithFields(log.Fields{
 			"mastervolid": masterid,

--- a/plugins/georeplication/transactions.go
+++ b/plugins/georeplication/transactions.go
@@ -166,7 +166,7 @@ func txnGeorepStatus(c transaction.TxnCtx) error {
 		}
 		args := gsyncd.statusArgs(w.Path)
 
-		out, err := utils.ExecuteCommandOutput(gsyncdCommand, args...)
+		out, err := utils.ExecuteCommandOutput(getGsyncdCommand(), args...)
 		if err != nil {
 			return err
 		}
@@ -415,7 +415,7 @@ func txnSSHKeysPush(c transaction.TxnCtx) error {
 		return err
 	}
 
-	sshCmdGsyncdPrefix := "command=\"" + gsyncdCommand + "\"  "
+	sshCmdGsyncdPrefix := "command=\"" + getGsyncdCommand() + "\"  "
 	sshCmdTarPrefix := "command=\"tar ${SSH_ORIGINAL_COMMAND#* }\"  "
 	authorizedKeysFile := "/root/.ssh/authorized_keys"
 


### PR DESCRIPTION
- gsyncd path defaulted to `/usr/libexec/glusterfs/gsyncd`
- Fixes remote REST API auth issues
- Workaround to make it work with marker xlator

Signed-off-by: Aravinda VK <avishwan@redhat.com>