### PR TITLE
etcd txn: Add expvar counters to wrappers

### DIFF
--- a/glusterd2/store/store.go
+++ b/glusterd2/store/store.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"errors"
+	"expvar"
 	"fmt"
 	"os"
 	"sync"
@@ -24,6 +25,8 @@ const (
 	putTimeout    = 5
 	deleteTimeout = 5
 )
+
+var storeCounters = expvar.NewMap("store")
 
 var (
 	// Store is the default GDStore that must to be used by the packages in GD2
@@ -191,6 +194,7 @@ func Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.
 		defer cancel()
 	}
 
+	defer storeCounters.Add("get", 1)
 	return Store.Get(ctx, key, opts...)
 }
 
@@ -202,6 +206,8 @@ func Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clie
 		ctx, cancel = context.WithTimeout(context.Background(), putTimeout*time.Second)
 		defer cancel()
 	}
+
+	defer storeCounters.Add("put", 1)
 	return Store.Put(ctx, key, val, opts...)
 }
 
@@ -213,6 +219,8 @@ func Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*client
 		ctx, cancel = context.WithTimeout(context.Background(), deleteTimeout*time.Second)
 		defer cancel()
 	}
+
+	defer storeCounters.Add("delete", 1)
 	return Store.Delete(ctx, key, opts...)
 }
 
@@ -220,5 +228,6 @@ func Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*client
 func Txn(ctx context.Context) clientv3.Txn {
 	// can't cancel() here as caller will have to eventually call
 	// clientv3.Txn.Commit()
+	defer storeCounters.Add("txn", 1)
 	return Store.Txn(ctx)
 }

--- a/glusterd2/store/store.go
+++ b/glusterd2/store/store.go
@@ -215,3 +215,10 @@ func Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*client
 	}
 	return Store.Delete(ctx, key, opts...)
 }
+
+// Txn is a wrapper function that calls clientv3.KV.Txn which creates a transaction
+func Txn(ctx context.Context) clientv3.Txn {
+	// can't cancel() here as caller will have to eventually call
+	// clientv3.Txn.Commit()
+	return Store.Txn(ctx)
+}

--- a/glusterd2/transaction/context.go
+++ b/glusterd2/transaction/context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"time"
 
 	"github.com/gluster/glusterd2/glusterd2/store"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
+
+const etcdTxnTimeout = 10
 
 // TxnCtx is used to carry contextual information across the lifetime of a transaction
 type TxnCtx interface {
@@ -96,11 +99,13 @@ func (c *Tctx) commit() error {
 		putOps = append(putOps, clientv3.OpPut(key, value))
 	}
 
-	txn, err := store.Store.Txn(context.TODO()).
+	ctx, cancel := context.WithTimeout(context.Background(), etcdTxnTimeout*time.Second)
+	txn, err := store.Txn(ctx).
 		If().
 		Then(putOps...).
 		Else().
 		Commit()
+	cancel()
 
 	if err != nil || !txn.Succeeded {
 		msg := "etcd txn to store txn context keys failed"


### PR DESCRIPTION
...so that we can quickly know how many etcd operations are invoked
in a particular glusterd2 volume operation.

These expvar metrics can be seen using `/statedump` endpoint.

Updates https://github.com/gluster/glusterd2/issues/1079