### PR TITLE
Updating development guide to use golang version 1.9

### DIFF
--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -9,7 +9,7 @@ Glusterd2 is written in Go and if you are new to the language, it is **highly** 
 
 ### Workspace and repository setup
 
-1. [Download](https://golang.org/dl/) Go (>=1.8) and [install](https://golang.org/doc/install) it on your system.
+1. [Download](https://golang.org/dl/) Go (>=1.9) and [install](https://golang.org/doc/install) it on your system.
 1. Setup the [GOPATH](http://www.g33knotes.org/2014/07/60-second-count-down-to-go.html) environment.
 1. Run `$ go get -d github.com/gluster/glusterd2`  
    This will just download the source and not build it. The downloaded source will be at `$GOPATH/src/github.com/gluster/glusterd2`


### PR DESCRIPTION
With respect to https://github.com/gluster/glusterd2/pull/1123. Using golang 1.9 or higher instead of 1.8. @prashanthpai Please check if we need to make changes in any other documentation.