### PR TITLE
restClient: return http.Response along with error from all Rest Client APIs

### DIFF
--- a/e2e/bitrot_test.go
+++ b/e2e/bitrot_test.go
@@ -61,12 +61,13 @@ func testBitrotOnReplicaVolume(t *testing.T, tc *testCluster) {
 		Force: true,
 	}
 
-	_, err := client.VolumeCreate(createReq)
+	_, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	testbitrot(t)
 
-	r.Nil(client.VolumeDelete(volumeName))
+	_, err = client.VolumeDelete(volumeName)
+	r.Nil(err)
 }
 
 func testBitrotOnDistVolume(t *testing.T, tc *testCluster) {
@@ -100,14 +101,15 @@ func testBitrotOnDistVolume(t *testing.T, tc *testCluster) {
 		Force: true,
 	}
 
-	_, err := client.VolumeCreate(createReq)
+	_, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
-	_, err = client.Volumes(volumeName)
+	_, _, err = client.Volumes(volumeName)
 	r.Nil(err)
 	testbitrot(t)
 
-	r.Nil(client.VolumeDelete(volumeName))
+	_, err = client.VolumeDelete(volumeName)
+	r.Nil(err)
 
 }
 
@@ -116,64 +118,64 @@ func testbitrot(t *testing.T) {
 	r := require.New(t)
 
 	//check bitrot status, before starting volume
-	_, err1 := client.BitrotScrubStatus(volumeName)
+	_, _, err1 := client.BitrotScrubStatus(volumeName)
 	r.Contains(err1.Error(), "volume not started")
 
 	//start volume
-	err := client.VolumeStart(volumeName, true)
+	_, err := client.VolumeStart(volumeName, true)
 	r.Nil(err)
 
 	//check bitrot status on started volume
-	_, err = client.BitrotScrubStatus(volumeName)
+	_, _, err = client.BitrotScrubStatus(volumeName)
 	r.Contains(err.Error(), "bitrot is not enabled")
 
 	//enable bitrot on volume
-	err = client.BitrotEnable(volumeName)
+	_, err = client.BitrotEnable(volumeName)
 	r.Nil(err)
 
 	//check bitrot status
-	scrubStatus, err := client.BitrotScrubStatus(volumeName)
+	scrubStatus, _, err := client.BitrotScrubStatus(volumeName)
 	r.Nil(err)
 	r.Equal(scrubStatus.State, "Active (Idle)")
 
 	//disable bitrot on volume
-	err = client.BitrotDisable(volumeName)
+	_, err = client.BitrotDisable(volumeName)
 	r.Nil(err)
 
 	//check bitrot status
-	_, err = client.BitrotScrubStatus(volumeName)
+	_, _, err = client.BitrotScrubStatus(volumeName)
 	r.Contains(err.Error(), "bitrot is not enabled")
 
 	//stop volume
-	err = client.VolumeStop(volumeName)
+	_, err = client.VolumeStop(volumeName)
 	r.Nil(err)
 
 	//check bitrot status
-	_, err = client.BitrotScrubStatus(volumeName)
+	_, _, err = client.BitrotScrubStatus(volumeName)
 	r.Contains(err.Error(), "volume not started")
 
 	//enable bitrot on volume
-	err = client.BitrotEnable(volumeName)
+	_, err = client.BitrotEnable(volumeName)
 	r.Contains(err.Error(), "volume not started")
 
 	//start volume
-	err = client.VolumeStart(volumeName, true)
+	_, err = client.VolumeStart(volumeName, true)
 	r.Nil(err)
 
 	//check bitrot status
-	scrubStatus, err = client.BitrotScrubStatus(volumeName)
+	scrubStatus, _, err = client.BitrotScrubStatus(volumeName)
 	r.Contains(err.Error(), "bitrot is not enabled")
 
 	//disable bitrot on volume
-	err = client.BitrotDisable(volumeName)
+	_, err = client.BitrotDisable(volumeName)
 	r.Contains(err.Error(), "bitrot is already disabled")
 
 	//check bitrot status
-	_, err = client.BitrotScrubStatus(volumeName)
+	_, _, err = client.BitrotScrubStatus(volumeName)
 	r.Contains(err.Error(), "bitrot is not enabled")
 
 	//stop volume
-	err = client.VolumeStop(volumeName)
+	_, err = client.VolumeStop(volumeName)
 	r.Nil(err)
 
 }

--- a/e2e/georep_test.go
+++ b/e2e/georep_test.go
@@ -44,7 +44,7 @@ func TestGeorepCreateDelete(t *testing.T) {
 		},
 		Force: true,
 	}
-	vol1, err := client.VolumeCreate(reqVol)
+	vol1, _, err := client.VolumeCreate(reqVol)
 	r.Nil(err)
 
 	volname2 := "testvol2"
@@ -61,7 +61,7 @@ func TestGeorepCreateDelete(t *testing.T) {
 		},
 		Force: true,
 	}
-	vol2, err := client.VolumeCreate(reqVol)
+	vol2, _, err := client.VolumeCreate(reqVol)
 	r.Nil(err)
 
 	reqGeorep := georepapi.GeorepCreateReq{
@@ -72,18 +72,18 @@ func TestGeorepCreateDelete(t *testing.T) {
 		},
 	}
 
-	_, err = client.GeorepCreate(vol1.ID.String(), vol2.ID.String(), reqGeorep)
+	_, _, err = client.GeorepCreate(vol1.ID.String(), vol2.ID.String(), reqGeorep)
 	r.Nil(err)
 
 	// delete geo-rep session
-	err = client.GeorepDelete(vol1.ID.String(), vol2.ID.String(), false)
+	_, err = client.GeorepDelete(vol1.ID.String(), vol2.ID.String(), false)
 	r.Nil(err)
 
 	// delete volume
-	err = client.VolumeDelete(volname)
+	_, err = client.VolumeDelete(volname)
 	r.Nil(err)
 
 	// delete volume
-	err = client.VolumeDelete(volname2)
+	_, err = client.VolumeDelete(volname2)
 	r.Nil(err)
 }

--- a/e2e/glustershd_test.go
+++ b/e2e/glustershd_test.go
@@ -43,16 +43,19 @@ func TestSelfHeal(t *testing.T) {
 		},
 		Force: true,
 	}
-	vol1, err := client.VolumeCreate(reqVol)
+	vol1, _, err := client.VolumeCreate(reqVol)
 	r.Nil(err)
 
-	r.Nil(client.VolumeStart(vol1.Name, false), "volume start failed")
+	_, err = client.VolumeStart(vol1.Name, false)
+	r.Nil(err, "volume start failed")
 
-	_, err = client.SelfHealInfo(vol1.Name)
+	_, _, err = client.SelfHealInfo(vol1.Name)
 	r.Nil(err)
-	_, err = client.SelfHealInfo(vol1.Name, "info-summary")
+
+	_, _, err = client.SelfHealInfo(vol1.Name, "info-summary")
 	r.Nil(err)
-	_, err = client.SelfHealInfo(vol1.Name, "split-brain-info")
+
+	_, _, err = client.SelfHealInfo(vol1.Name, "split-brain-info")
 	r.Nil(err)
 
 	var optionReq api.VolOptionReq
@@ -60,12 +63,19 @@ func TestSelfHeal(t *testing.T) {
 	optionReq.Options = map[string]string{"replicate.self-heal-daemon": "on"}
 	optionReq.Advanced = true
 
-	r.Nil(client.VolumeSet(vol1.Name, optionReq))
-	r.Nil(client.SelfHeal(vol1.Name, "index"))
-	r.Nil(client.SelfHeal(vol1.Name, "full"))
+	_, err = client.VolumeSet(vol1.Name, optionReq)
+	r.Nil(err)
+
+	_, err = client.SelfHeal(vol1.Name, "index")
+	r.Nil(err)
+
+	_, err = client.SelfHeal(vol1.Name, "full")
+	r.Nil(err)
 
 	// Stop Volume
-	r.Nil(client.VolumeStop(vol1.Name), "Volume stop failed")
+	_, err = client.VolumeStop(vol1.Name)
+	r.Nil(err, "Volume stop failed")
 	// delete volume
-	r.Nil(client.VolumeDelete(vol1.Name))
+	_, err = client.VolumeDelete(vol1.Name)
+	r.Nil(err)
 }

--- a/e2e/peer_ops_test.go
+++ b/e2e/peer_ops_test.go
@@ -38,7 +38,7 @@ func TestAddRemovePeer(t *testing.T) {
 			"owner": "gd2test",
 		},
 	}
