### PR TITLE
rest: Return 'Location' header in 201 Created responses

### DIFF
--- a/glusterd2/commands/peers/addpeer.go
+++ b/glusterd2/commands/peers/addpeer.go
@@ -128,6 +128,7 @@ func addPeerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := createPeerAddResp(newpeer)
+	restutils.SetLocationHeader(r, w, newpeer.ID.String())
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
 
 	// Save updated store endpoints for restarts

--- a/glusterd2/commands/peers/editpeer.go
+++ b/glusterd2/commands/peers/editpeer.go
@@ -79,7 +79,7 @@ func editPeer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := createPeerEditResp(&peerInfo)
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, resp)
 
 }
 

--- a/glusterd2/commands/snapshot/snapshot-clone.go
+++ b/glusterd2/commands/snapshot/snapshot-clone.go
@@ -380,6 +380,7 @@ func snapshotCloneHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := createVolumeCreateResp(vol)
+	restutils.SetLocationHeader(r, w, vol.Name)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
 
 }

--- a/glusterd2/commands/snapshot/snapshot-create.go
+++ b/glusterd2/commands/snapshot/snapshot-create.go
@@ -783,8 +783,8 @@ func snapshotCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := createSnapCreateResp(&snapInfo)
+	restutils.SetLocationHeader(r, w, snapInfo.SnapVolinfo.Name)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
-
 }
 
 // createSnapCreateResp functions create resnse for rest utils

--- a/glusterd2/commands/volumes/optiongroup-create.go
+++ b/glusterd2/commands/volumes/optiongroup-create.go
@@ -66,5 +66,8 @@ func optionGroupCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, req)
+	// FIXME: Change this to http.StatusCreated when we are able to set
+	// location header with a unique URL that points to created option
+	// group.
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, req)
 }

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -218,6 +218,7 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 	events.Broadcast(volume.NewEvent(volume.EventVolumeCreated, volinfo))
 
 	resp := createVolumeCreateResp(volinfo)
+	restutils.SetLocationHeader(r, w, volinfo.Name)
 	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, resp)
 }
 

--- a/glusterd2/servers/rest/utils/utils.go
+++ b/glusterd2/servers/rest/utils/utils.go
@@ -19,6 +19,17 @@ func UnmarshalRequest(r *http.Request, v interface{}) error {
 	return json.NewDecoder(r.Body).Decode(v)
 }
 
+// SetLocationHeader sets the HTTP 'Location' header in returned response. The
+// spec requires that this header be set for following responses: 201, 3xx.
+// An obsolete version of the HTTP 1.1 spec (IETF RFC 2616) required a complete
+// absolute URI to be returned. However, the updated HTTP 1.1 spec (IETF RFC
+// 7231) relaxed the original constraint, allowing the use of relative URLs in
+// Location headers.
+func SetLocationHeader(r *http.Request, w http.ResponseWriter, resourceID string) {
+	relativeURL := fmt.Sprintf("%s/%s", r.URL, resourceID)
+	w.Header().Set("Location", relativeURL)
+}
+
 // SendHTTPResponse sends non-error response to the client.
 func SendHTTPResponse(ctx context.Context, w http.ResponseWriter, statusCode int, resp interface{}) {
 

--- a/pkg/restclient/device.go
+++ b/pkg/restclient/device.go
@@ -12,6 +12,6 @@ func (c *Client) DeviceAdd(peerid string, device string) (deviceapi.AddDeviceRes
 	req := deviceapi.AddDeviceReq{
 		Device: device,
 	}
-	err := c.post("/v1/devices/"+peerid, req, http.StatusCreated, &peerinfo)
+	err := c.post("/v1/devices/"+peerid, req, http.StatusOK, &peerinfo)
 	return peerinfo, err
 }

--- a/pkg/restclient/georep.go
+++ b/pkg/restclient/georep.go
@@ -11,7 +11,7 @@ import (
 func (c *Client) GeorepCreate(mastervolid string, slavevolid string, req georepapi.GeorepCreateReq) (georepapi.GeorepSession, error) {
 	var session georepapi.GeorepSession
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s", mastervolid, slavevolid)
-	err := c.post(url, req, http.StatusCreated, &session)
+	err := c.post(url, req, http.StatusOK, &session)
 	return session, err
 }
 
@@ -86,7 +86,7 @@ func (c *Client) GeorepStatus(mastervolid string, slavevolid string) ([]georepap
 func (c *Client) GeorepSSHKeysGenerate(volname string) ([]georepapi.GeorepSSHPublicKey, error) {
 	url := "/v1/ssh-key/" + volname + "/generate"
 	var sshkeys []georepapi.GeorepSSHPublicKey
-	err := c.post(url, nil, http.StatusCreated, &sshkeys)
+	err := c.post(url, nil, http.StatusOK, &sshkeys)
 	return sshkeys, err
 }
 
@@ -101,7 +101,7 @@ func (c *Client) GeorepSSHKeys(volname string) ([]georepapi.GeorepSSHPublicKey, 
 // GeorepSSHKeysPush pushes SSH public keys to all Volume nodes
 func (c *Client) GeorepSSHKeysPush(volname string, sshkeys []georepapi.GeorepSSHPublicKey) error {
 	url := "/v1/ssh-key/" + volname + "/push"
-	return c.post(url, sshkeys, http.StatusCreated, nil)
+	return c.post(url, sshkeys, http.StatusOK, nil)
 }
 
 // GeorepGet gets Geo-replication options

--- a/pkg/restclient/volume.go
+++ b/pkg/restclient/volume.go
@@ -153,7 +153,7 @@ func (c *Client) VolumeStatedump(volname string, req api.VolStatedumpReq) error 
 
 // OptionGroupCreate creates a new option group
 func (c *Client) OptionGroupCreate(req api.OptionGroupReq) error {
-	return c.post("/v1/volumes/options-group", req, http.StatusCreated, nil)
+	return c.post("/v1/volumes/options-group", req, http.StatusOK, nil)
 }
 
 // OptionGroupList returns a list of all option groups

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -100,7 +100,9 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, peerInfo)
+	// FIXME: Change this to http.StatusCreated when we are able to set
+	// location header with a unique URL that points to created device.
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, peerInfo)
 }
 
 func deviceListHandler(w http.ResponseWriter, r *http.Request) {

--- a/plugins/georeplication/rest.go
+++ b/plugins/georeplication/rest.go
@@ -220,7 +220,7 @@ func georepCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	events.Broadcast(newGeorepEvent(eventGeorepCreated, geoSession, nil))
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, geoSession)
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, geoSession)
 }
 
 func georepActionHandler(w http.ResponseWriter, r *http.Request, action actionType) {
@@ -1020,7 +1020,7 @@ func georepSSHKeyGenerateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, sshkeys)
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, sshkeys)
 }
 
 func georepSSHKeyGetHandler(w http.ResponseWriter, r *http.Request) {
@@ -1102,5 +1102,5 @@ func georepSSHKeyPushHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restutils.SendHTTPResponse(ctx, w, http.StatusCreated, nil)
+	restutils.SendHTTPResponse(ctx, w, http.StatusOK, nil)
 }


### PR DESCRIPTION
When new resources such as peers, volumes and snapshots are created,
we return a `201 Created` response. The [HTTP RFC](https://tools.ietf.org/html/rfc7231#page-68) requires us to
return a `Location` header which contains an absolute or relative URL to
the newly created resource.

In cases where no new uniquely identifiable resource was created (georep),
we return a `200 OK` instead of `201 Created`

Other fix:
Return status `200 OK` and not `201 Created` in response to peer edit
request.

Fixes #1077 