### PR TITLE
[Fix] REST API Reference link

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -3,7 +3,7 @@
 ## User Documentation
 
 * [Quick Start Guide](quick-start-user-guide.md)
-* [REST API Reference](doc/endpoints.md)
+* [REST API Reference](endpoints.md)
 * [Network and firewall configuration](network.md)
 
 ## Developer Documentation


### PR DESCRIPTION
Link for REST API Reference page is not working.

Signed-off-by: Ankush Behl <cloudbehl@gmail.com>