-	_, err = client.PeerAdd(peerAddReq)
+	_, _, err = client.PeerAdd(peerAddReq)
 	r.Nil(err)
 
 	// add peer: ask g1 to add g3 as peer
@@ -46,14 +46,14 @@ func TestAddRemovePeer(t *testing.T) {
 		Addresses: []string{g3.PeerAddress},
 	}
 
-	peerinfo, err := client.PeerAdd(peerAddReq)
+	peerinfo, _, err := client.PeerAdd(peerAddReq)
 	r.Nil(err)
 
-	_, err = client.GetPeer(peerinfo.ID.String())
+	_, _, err = client.GetPeer(peerinfo.ID.String())
 	r.Nil(err)
 
 	// list and check you have 3 peers in cluster
-	peers, err := client.Peers()
+	peers, _, err := client.Peers()
 	r.Nil(err)
 	r.Len(peers, 3)
 
@@ -71,7 +71,7 @@ func TestAddRemovePeer(t *testing.T) {
 		"value": "gd2test",
 	})
 	for _, filter := range matchingQueries {
-		peers, err := client.Peers(filter)
+		peers, _, err := client.Peers(filter)
 		r.Nil(err)
 		r.Len(peers, 1)
 	}
@@ -87,12 +87,12 @@ func TestAddRemovePeer(t *testing.T) {
 		"value": "gd2tests",
 	})
 	for _, filter := range nonMatchingQueries {
-		peers, err := client.Peers(filter)
+		peers, _, err := client.Peers(filter)
 		r.Nil(err)
 		r.Len(peers, 0)
 	}
 
 	// remove peer: ask g1 to remove g2 as peer
-	err = client.PeerRemove(g2.PeerID())
+	_, err = client.PeerRemove(g2.PeerID())
 	r.Nil(err)
 }

