### PR TITLE
Data Race While Starting GD2.

### DIFF
--- a/glusterd2/events/eventhandler.go
+++ b/glusterd2/events/eventhandler.go
@@ -106,10 +106,10 @@ func handleEvents(in <-chan *api.Event, h Handler) {
 	for e := range in {
 		if interested(e, events) {
 			wg.Add(1)
-			go func() {
+			go func(e *api.Event) {
 				h.Handle(e)
 				wg.Done()
-			}()
+			}(e)
 		}
 	}
 

--- a/glusterd2/events/liveness.go
+++ b/glusterd2/events/liveness.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"errors"
 	"strings"
 	"sync"
 
@@ -19,6 +18,7 @@ const (
 type livenessWatcher struct {
 	stopCh chan struct{}
 	wg     sync.WaitGroup
+	stop   sync.Once
 }
 
 var lWatcher *livenessWatcher
@@ -68,12 +68,10 @@ func (l *livenessWatcher) Watch() {
 //Stop will stop the livenessWatcher if it is running and waits for
 //it to exit.
 func (l *livenessWatcher) Stop() error {
-	if l.stopCh == nil {
-		return errors.New("livness watcher has not been started")
-	}
-	close(l.stopCh)
-	l.stopCh = nil
-	l.wg.Wait()
+	l.stop.Do(func() {
+		close(l.stopCh)
+		l.wg.Wait()
+	})
 	return nil
 }
 


### PR DESCRIPTION
If we build GD2 by enabling the -race flag,
then On startup of GD2 it shows Data Race warning.
Fixes #715

Signed-off-by: Oshank Kumar <okumar@redhat.com>