### PR TITLE
cli: Valiate Last Error Response in failure function of GlusterCli

### DIFF
--- a/glustercli/cmd/common.go
+++ b/glustercli/cmd/common.go
@@ -56,9 +56,14 @@ func failure(msg string, err error, errcode int) {
 
 	w.WriteString(msg + "\n")
 
-	if err != nil {
-		resp := client.LastErrorResponse()
+	resp := client.LastErrorResponse()
 
+	if resp == nil && err != nil {
+		fmt.Fprintln(w, err)
+		os.Exit(errcode)
+	}
+
+	if err != nil {
 		w.WriteString("\nResponse headers:\n")
 		for k, v := range resp.Header {
 			if strings.HasSuffix(k, "-Id") {


### PR DESCRIPTION
If last Error Response is nil, then calling failure function will cause
segmentation fault error
Fixes #1115

Signed-off-by: Oshank Kumar <okumar@redhat.com>