--- a/e2e/quota_enable.go
+++ b/e2e/quota_enable.go
@@ -18,7 +18,7 @@ func TestQuota(t *testing.T) {
 	var brickPaths []string
 	r := require.New(t)
 
-	tc, err := setupCluster("./config/1.toml", "./config/2.toml")
+	tc, err := setupCluster(".	/config/1.toml", "./config/2.toml")
 	r.Nil(err)
 	defer teardownCluster(tc)
 
@@ -61,7 +61,7 @@ func TestQuota(t *testing.T) {
 		Force: true,
 	}
 
-	_, err = client.VolumeCreate(createReq)
+	_, _, err = client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	// test Quota on dist-rep volume
@@ -84,7 +84,7 @@ func testQuotaEnable(t *testing.T, tc *testCluster) {
 	optionReqOff.Options = map[string]string{quotaKey: "off"}
 
 	// Quota not enabled: no quotad should be there
-	err = client.VolumeSet(volname, optionReqOff)
+	_, err = client.VolumeSet(volname, optionReqOff)
 	r.Contains(err.Error(), "quotad is not enabled")
 
 	// Checking if the quotad is not running
@@ -103,29 +103,31 @@ func testQuotaEnable(t *testing.T, tc *testCluster) {
 	r.True(isProcessRunning(pidpath))
 
 	// check the error for enabling it again
-	err = client.VolumeSet(volname, optionReqOn)
+	_, err = client.VolumeSet(volname, optionReqOn)
 	r.Contains(err.Error(), "process is already running")
 
 	// Checking if the quotad is running
 	r.True(isProcessRunning(pidpath))
 
 	// Disable quota
-	r.Nil(client.VolumeSet(volname, optionReqOff))
+	_, err = client.VolumeSet(volname, optionReqOff)
+	r.Nil(err)
 
 	// Checking if the quotad is not running
 	r.False(isProcessRunning(pidpath))
 
 	// Check the error for disabling it again.
-	err = client.VolumeSet(volname, optionReqOff)
+	_, err = client.VolumeSet(volname, optionReqOff)
 	r.Contains(err.Error(), "quotad is not enabled")
 
 	// Checking if the quotad is not running
 	r.False(isProcessRunning(pidpath))
 
 	// Stop Volume
-	r.Nil(client.VolumeStop(volname), "Volume stop failed")
+	_, err = client.VolumeStop(volname)
+	r.Nil(err, "Volume stop failed")
 	// delete volume
-	err = client.VolumeDelete(volname)
+	_, err = client.VolumeDelete(volname)
 	r.Nil(err)
 
 }

--- a/e2e/restapi_auth_test.go
+++ b/e2e/restapi_auth_test.go
@@ -25,7 +25,7 @@ func TestRESTAPIAuth(t *testing.T) {
 	client := restclient.New("http://"+g1.ClientAddress, "glustercli", string(secret), "", false)
 
 	// Get Peers information, should work if auth works
-	peers, err := client.Peers()
+	peers, _, err := client.Peers()
 	r.Nil(err)
 	r.Len(peers, 1)
 }

--- a/e2e/restart_test.go
+++ b/e2e/restart_test.go
@@ -40,7 +40,7 @@ func TestRestart(t *testing.T) {
 		},
 		Force: true,
 	}
-	_, errVolCreate := client.VolumeCreate(createReq)
+	_, _, errVolCreate := client.VolumeCreate(createReq)
 	r.Nil(errVolCreate)
 
 	r.Len(getVols(gd, r), 1)
@@ -59,7 +59,7 @@ func TestRestart(t *testing.T) {
 func getVols(gd *gdProcess, r *require.Assertions) api.VolumeListResp {
 	client := initRestclient(gd)
 	volname := ""
-	vols, err := client.Volumes(volname)
+	vols, _, err := client.Volumes(volname)
 	r.Nil(err)
 	return vols
 }

--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -37,7 +37,7 @@ func testSmartVolumeDistribute(t *testing.T) {
 		Size:            60,
 		DistributeCount: 3,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 3)
@@ -50,7 +50,8 @@ func testSmartVolumeDistribute(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[0].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[2].Bricks[0].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeReplicate2(t *testing.T) {
@@ -62,7 +63,7 @@ func testSmartVolumeReplicate2(t *testing.T) {
 		Size:         20,
 		ReplicaCount: 2,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 1)
@@ -72,7 +73,8 @@ func testSmartVolumeReplicate2(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[0].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeReplicate3(t *testing.T) {
@@ -85,7 +87,7 @@ func testSmartVolumeReplicate3(t *testing.T) {
 		Size:         20,
 		ReplicaCount: 3,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 1)
@@ -95,7 +97,8 @@ func testSmartVolumeReplicate3(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeArbiter(t *testing.T) {
@@ -109,7 +112,7 @@ func testSmartVolumeArbiter(t *testing.T) {
 		ReplicaCount: 2,
 		ArbiterCount: 1,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 1)
@@ -123,7 +126,8 @@ func testSmartVolumeArbiter(t *testing.T) {
 	// TODO: Change this after arbiter calculation fix
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeDisperse(t *testing.T) {
@@ -137,7 +141,7 @@ func testSmartVolumeDisperse(t *testing.T) {
 		Size:          40,
 		DisperseCount: 3,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 1)
@@ -148,7 +152,8 @@ func testSmartVolumeDisperse(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[1].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[0].Bricks[2].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeDistributeReplicate(t *testing.T) {
@@ -164,7 +169,7 @@ func testSmartVolumeDistributeReplicate(t *testing.T) {
 		ReplicaCount:       3,
 		SubvolZonesOverlap: true,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 2)
@@ -179,7 +184,8 @@ func testSmartVolumeDistributeReplicate(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[1].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[2].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeDistributeDisperse(t *testing.T) {
@@ -195,7 +201,7 @@ func testSmartVolumeDistributeDisperse(t *testing.T) {
 		DisperseCount:      3,
 		SubvolZonesOverlap: true,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 2)
@@ -210,7 +216,8 @@ func testSmartVolumeDistributeDisperse(t *testing.T) {
 	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[1].Path, 16, 21))
 	r.Nil(brickSizeTest(volinfo.Subvols[1].Bricks[2].Path, 16, 21))
 
-	r.Nil(client.VolumeDelete(smartvolname))
+	_, err = client.VolumeDelete(smartvolname)
+	r.Nil(err)
 }
 
 func testSmartVolumeWithoutName(t *testing.T) {
@@ -219,10 +226,11 @@ func testSmartVolumeWithoutName(t *testing.T) {
 	createReq := api.VolCreateReq{
 		Size: 20,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, _, err := client.VolumeCreate(createReq)
 	r.Nil(err)
 
-	r.Nil(client.VolumeDelete(volinfo.Name))
+	_, err = client.VolumeDelete(volinfo.Name)
+	r.Nil(err)
 }
 
 // TestSmartVolume creates a volume and starts it, runs further tests on it and
@@ -248,13 +256,13 @@ func TestSmartVolume(t *testing.T) {
 	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev2.img", "2", "400M"))
 	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev3.img", "3", "400M"))
 
-	_, err = client.DeviceAdd(tc.gds[0].PeerID(), "/dev/gluster_loop1")
+	_, _, err = client.DeviceAdd(tc.gds[0].PeerID(), "/dev/gluster_loop1")
 	r.Nil(err)
 
-	_, err = client.DeviceAdd(tc.gds[1].PeerID(), "/dev/gluster_loop2")
+	_, _, err = client.DeviceAdd(tc.gds[1].PeerID(), "/dev/gluster_loop2")
 	r.Nil(err)
 
-	_, err = client.DeviceAdd(tc.gds[2].PeerID(), "/dev/gluster_loop3")
+	_, _, err = client.DeviceAdd(tc.gds[2].PeerID(), "/dev/gluster_loop3")
 	r.Nil(err)
 
 	t.Run("Smartvol Distributed Volume", testSmartVolumeDistribute)

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -88,14 +88,14 @@ func setupCluster(configFiles ...string) (*testCluster, error) {
 			Addresses: []string{gd.PeerAddress},
 		}
 
-		if _, err := client.PeerAdd(peerAddReq); err != nil {
+		if _, _, err := client.PeerAdd(peerAddReq); err != nil {
 			return nil, fmt.Errorf("setupCluster(): Peer add failed with error response %s",
 				err.Error())
 		}
 	}
 
 	// fail if the cluster hasn't been formed properly
-	peers, err := client.Peers()
+	peers, _, err := client.Peers()
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -44,7 +44,8 @@ func testAddWebhook(t *testing.T, tc *testCluster) {
 
 	webhookURL = ts.URL
 	//create webhook
-	r.Nil(client.WebhookAdd(webhookURL, "", ""))
+	_, err := client.WebhookAdd(webhookURL, "", "")
+	r.Nil(err)
 
 	volumeName := formatVolName(t.Name())
 	var brickPaths []string
@@ -78,16 +79,17 @@ func testAddWebhook(t *testing.T, tc *testCluster) {
 		Force: true,
 	}
 
-	_, err := client.VolumeCreate(createReq)
+	_, _, err = client.VolumeCreate(createReq)
 	r.Nil(err)
 
-	r.Nil(client.VolumeDelete(volumeName))
+	_, err = client.VolumeDelete(volumeName)
+	r.Nil(err)
 }
 
 func testGetWebhook(t *testing.T) {
 	r := require.New(t)
 
-	webhooks, err := client.Webhooks()
+	webhooks, _, err := client.Webhooks()
 	r.Nil(err)
 	r.Equal(webhooks[0], webhookURL)
 }
@@ -95,14 +97,15 @@ func testGetWebhook(t *testing.T) {
 func testDeleteWebhook(t *testing.T) {
 	r := require.New(t)
 	//delete webhook
-	r.Nil(client.WebhookDelete(webhookURL))
+	_, err := client.WebhookDelete(webhookURL)
+	r.Nil(err)
 
 }
 
 func testEvents(t *testing.T) {
 	r := require.New(t)
 
-	events, err := client.ListEvents()
+	events, _, err := client.ListEvents()
 	r.Nil(err)
 	r.NotEmpty(events)
 }
@@ -119,9 +122,10 @@ func testwebhookconnection(t *testing.T) {
 
 	webhookURL = ts.URL
 	//test webhook connection
-	r.Nil(client.WebhookTest(webhookURL, "", ""))
+	_, err := client.WebhookTest(webhookURL, "", "")
+	r.Nil(err)
 
-	peers, err := client.Peers()
+	peers, _, err := client.Peers()
 	r.Nil(err)
 
 	if c != len(peers) {

--- a/glustercli/cmd/bitrot.go
+++ b/glustercli/cmd/bitrot.go
@@ -53,7 +53,7 @@ var bitrotEnableCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := args[0]
-		err := client.BitrotEnable(volname)
+		_, err := client.BitrotEnable(volname)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("volume", volname).Error("failed to enable bitrot")
@@ -71,7 +71,7 @@ var bitrotDisableCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := args[0]
 
-		err := client.BitrotDisable(volname)
+		_, err := client.BitrotDisable(volname)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("volume", volname).Error("failed to disable bitrot")
@@ -162,7 +162,7 @@ var bitrotScrubCmd = &cobra.Command{
 			fmt.Printf("Bitrot scrub %s is successful for volume %s\n", args[1], volname)
 
 		case scrubStatus:
-			scrubStatus, err := client.BitrotScrubStatus(volname)
+			scrubStatus, _, err := client.BitrotScrubStatus(volname)
 			if err != nil {
 				if GlobalFlag.Verbose {
 					log.WithError(err).WithField(
@@ -207,7 +207,7 @@ var bitrotScrubCmd = &cobra.Command{
 			}
 
 		case scrubOndemand:
-			err := client.BitrotScrubOndemand(volname)
+			_, err := client.BitrotScrubOndemand(volname)
 			if err != nil {
 				if GlobalFlag.Verbose {
 					log.WithError(err).WithField(

--- a/glustercli/cmd/device.go
+++ b/glustercli/cmd/device.go
@@ -29,7 +29,7 @@ var deviceAddCmd = &cobra.Command{
 		peerid := args[0]
 		devname := args[1]
 
-		_, err := client.DeviceAdd(peerid, devname)
+		_, _, err := client.DeviceAdd(peerid, devname)
 
 		if err != nil {
 			if GlobalFlag.Verbose {

--- a/glustercli/cmd/events.go
+++ b/glustercli/cmd/events.go
@@ -43,7 +43,7 @@ var eventsWebhookAddCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		url := args[0]
-		err := client.WebhookAdd(url, flagWebhookAddCmdToken, flagWebhookAddCmdSecret)
+		_, err := client.WebhookAdd(url, flagWebhookAddCmdToken, flagWebhookAddCmdSecret)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("url", url).Error("failed to add webhook")
@@ -60,7 +60,7 @@ var eventsWebhookDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		url := args[0]
-		err := client.WebhookDelete(url)
+		_, err := client.WebhookDelete(url)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("url", url).Error("failed to delete webhook")
@@ -76,7 +76,7 @@ var eventsWebhookListCmd = &cobra.Command{
 	Short: helpEventsWebhookAddCmd,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		webhooks, err := client.Webhooks()
+		webhooks, _, err := client.Webhooks()
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).Error("failed to list webhooks")

--- a/glustercli/cmd/glustershd.go
+++ b/glustercli/cmd/glustershd.go
@@ -41,11 +41,11 @@ var selfHealInfoCmd = &cobra.Command{
 		var selfHealInfo []glustershdapi.BrickHealInfo
 		volname := args[0]
 		if flagSummaryInfo {
-			selfHealInfo, err = client.SelfHealInfo(volname, "info-summary")
+			selfHealInfo, _, err = client.SelfHealInfo(volname, "info-summary")
 		} else if flagSplitBrainInfo {
-			selfHealInfo, err = client.SelfHealInfo(volname, "split-brain-info")
+			selfHealInfo, _, err = client.SelfHealInfo(volname, "split-brain-info")
 		} else {
-			selfHealInfo, err = client.SelfHealInfo(volname)
+			selfHealInfo, _, err = client.SelfHealInfo(volname)
 		}
 		if err != nil {
 			if GlobalFlag.Verbose {
@@ -90,7 +90,7 @@ var selfHealIndexCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		volname := args[0]
-		err = client.SelfHeal(volname, "index")
+		_, err = client.SelfHeal(volname, "index")
 		if err != nil {
 			failure(fmt.Sprintf("Failed to run heal for volume %s\n", volname), err, 1)
 		}
@@ -106,7 +106,7 @@ var selfHealFullCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		volname := args[0]
-		err = client.SelfHeal(volname, "full")
+		_, err = client.SelfHeal(volname, "full")
 		if err != nil {
 			failure(fmt.Sprintf("Failed to run heal for volume %s\n", volname), err, 1)
 		}

--- a/glustercli/cmd/peer.go
+++ b/glustercli/cmd/peer.go
@@ -55,7 +55,7 @@ var peerAddCmd = &cobra.Command{
 		peerAddReq := api.PeerAddReq{
 			Addresses: []string{hostname},
 		}
-		peer, err := client.PeerAdd(peerAddReq)
+		peer, _, err := client.PeerAdd(peerAddReq)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("host", hostname).Error("peer add failed")
@@ -81,7 +81,7 @@ var peerRemoveCmd = &cobra.Command{
 			err = errors.New("failed to parse peerID")
 		}
 		if err == nil {
-			err = client.PeerRemove(peerID)
+			_, err = client.PeerRemove(peerID)
 		}
 		if err != nil {
 			if GlobalFlag.Verbose {
@@ -97,13 +97,13 @@ func peerStatusHandler(cmd *cobra.Command) {
 	var peers api.PeerListResp
 	var err error
 	if flagCmdFilterKey == "" && flagCmdFilterValue == "" {
-		peers, err = client.Peers()
+		peers, _, err = client.Peers()
 	} else if flagCmdFilterKey != "" && flagCmdFilterValue == "" {
-		peers, err = client.Peers(map[string]string{"key": flagCmdFilterKey})
+		peers, _, err = client.Peers(map[string]string{"key": flagCmdFilterKey})
 	} else if flagCmdFilterKey == "" && flagCmdFilterValue != "" {
-		peers, err = client.Peers(map[string]string{"value": flagCmdFilterValue})
+		peers, _, err = client.Peers(map[string]string{"value": flagCmdFilterValue})
 	} else if flagCmdFilterKey != "" && flagCmdFilterValue != "" {
-		peers, err = client.Peers(map[string]string{"key": flagCmdFilterKey,
+		peers, _, err = client.Peers(map[string]string{"key": flagCmdFilterKey,
 			"value": flagCmdFilterValue,
 		})
 	}

--- a/glustercli/cmd/snapshot-activate.go
+++ b/glustercli/cmd/snapshot-activate.go
@@ -36,7 +36,7 @@ func snapshotActivateCmdRun(cmd *cobra.Command, args []string) {
 	req := api.SnapActivateReq{
 		Force: flagSnapshotActivateCmdForce,
 	}
-	err := client.SnapshotActivate(req, snapname)
+	_, err := client.SnapshotActivate(req, snapname)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField("snapshot", snapname).Error("snapshot activation failed")

--- a/glustercli/cmd/snapshot-clone.go
+++ b/glustercli/cmd/snapshot-clone.go
@@ -36,7 +36,7 @@ func snapshotCloneCmdRun(cmd *cobra.Command, args []string) {
 		CloneName: clonename,
 	}
 
-	vol, err := client.SnapshotClone(snapname, req)
+	vol, _, err := client.SnapshotClone(snapname, req)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithFields(

--- a/glustercli/cmd/snapshot-create.go
+++ b/glustercli/cmd/snapshot-create.go
@@ -48,7 +48,7 @@ func snapshotCreateCmdRun(cmd *cobra.Command, args []string) {
 		Description: flagSnapshotCreateDescription,
 	}
 
-	snap, err := client.SnapshotCreate(req)
+	snap, _, err := client.SnapshotCreate(req)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithFields(

--- a/glustercli/cmd/snapshot-deactivate.go
+++ b/glustercli/cmd/snapshot-deactivate.go
@@ -26,7 +26,7 @@ func init() {
 
 func snapshotDeactivateCmdRun(cmd *cobra.Command, args []string) {
 	snapname := cmd.Flags().Args()[0]
-	err := client.SnapshotDeactivate(snapname)
+	_, err := client.SnapshotDeactivate(snapname)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField("snapshot", snapname).Error("snapshot deactivation failed")

--- a/glustercli/cmd/snapshot-delete.go
+++ b/glustercli/cmd/snapshot-delete.go
@@ -29,7 +29,7 @@ func init() {
 func snapshotDeleteCmdRun(cmd *cobra.Command, args []string) {
 	snapname := args[0]
 
-	err := client.SnapshotDelete(snapname)
+	_, err := client.SnapshotDelete(snapname)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField(

--- a/glustercli/cmd/snapshot-info.go
+++ b/glustercli/cmd/snapshot-info.go
@@ -59,7 +59,7 @@ func snapshotInfoHandler(cmd *cobra.Command) error {
 	var err error
 
 	snapname := cmd.Flags().Args()[0]
-	snap, err = client.SnapshotInfo(snapname)
+	snap, _, err = client.SnapshotInfo(snapname)
 
 	if err != nil {
 		return err

--- a/glustercli/cmd/snapshot-list.go
+++ b/glustercli/cmd/snapshot-list.go
@@ -27,7 +27,7 @@ func snapshotListHandler(cmd *cobra.Command) error {
 		volname = cmd.Flags().Args()[0]
 	}
 
-	snaps, err = client.SnapshotList(volname)
+	snaps, _, err = client.SnapshotList(volname)
 	if err != nil {
 		return err
 	}

--- a/glustercli/cmd/snapshot-restore.go
+++ b/glustercli/cmd/snapshot-restore.go
@@ -28,7 +28,7 @@ func init() {
 
 func snapshotRestoreCmdRun(cmd *cobra.Command, args []string) {
 	snapname := cmd.Flags().Args()[0]
-	vol, err := client.SnapshotRestore(snapname)
+	vol, _, err := client.SnapshotRestore(snapname)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithFields(log.Fields{

--- a/glustercli/cmd/snapshot-status.go
+++ b/glustercli/cmd/snapshot-status.go
@@ -49,7 +49,7 @@ func snapshotStatusHandler(cmd *cobra.Command) error {
 		snapname = cmd.Flags().Args()[0]
 	}
 
-	snap, err := client.SnapshotStatus(snapname)
+	snap, _, err := client.SnapshotStatus(snapname)
 	if err != nil {
 		return err
 	}

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -112,7 +112,7 @@ func smartVolumeCreate(cmd *cobra.Command, args []string) {
 		Force:                   flagCreateForce,
 	}
 
-	vol, err := client.VolumeCreate(req)
+	vol, _, err := client.VolumeCreate(req)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField(
@@ -290,7 +290,7 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	vol, err := client.VolumeCreate(req)
+	vol, _, err := client.VolumeCreate(req)
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField("volume", volname).Error("volume creation failed")

--- a/glustercli/cmd/volume-reset.go
+++ b/glustercli/cmd/volume-reset.go
@@ -40,7 +40,7 @@ var volumeResetCmd = &cobra.Command{
 				req.Options = options
 			}
 		}
-		err := client.VolumeReset(volname, req)
+		_, err := client.VolumeReset(volname, req)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithError(err).WithField("volume", volname).Error("volume reset failed")

--- a/glustercli/cmd/volume-set.go
+++ b/glustercli/cmd/volume-set.go
@@ -71,13 +71,13 @@ func volumeOptionJSONHandler(cmd *cobra.Command, volname string, options []strin
 	}
 
 	if volname == "all" {
-		err := client.GlobalOptionSet(api.GlobalOptionReq{
+		_, err := client.GlobalOptionSet(api.GlobalOptionReq{
 			Options: vopt,
 		})
 		return err
 	}
 
-	err := client.VolumeSet(volname, api.VolOptionReq{
+	_, err := client.VolumeSet(volname, api.VolOptionReq{
 		Options:      vopt,
 		Advanced:     flagSetAdv,
 		Experimental: flagSetExp,

--- a/glustercli/cmd/volume-statedump.go
+++ b/glustercli/cmd/volume-statedump.go
@@ -78,7 +78,7 @@ func volumeStatedumpCmdRun(cmd *cobra.Command, args []string) {
 	}
 
 	volname := args[0]
-	if err := client.VolumeStatedump(volname, req); err != nil {
+	if _, err := client.VolumeStatedump(volname, req); err != nil {
 		fmt.Println(err)
 	}
 }

--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -142,7 +142,7 @@ func bricksAsUUID(bricks []string) ([]api.BrickReq, error) {
 		return bs, nil
 	}
 
-	peers, err := client.Peers()
+	peers, _, err := client.Peers()
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ var volumeStartCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := cmd.Flags().Args()[0]
-		err := client.VolumeStart(volname, flagStartCmdForce)
+		_, err := client.VolumeStart(volname, flagStartCmdForce)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithFields(log.Fields{
@@ -198,7 +198,7 @@ var volumeStopCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := cmd.Flags().Args()[0]
-		err := client.VolumeStop(volname)
+		_, err := client.VolumeStop(volname)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithFields(log.Fields{
@@ -218,7 +218,7 @@ var volumeDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := cmd.Flags().Args()[0]
-		err := client.VolumeDelete(volname)
+		_, err := client.VolumeDelete(volname)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithFields(log.Fields{
@@ -241,7 +241,7 @@ var volumeGetCmd = &cobra.Command{
 		volname := args[0]
 		optname := args[1]
 
-		opts, err := client.VolumeGet(volname, optname)
+		opts, _, err := client.VolumeGet(volname, optname)
 		if err != nil {
 			log.WithError(err).Error("error getting volume options")
 			failure("Error getting volume options", err, 1)
@@ -325,13 +325,13 @@ func volumeInfoHandler2(cmd *cobra.Command, isInfo bool) error {
 	}
 	if volname == "" {
 		if flagCmdFilterKey == "" && flagCmdFilterValue == "" {
-			vols, err = client.Volumes("")
+			vols, _, err = client.Volumes("")
 		} else if flagCmdFilterKey != "" && flagCmdFilterValue == "" {
-			vols, err = client.Volumes("", map[string]string{"key": flagCmdFilterKey})
+			vols, _, err = client.Volumes("", map[string]string{"key": flagCmdFilterKey})
 		} else if flagCmdFilterKey == "" && flagCmdFilterValue != "" {
-			vols, err = client.Volumes("", map[string]string{"value": flagCmdFilterValue})
+			vols, _, err = client.Volumes("", map[string]string{"value": flagCmdFilterValue})
 		} else if flagCmdFilterKey != "" && flagCmdFilterValue != "" {
-			vols, err = client.Volumes("", map[string]string{"key": flagCmdFilterKey,
+			vols, _, err = client.Volumes("", map[string]string{"key": flagCmdFilterKey,
 				"value": flagCmdFilterValue,
 			})
 		}
@@ -339,7 +339,7 @@ func volumeInfoHandler2(cmd *cobra.Command, isInfo bool) error {
 		if flagCmdFilterKey != "" || flagCmdFilterValue != "" {
 			return errors.New("invalid command. Cannot give filter arguments when providing volname")
 		}
-		vols, err = client.Volumes(volname)
+		vols, _, err = client.Volumes(volname)
 	}
 
 	if err != nil {
@@ -423,9 +423,9 @@ func volumeStatusHandler(cmd *cobra.Command) error {
 	}
 	if volname == "" {
 		var volList api.VolumeListResp
-		volList, err = client.Volumes("")
+		volList, _, err = client.Volumes("")
 		for _, volume := range volList {
-			vol, err = client.BricksStatus(volume.Name)
+			vol, _, err = client.BricksStatus(volume.Name)
 			fmt.Println("Volume :", volume.Name)
 			if err == nil {
 				volumeStatusDisplay(vol)
@@ -439,7 +439,7 @@ func volumeStatusHandler(cmd *cobra.Command) error {
 			}
 		}
 	} else {
-		vol, err = client.BricksStatus(volname)
+		vol, _, err = client.BricksStatus(volname)
 		fmt.Println("Volume :", volname)
 		if err == nil {
 			volumeStatusDisplay(vol)
@@ -471,7 +471,7 @@ var volumeSizeCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		volname := cmd.Flags().Args()[0]
-		vol, err := client.VolumeStatus(volname)
+		vol, _, err := client.VolumeStatus(volname)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithFields(log.Fields{
@@ -510,7 +510,7 @@ var volumeExpandCmd = &cobra.Command{
 		flags["allow-mount-as-brick"] = flagAllowMountAsBrick
 		flags["create-brick-dir"] = flagCreateBrickDir
 
-		vol, err := client.VolumeExpand(volname, api.VolExpandReq{
+		vol, _, err := client.VolumeExpand(volname, api.VolExpandReq{
 			ReplicaCount: flagExpandCmdReplicaCount,
 			Bricks:       bricks, // string of format <UUID>:<path>
 			Force:        flagExpandCmdForce,
@@ -541,7 +541,7 @@ var volumeEditCmd = &cobra.Command{
 			Metadata:       metadata,
 			DeleteMetadata: flagCmdDeleteMetadata,
 		}
-		_, err := client.EditVolume(volname, editMetadataReq)
+		_, _, err := client.EditVolume(volname, editMetadataReq)
 		if err != nil {
 			if GlobalFlag.Verbose {
 				log.WithFields(log.Fields{

--- a/pkg/restclient/bitrot.go
+++ b/pkg/restclient/bitrot.go
@@ -8,27 +8,27 @@ import (
 )
 
 // BitrotEnable enables bitrot for a volume
-func (c *Client) BitrotEnable(volname string) error {
+func (c *Client) BitrotEnable(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/bitrot/enable", volname)
 	return c.post(url, nil, http.StatusOK, nil)
 }
 
 // BitrotDisable disables bitrot for a volume
-func (c *Client) BitrotDisable(volname string) error {
+func (c *Client) BitrotDisable(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/bitrot/disable", volname)
 	return c.post(url, nil, http.StatusOK, nil)
 }
 
 // BitrotScrubOndemand starts bitrot scrubber on demand for a volume
-func (c *Client) BitrotScrubOndemand(volname string) error {
+func (c *Client) BitrotScrubOndemand(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/bitrot/scrubondemand", volname)
 	return c.post(url, nil, http.StatusOK, nil)
 }
 
 // BitrotScrubStatus returns bitrot scrub status of a volume
-func (c *Client) BitrotScrubStatus(volname string) (bitrotapi.ScrubStatus, error) {
+func (c *Client) BitrotScrubStatus(volname string) (bitrotapi.ScrubStatus, *http.Response, error) {
 	var scrubStatus bitrotapi.ScrubStatus
 	url := fmt.Sprintf("/v1/volumes/%s/bitrot/scrubstatus", volname)
-	err := c.get(url, nil, http.StatusOK, &scrubStatus)
-	return scrubStatus, err
+	resp, err := c.get(url, nil, http.StatusOK, &scrubStatus)
+	return scrubStatus, resp, err
 }

--- a/pkg/restclient/device.go
+++ b/pkg/restclient/device.go
@@ -7,11 +7,11 @@ import (
 )
 
 // DeviceAdd registers devices
-func (c *Client) DeviceAdd(peerid string, device string) (deviceapi.AddDeviceResp, error) {
+func (c *Client) DeviceAdd(peerid string, device string) (deviceapi.AddDeviceResp, *http.Response, error) {
 	var peerinfo deviceapi.AddDeviceResp
 	req := deviceapi.AddDeviceReq{
 		Device: device,
 	}
-	err := c.post("/v1/devices/"+peerid, req, http.StatusOK, &peerinfo)
-	return peerinfo, err
+	resp, err := c.post("/v1/devices/"+peerid, req, http.StatusOK, &peerinfo)
+	return peerinfo, resp, err
 }

--- a/pkg/restclient/events.go
+++ b/pkg/restclient/events.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WebhookAdd registers webhook to listen to Gluster Events
-func (c *Client) WebhookAdd(url string, token string, secret string) error {
+func (c *Client) WebhookAdd(url string, token string, secret string) (*http.Response, error) {
 	req := &eventsapi.Webhook{
 		URL:    url,
 		Token:  token,
@@ -18,7 +18,7 @@ func (c *Client) WebhookAdd(url string, token string, secret string) error {
 }
 
 // WebhookDelete deletes the webhook
-func (c *Client) WebhookDelete(url string) error {
+func (c *Client) WebhookDelete(url string) (*http.Response, error) {
 	req := &eventsapi.WebhookDel{
 		URL: url,
 	}
@@ -27,21 +27,21 @@ func (c *Client) WebhookDelete(url string) error {
 }
 
 // Webhooks returns the list of Webhooks listening to Gluster Events
-func (c *Client) Webhooks() (eventsapi.WebhookList, error) {
+func (c *Client) Webhooks() (eventsapi.WebhookList, *http.Response, error) {
 	var resp eventsapi.WebhookList
-	err := c.get("/v1/events/webhook", nil, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.get("/v1/events/webhook", nil, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 // ListEvents returns the list of Gluster Events
-func (c *Client) ListEvents() ([]*api.Event, error) {
+func (c *Client) ListEvents() ([]*api.Event, *http.Response, error) {
 	var resp []*api.Event
-	err := c.get("/v1/events", nil, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.get("/v1/events", nil, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 // WebhookTest tests connection between peers and specified URL
-func (c *Client) WebhookTest(url string, token string, secret string) error {
+func (c *Client) WebhookTest(url string, token string, secret string) (*http.Response, error) {
 	req := &eventsapi.Webhook{
 		URL:    url,
 		Token:  token,

--- a/pkg/restclient/georep.go
+++ b/pkg/restclient/georep.go
@@ -8,118 +8,123 @@ import (
 )
 
 // GeorepCreate establishes Geo-replication session
-func (c *Client) GeorepCreate(mastervolid string, slavevolid string, req georepapi.GeorepCreateReq) (georepapi.GeorepSession, error) {
+func (c *Client) GeorepCreate(mastervolid string, slavevolid string, req georepapi.GeorepCreateReq) (georepapi.GeorepSession, *http.Response, error) {
 	var session georepapi.GeorepSession
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s", mastervolid, slavevolid)
-	err := c.post(url, req, http.StatusOK, &session)
-	return session, err
+	resp, err := c.post(url, req, http.StatusOK, &session)
+	return session, resp, err
 }
 
 // GeorepStart starts Geo-replication session
-func (c *Client) GeorepStart(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, error) {
+func (c *Client) GeorepStart(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, *http.Response, error) {
 	var session georepapi.GeorepSession
 	opts := georepapi.GeorepCommandsReq{Force: force}
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/start", mastervolid, slavevolid)
-	err := c.post(url, &opts, http.StatusOK, &session)
-	return session, err
+	resp, err := c.post(url, &opts, http.StatusOK, &session)
+	return session, resp, err
 }
 
 // GeorepPause pauses Geo-replication session
-func (c *Client) GeorepPause(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, error) {
+func (c *Client) GeorepPause(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, *http.Response, error) {
 	var session georepapi.GeorepSession
 	opts := georepapi.GeorepCommandsReq{Force: force}
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/pause", mastervolid, slavevolid)
-	err := c.post(url, &opts, http.StatusOK, &session)
-	return session, err
+	resp, err := c.post(url, &opts, http.StatusOK, &session)
+	return session, resp, err
 }
 
 // GeorepResume resumes Geo-replication session
-func (c *Client) GeorepResume(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, error) {
+func (c *Client) GeorepResume(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, *http.Response, error) {
 	var session georepapi.GeorepSession
 	opts := georepapi.GeorepCommandsReq{Force: force}
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/resume", mastervolid, slavevolid)
-	err := c.post(url, &opts, http.StatusOK, &session)
-	return session, err
+	resp, err := c.post(url, &opts, http.StatusOK, &session)
+	return session, resp, err
 }
 
 // GeorepStop stops Geo-replication session
-func (c *Client) GeorepStop(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, error) {
+func (c *Client) GeorepStop(mastervolid string, slavevolid string, force bool) (georepapi.GeorepSession, *http.Response, error) {
 	var session georepapi.GeorepSession
 	opts := georepapi.GeorepCommandsReq{Force: force}
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/stop", mastervolid, slavevolid)
-	err := c.post(url, &opts, http.StatusOK, &session)
-	return session, err
+	resp, err := c.post(url, &opts, http.StatusOK, &session)
+	return session, resp, err
 }
 
 // GeorepDelete deletes Geo-replication session
-func (c *Client) GeorepDelete(mastervolid string, slavevolid string, force bool) error {
+func (c *Client) GeorepDelete(mastervolid string, slavevolid string, force bool) (*http.Response, error) {
 	opts := georepapi.GeorepCommandsReq{Force: force}
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s", mastervolid, slavevolid)
-	err := c.del(url, &opts, http.StatusNoContent, nil)
-	return err
+	return c.del(url, &opts, http.StatusNoContent, nil)
+
 }
 
 // GeorepStatus gets status of Geo-replication sessions
-func (c *Client) GeorepStatus(mastervolid string, slavevolid string) ([]georepapi.GeorepSession, error) {
+func (c *Client) GeorepStatus(mastervolid string, slavevolid string) ([]georepapi.GeorepSession, *http.Response, error) {
+	var (
+		err      error
+		sessions []georepapi.GeorepSession
+		httpResp *http.Response
+	)
+
 	url := "/v1/geo-replication"
 	allSessions := false
-	var err error
 
 	if mastervolid != "" && slavevolid != "" {
 		allSessions = true
 		url = fmt.Sprintf("%s/%s/%s", url, mastervolid, slavevolid)
 	}
-	var sessions []georepapi.GeorepSession
+
 	if !allSessions {
-		err = c.get(url, nil, http.StatusOK, &sessions)
+		httpResp, err = c.get(url, nil, http.StatusOK, &sessions)
 	} else {
 		var session georepapi.GeorepSession
-		err = c.get(url, nil, http.StatusOK, &session)
+		httpResp, err = c.get(url, nil, http.StatusOK, &session)
 		if err == nil {
 			sessions = []georepapi.GeorepSession{session}
 		}
 	}
-	return sessions, err
+	return sessions, httpResp, err
 }
 
 // GeorepSSHKeysGenerate generates SSH keys in all Volume nodes
-func (c *Client) GeorepSSHKeysGenerate(volname string) ([]georepapi.GeorepSSHPublicKey, error) {
+func (c *Client) GeorepSSHKeysGenerate(volname string) ([]georepapi.GeorepSSHPublicKey, *http.Response, error) {
 	url := "/v1/ssh-key/" + volname + "/generate"
 	var sshkeys []georepapi.GeorepSSHPublicKey
-	err := c.post(url, nil, http.StatusOK, &sshkeys)
-	return sshkeys, err
+	resp, err := c.post(url, nil, http.StatusOK, &sshkeys)
+	return sshkeys, resp, err
 }
 
 // GeorepSSHKeys gets SSH keys from all Volume nodes
-func (c *Client) GeorepSSHKeys(volname string) ([]georepapi.GeorepSSHPublicKey, error) {
+func (c *Client) GeorepSSHKeys(volname string) ([]georepapi.GeorepSSHPublicKey, *http.Response, error) {
 	url := "/v1/ssh-key/" + volname
 	var sshkeys []georepapi.GeorepSSHPublicKey
-	err := c.get(url, nil, http.StatusOK, &sshkeys)
-	return sshkeys, err
+	resp, err := c.get(url, nil, http.StatusOK, &sshkeys)
+	return sshkeys, resp, err
 }
 
 // GeorepSSHKeysPush pushes SSH public keys to all Volume nodes
-func (c *Client) GeorepSSHKeysPush(volname string, sshkeys []georepapi.GeorepSSHPublicKey) error {
+func (c *Client) GeorepSSHKeysPush(volname string, sshkeys []georepapi.GeorepSSHPublicKey) (*http.Response, error) {
 	url := "/v1/ssh-key/" + volname + "/push"
 	return c.post(url, sshkeys, http.StatusOK, nil)
 }
 
 // GeorepGet gets Geo-replication options
-func (c *Client) GeorepGet(mastervolid string, slavevolid string) ([]georepapi.GeorepOption, error) {
+func (c *Client) GeorepGet(mastervolid string, slavevolid string) ([]georepapi.GeorepOption, *http.Response, error) {
 	var options []georepapi.GeorepOption
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/config", mastervolid, slavevolid)
-	err := c.get(url, nil, http.StatusOK, &options)
-	return options, err
+	resp, err := c.get(url, nil, http.StatusOK, &options)
+	return options, resp, err
 }
 
 // GeorepSet sets Geo-replication options
-func (c *Client) GeorepSet(mastervolid string, slavevolid string, keyvals map[string]string) error {
+func (c *Client) GeorepSet(mastervolid string, slavevolid string, keyvals map[string]string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/config", mastervolid, slavevolid)
 	return c.post(url, &keyvals, http.StatusOK, nil)
 }
 
 // GeorepReset resets Geo-replication options
-func (c *Client) GeorepReset(mastervolid string, slavevolid string, keys []string) error {
+func (c *Client) GeorepReset(mastervolid string, slavevolid string, keys []string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/geo-replication/%s/%s/config", mastervolid, slavevolid)
 	return c.del(url, &keys, http.StatusOK, nil)
 }

--- a/pkg/restclient/glustershd.go
+++ b/pkg/restclient/glustershd.go
@@ -9,22 +9,22 @@ import (
 )
 
 // SelfHealInfo sends request to heal-info API
-func (c *Client) SelfHealInfo(params ...string) ([]glustershdapi.BrickHealInfo, error) {
+func (c *Client) SelfHealInfo(params ...string) ([]glustershdapi.BrickHealInfo, *http.Response, error) {
 	var url string
 	if len(params) == 1 {
 		url = fmt.Sprintf("/v1/volumes/%s/heal-info", params[0])
 	} else if len(params) == 2 {
 		url = fmt.Sprintf("/v1/volumes/%s/%s/heal-info", params[0], params[1])
 	} else {
-		return nil, errors.New("invalid parameters")
+		return nil, nil, errors.New("invalid parameters")
 	}
 	var output []glustershdapi.BrickHealInfo
-	err := c.get(url, nil, http.StatusOK, &output)
-	return output, err
+	resp, err := c.get(url, nil, http.StatusOK, &output)
+	return output, resp, err
 }
 
 // SelfHeal sends request to start the heal process on the specified volname
-func (c *Client) SelfHeal(volname string, healType string) error {
+func (c *Client) SelfHeal(volname string, healType string) (*http.Response, error) {
 	var url string
 	switch healType {
 	case "index":
@@ -32,7 +32,7 @@ func (c *Client) SelfHeal(volname string, healType string) error {
 	case "full":
 		url = fmt.Sprintf("/v1/volumes/%s/heal?type=%s", volname, healType)
 	default:
-		return errors.New("invalid parameters")
+		return nil, errors.New("invalid parameters")
 	}
 
 	return c.post(url, nil, http.StatusOK, nil)

--- a/pkg/restclient/peer.go
+++ b/pkg/restclient/peer.go
@@ -8,32 +8,32 @@ import (
 )
 
 // PeerAdd adds a peer to the Cluster
-func (c *Client) PeerAdd(peerAddReq api.PeerAddReq) (api.PeerAddResp, error) {
+func (c *Client) PeerAdd(peerAddReq api.PeerAddReq) (api.PeerAddResp, *http.Response, error) {
 	var resp api.PeerAddResp
-	err := c.post("/v1/peers", peerAddReq, http.StatusCreated, &resp)
-	return resp, err
+	httpResp, err := c.post("/v1/peers", peerAddReq, http.StatusCreated, &resp)
+	return resp, httpResp, err
 }
 
 // PeerRemove removes a peer from the Cluster
-func (c *Client) PeerRemove(peerid string) error {
+func (c *Client) PeerRemove(peerid string) (*http.Response, error) {
 	delURL := fmt.Sprintf("/v1/peers/%s", peerid)
 	return c.del(delURL, nil, http.StatusNoContent, nil)
 }
 
 // GetPeer returns information about a peer
-func (c *Client) GetPeer(peerid string) (api.PeerGetResp, error) {
+func (c *Client) GetPeer(peerid string) (api.PeerGetResp, *http.Response, error) {
 	var peer api.PeerGetResp
-	err := c.get("/v1/peers/"+peerid, nil, http.StatusOK, &peer)
-	return peer, err
+	resp, err := c.get("/v1/peers/"+peerid, nil, http.StatusOK, &peer)
+	return peer, resp, err
 }
 
 // Peers gets list of Gluster Peers
-func (c *Client) Peers(filterParams ...map[string]string) (api.PeerListResp, error) {
+func (c *Client) Peers(filterParams ...map[string]string) (api.PeerListResp, *http.Response, error) {
 	var peers api.PeerListResp
 	var queryString string
 	if len(filterParams) != 0 {
 		queryString = getQueryString(filterParams[0])
 	}
-	err := c.get("/v1/peers"+queryString, nil, http.StatusOK, &peers)
-	return peers, err
+	resp, err := c.get("/v1/peers"+queryString, nil, http.StatusOK, &peers)
+	return peers, resp, err
 }

--- a/pkg/restclient/quota.go
+++ b/pkg/restclient/quota.go
@@ -6,7 +6,7 @@ import (
 )
 
 // QuotaEnable starts a Gluster Volume
-func (c *Client) QuotaEnable(volname string) error {
+func (c *Client) QuotaEnable(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/quota/%s", volname)
 	return c.post(url, nil, http.StatusOK, nil)
 }

--- a/pkg/restclient/snapshot.go
+++ b/pkg/restclient/snapshot.go
@@ -8,26 +8,26 @@ import (
 )
 
 // SnapshotCreate creates Gluster Snapshot
-func (c *Client) SnapshotCreate(req api.SnapCreateReq) (api.SnapCreateResp, error) {
+func (c *Client) SnapshotCreate(req api.SnapCreateReq) (api.SnapCreateResp, *http.Response, error) {
 	var snap api.SnapCreateResp
-	err := c.post("/v1/snapshot", req, http.StatusCreated, &snap)
-	return snap, err
+	resp, err := c.post("/v1/snapshot", req, http.StatusCreated, &snap)
+	return snap, resp, err
 }
 
 //SnapshotActivate activate a Gluster snapshot
-func (c *Client) SnapshotActivate(req api.SnapActivateReq, snapname string) error {
+func (c *Client) SnapshotActivate(req api.SnapActivateReq, snapname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/snapshot/%s/activate", snapname)
 	return c.post(url, req, http.StatusOK, nil)
 }
 
 //SnapshotDeactivate deactivate a Gluster snapshot
-func (c *Client) SnapshotDeactivate(snapname string) error {
+func (c *Client) SnapshotDeactivate(snapname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/snapshot/%s/deactivate", snapname)
 	return c.post(url, nil, http.StatusOK, nil)
 }
 
 // SnapshotList returns list of all snapshots or all snapshots of a volume
-func (c *Client) SnapshotList(volname string) (api.SnapListResp, error) {
+func (c *Client) SnapshotList(volname string) (api.SnapListResp, *http.Response, error) {
 	var snaps api.SnapListResp
 	var url string
 	if volname == "" {
@@ -35,47 +35,46 @@ func (c *Client) SnapshotList(volname string) (api.SnapListResp, error) {
 	} else {
 		url = fmt.Sprintf("/v1/snapshots?volume=%s", volname)
 	}
-	err := c.get(url, nil, http.StatusOK, &snaps)
-	return snaps, err
+	resp, err := c.get(url, nil, http.StatusOK, &snaps)
+	return snaps, resp, err
 }
 
 // SnapshotInfo returns information about a snapshot
-func (c *Client) SnapshotInfo(snapname string) (api.SnapGetResp, error) {
+func (c *Client) SnapshotInfo(snapname string) (api.SnapGetResp, *http.Response, error) {
 	var snap api.SnapGetResp
 	var url string
 	url = fmt.Sprintf("/v1/snapshot/%s", snapname)
-	err := c.get(url, nil, http.StatusOK, &snap)
-	return snap, err
+	resp, err := c.get(url, nil, http.StatusOK, &snap)
+	return snap, resp, err
 }
 
 // SnapshotDelete will delete Gluster Snapshot and respective lv
-func (c *Client) SnapshotDelete(snapname string) error {
+func (c *Client) SnapshotDelete(snapname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/snapshot/%s", snapname)
-	err := c.del(url, nil, http.StatusNoContent, nil)
-	return err
+	return c.del(url, nil, http.StatusNoContent, nil)
 }
 
 // SnapshotStatus will list the detailed status of snapshot bricks
-func (c *Client) SnapshotStatus(snapname string) (api.SnapStatusResp, error) {
+func (c *Client) SnapshotStatus(snapname string) (api.SnapStatusResp, *http.Response, error) {
 	var resp api.SnapStatusResp
 
 	url := fmt.Sprintf("/v1/snapshot/%s/status", snapname)
-	err := c.get(url, nil, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.get(url, nil, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 //SnapshotRestore will restore the volume to given snapshot
-func (c *Client) SnapshotRestore(snapname string) (api.VolumeGetResp, error) {
+func (c *Client) SnapshotRestore(snapname string) (api.VolumeGetResp, *http.Response, error) {
 	var resp api.VolumeGetResp
 	url := fmt.Sprintf("/v1/snapshot/%s/restore", snapname)
-	err := c.post(url, nil, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.post(url, nil, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 // SnapshotClone creates a writable Gluster Snapshot, it will be similar to a volume
-func (c *Client) SnapshotClone(snapname string, req api.SnapCloneReq) (api.VolumeCreateResp, error) {
+func (c *Client) SnapshotClone(snapname string, req api.SnapCloneReq) (api.VolumeCreateResp, *http.Response, error) {
 	var vol api.VolumeCreateResp
 	url := fmt.Sprintf("/v1/snapshot/%s/clone", snapname)
-	err := c.post(url, req, http.StatusCreated, &vol)
-	return vol, err
+	resp, err := c.post(url, req, http.StatusCreated, &vol)
+	return vol, resp, err
 }

--- a/pkg/restclient/volume.go
+++ b/pkg/restclient/volume.go
@@ -20,10 +20,10 @@ const (
 )
 
 // VolumeCreate creates Gluster Volume
-func (c *Client) VolumeCreate(req api.VolCreateReq) (api.VolumeCreateResp, error) {
+func (c *Client) VolumeCreate(req api.VolCreateReq) (api.VolumeCreateResp, *http.Response, error) {
 	var vol api.VolumeCreateResp
-	err := c.post("/v1/volumes", req, http.StatusCreated, &vol)
-	return vol, err
+	resp, err := c.post("/v1/volumes", req, http.StatusCreated, &vol)
+	return vol, resp, err
 }
 
 // getFilterType return the filter type for volume list/info
@@ -56,7 +56,7 @@ func getQueryString(filterParam map[string]string) string {
 }
 
 // Volumes returns list of all volumes
-func (c *Client) Volumes(volname string, filterParams ...map[string]string) (api.VolumeListResp, error) {
+func (c *Client) Volumes(volname string, filterParams ...map[string]string) (api.VolumeListResp, *http.Response, error) {
 	if volname == "" {
 		var vols api.VolumeListResp
 		var queryString string
@@ -64,33 +64,33 @@ func (c *Client) Volumes(volname string, filterParams ...map[string]string) (api
 			queryString = getQueryString(filterParams[0])
 		}
 		url := fmt.Sprintf("/v1/volumes%s", queryString)
-		err := c.get(url, nil, http.StatusOK, &vols)
-		return vols, err
+		resp, err := c.get(url, nil, http.StatusOK, &vols)
+		return vols, resp, err
 	}
 	var vol api.VolumeGetResp
 	url := fmt.Sprintf("/v1/volumes/%s", volname)
-	err := c.get(url, nil, http.StatusOK, &vol)
-	return []api.VolumeGetResp{vol}, err
+	resp, err := c.get(url, nil, http.StatusOK, &vol)
+	return []api.VolumeGetResp{vol}, resp, err
 }
 
 // BricksStatus returns the status of bricks that form a Gluster volume
-func (c *Client) BricksStatus(volname string) (api.BricksStatusResp, error) {
+func (c *Client) BricksStatus(volname string) (api.BricksStatusResp, *http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/bricks", volname)
 	var resp api.BricksStatusResp
-	err := c.get(url, nil, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.get(url, nil, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 // VolumeStatus returns the status of a Gluster volume
-func (c *Client) VolumeStatus(volname string) (api.VolumeStatusResp, error) {
+func (c *Client) VolumeStatus(volname string) (api.VolumeStatusResp, *http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/status", volname)
 	var volStatus api.VolumeStatusResp
-	err := c.get(url, nil, http.StatusOK, &volStatus)
-	return volStatus, err
+	resp, err := c.get(url, nil, http.StatusOK, &volStatus)
+	return volStatus, resp, err
 }
 
 // VolumeStart starts a Gluster Volume
-func (c *Client) VolumeStart(volname string, force bool) error {
+func (c *Client) VolumeStart(volname string, force bool) (*http.Response, error) {
 	req := api.VolumeStartReq{
 		ForceStartBricks: force,
 	}
@@ -99,87 +99,86 @@ func (c *Client) VolumeStart(volname string, force bool) error {
 }
 
 // VolumeStop stops a Gluster Volume
-func (c *Client) VolumeStop(volname string) error {
+func (c *Client) VolumeStop(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/stop", volname)
 	return c.post(url, nil, http.StatusOK, nil)
 }
 
 // VolumeDelete deletes a Gluster Volume
-func (c *Client) VolumeDelete(volname string) error {
+func (c *Client) VolumeDelete(volname string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s", volname)
 	return c.del(url, nil, http.StatusNoContent, nil)
 }
 
 // VolumeSet sets an option for a Gluster Volume
-func (c *Client) VolumeSet(volname string, req api.VolOptionReq) error {
+func (c *Client) VolumeSet(volname string, req api.VolOptionReq) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/options", volname)
-	err := c.post(url, req, http.StatusOK, nil)
-	return err
+	return c.post(url, req, http.StatusOK, nil)
 }
 
 // GlobalOptionSet sets cluster level options
-func (c *Client) GlobalOptionSet(req api.GlobalOptionReq) error {
+func (c *Client) GlobalOptionSet(req api.GlobalOptionReq) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/cluster/options")
 	return c.post(url, req, http.StatusOK, nil)
 }
 
 // VolumeGet gets volume options for a Gluster Volume
-func (c *Client) VolumeGet(volname string, optname string) (api.VolumeOptionsGetResp, error) {
+func (c *Client) VolumeGet(volname string, optname string) (api.VolumeOptionsGetResp, *http.Response, error) {
 	if optname == "all" {
 		var opts api.VolumeOptionsGetResp
 		url := fmt.Sprintf("/v1/volumes/%s/options", volname)
-		err := c.get(url, nil, http.StatusOK, &opts)
-		return opts, err
+		resp, err := c.get(url, nil, http.StatusOK, &opts)
+		return opts, resp, err
 	}
 	var opt api.VolumeOptionGetResp
 	url := fmt.Sprintf("/v1/volumes/%s/options/%s", volname, optname)
-	err := c.get(url, nil, http.StatusOK, &opt)
-	return []api.VolumeOptionGetResp{opt}, err
+	resp, err := c.get(url, nil, http.StatusOK, &opt)
+	return []api.VolumeOptionGetResp{opt}, resp, err
 }
 
 // VolumeExpand expands a Gluster Volume
-func (c *Client) VolumeExpand(volname string, req api.VolExpandReq) (api.VolumeExpandResp, error) {
+func (c *Client) VolumeExpand(volname string, req api.VolExpandReq) (api.VolumeExpandResp, *http.Response, error) {
 	var vol api.VolumeExpandResp
 	url := fmt.Sprintf("/v1/volumes/%s/expand", volname)
-	err := c.post(url, req, http.StatusOK, &vol)
-	return vol, err
+	resp, err := c.post(url, req, http.StatusOK, &vol)
+	return vol, resp, err
 }
 
 // VolumeStatedump takes statedump of various daemons
-func (c *Client) VolumeStatedump(volname string, req api.VolStatedumpReq) error {
+func (c *Client) VolumeStatedump(volname string, req api.VolStatedumpReq) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/statedump", volname)
 	return c.post(url, req, http.StatusOK, nil)
 }
 
 // OptionGroupCreate creates a new option group
-func (c *Client) OptionGroupCreate(req api.OptionGroupReq) error {
+func (c *Client) OptionGroupCreate(req api.OptionGroupReq) (*http.Response, error) {
 	return c.post("/v1/volumes/options-group", req, http.StatusOK, nil)
 }
 
 // OptionGroupList returns a list of all option groups
-func (c *Client) OptionGroupList() (api.OptionGroupListResp, error) {
+func (c *Client) OptionGroupList() (api.OptionGroupListResp, *http.Response, error) {
 	var l api.OptionGroupListResp
 	url := fmt.Sprintf("/v1/volumes/options-group")
-	err := c.get(url, nil, http.StatusOK, &l)
-	return l, err
+	resp, err := c.get(url, nil, http.StatusOK, &l)
+	return l, resp, err
 }
 
 // OptionGroupDelete deletes the specified option group
-func (c *Client) OptionGroupDelete(group string) error {
+func (c *Client) OptionGroupDelete(group string) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/options-group/%s", group)
 	return c.del(url, nil, http.StatusNoContent, nil)
 }
 
 // EditVolume edits the specified keys in volinfo of a volume
-func (c *Client) EditVolume(volname string, req api.VolEditReq) (api.VolumeEditResp, error) {
+func (c *Client) EditVolume(volname string, req api.VolEditReq) (api.VolumeEditResp, *http.Response, error) {
 	var resp api.VolumeEditResp
 	url := fmt.Sprintf("/v1/volumes/%s/edit", volname)
-	err := c.post(url, req, http.StatusOK, &resp)
-	return resp, err
+	httpResp, err := c.post(url, req, http.StatusOK, &resp)
+	return resp, httpResp, err
 }
 
 // VolumeReset resets volume options to their default values
-func (c *Client) VolumeReset(volname string, req api.VolOptionResetReq) error {
+func (c *Client) VolumeReset(volname string, req api.VolOptionResetReq) (*http.Response, error) {
 	url := fmt.Sprintf("/v1/volumes/%s/options", volname)
 	return c.del(url, req, http.StatusOK, nil)
 }


### PR DESCRIPTION
…t APIs

User of Rest Client may need Response Status Code or Response Headers in case
of failure. Returning http.Response from all rest API will help.

Fixes: #1128

Signed-off-by: Oshank Kumar <okumar@redhat.com>