### PR TITLE
return an error when failed to connect to the store

### DIFF
--- a/glusterd2/commands/peers/errors.go
+++ b/glusterd2/commands/peers/errors.go
@@ -13,6 +13,7 @@ const (
 	ErrUnknownPeer
 	ErrClusterIDUpdateFailed
 	ErrAnotherReqInProgress
+	ErrFailedToConnectToStore
 	ErrMax
 )
 
@@ -26,6 +27,7 @@ func init() {
 	errorStrings[ErrUnknownPeer] = "request received from unknown peer"
 	errorStrings[ErrClusterIDUpdateFailed] = "failed to set and store new cluster ID"
 	errorStrings[ErrAnotherReqInProgress] = "already processing another join/leave request"
+	errorStrings[ErrFailedToConnectToStore] = "failed to connect to store"
 }
 
 func (e Error) String() string {

--- a/glusterd2/commands/peers/peer-rpc-svc.go
+++ b/glusterd2/commands/peers/peer-rpc-svc.go
@@ -53,13 +53,22 @@ func (p *PeerService) Join(ctx context.Context, req *JoinReq) (*JoinRsp, error) 
 
 	// TODO: Ensure no other operations are happening
 
-	peers, _ := peer.GetPeersF()
+	peers, err := peer.GetPeersF()
+	if err != nil {
+		logger.WithError(err).Error("failed to connect to store")
+		return &JoinRsp{"", int32(ErrFailedToConnectToStore)}, nil
+	}
 	if len(peers) != 1 {
 		logger.Info("rejecting join, already part of a cluster")
 		return &JoinRsp{"", int32(ErrAnotherCluster)}, nil
 	}
 
-	volumes, _ := volume.GetVolumes()
+	volumes, err := volume.GetVolumes()
+	if err != nil {
+		logger.WithError(err).Error("failed to connect to store")
+		return &JoinRsp{"", int32(ErrFailedToConnectToStore)}, nil
+	}
+
 	if len(volumes) != 0 {
 		logger.Info("rejecting join, we already have volumes")
 		return &JoinRsp{"", int32(ErrAnotherCluster)}, nil


### PR DESCRIPTION
during peer add, if the node is not able to connect to the store(ETCD).
return error message saying failed to connect to the store.

Fixes: #1045 
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>