### PR TITLE
Fix snapshot clone issue if snap mount dir is symlinked

### DIFF
--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -148,13 +149,17 @@ func GetBrickMountRoot(brickPath string) (string, error) {
 
 //GetBrickMountInfo return mount related information
 func GetBrickMountInfo(mountRoot string) (*Mntent, error) {
+	realMountRoot, err := filepath.EvalSymlinks(mountRoot)
+	if err != nil {
+		return nil, err
+	}
 	mtabEntries, err := GetMounts()
 	if err != nil {
 		return nil, err
 	}
 
 	for _, entry := range mtabEntries {
-		if entry.MntDir == mountRoot {
+		if entry.MntDir == mountRoot || entry.MntDir == realMountRoot {
 			return entry, nil
 		}
 	}


### PR DESCRIPTION
In my machine, `/var/run` is symlinked to `/run`. Snapshot bricks are
mounted in `/var/run` but `df` or `mount` output shows `/run`.

Snapshot clone fails with following error

    Transaction step snap-clone.Validate failed on peer \
        4e646eb6-0f51-4385-9892-a3a4ec7b1a67 with error: \
        mount point not found

This PR fixes the issue by comparing realpath with the mount command
output.

Signed-off-by: Aravinda VK <avishwan@redhat.com>