### PR TITLE
Uniform Mountdir, Brick Paths and Device names

### DIFF
--- a/glusterd2/bricksplanner/planner.go
+++ b/glusterd2/bricksplanner/planner.go
@@ -3,7 +3,7 @@ package bricksplanner
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/api"
@@ -64,13 +64,7 @@ func handleDisperseSubvolReq(req *api.VolCreateReq) error {
 // not available with the layout
 func getBricksLayout(req *api.VolCreateReq) ([]api.SubvolReq, error) {
 	var err error
-	bricksMountRoot := config.GetString("bricksmountroot")
-	if bricksMountRoot == "" {
-		bricksMountRoot, err = filepath.Abs(config.GetString("localstatedir") + "/mounts")
-		if err != nil {
-			return nil, err
-		}
-	}
+	bricksMountRoot := path.Join(config.GetString("rundir"), "/bricks")
 
 	// If Distribute count is zero then automatically decide
 	// the distribute count based on available size in each device
@@ -128,10 +122,10 @@ func getBricksLayout(req *api.VolCreateReq) ([]api.SubvolReq, error) {
 
 			bricks = append(bricks, api.BrickReq{
 				Type:           brickType,
-				Path:           fmt.Sprintf("%s/%s-s%d-b%d/brick", bricksMountRoot, req.Name, i, j),
-				Mountdir:       fmt.Sprintf("%s/%s-s%d-b%d", bricksMountRoot, req.Name, i, j),
-				TpName:         fmt.Sprintf("tp-%s-s%d-b%d", req.Name, i, j),
-				LvName:         fmt.Sprintf("brick-%s-s%d-b%d", req.Name, i, j),
+				Path:           fmt.Sprintf("%s/%s/subvol%d/brick%d/brick", bricksMountRoot, req.Name, i+1, j+1),
+				Mountdir:       "/brick",
+				TpName:         fmt.Sprintf("tp_%s_s%d_b%d", req.Name, i+1, j+1),
+				LvName:         fmt.Sprintf("brick_%s_s%d_b%d", req.Name, i+1, j+1),
 				Size:           eachBrickSize,
 				TpSize:         eachBrickTpSize,
 				TpMetadataSize: deviceutils.GetPoolMetadataSize(eachBrickTpSize),

--- a/glusterd2/utils/mount.go
+++ b/glusterd2/utils/mount.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strings"
+
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/utils"
 
@@ -37,16 +39,17 @@ func MountLocalBricks() error {
 		for _, b := range v.GetLocalBricks() {
 			// Mount all local Bricks if they are auto provisioned
 			if b.MountInfo.DevicePath != "" {
-				if _, exists := mounts[b.MountInfo.Mountdir]; exists {
+				mountRoot := strings.TrimSuffix(b.Path, b.MountInfo.Mountdir)
+				if _, exists := mounts[mountRoot]; exists {
 					continue
 				}
 
-				err := utils.ExecuteCommandRun("mount", "-o", b.MountInfo.MntOpts, b.MountInfo.DevicePath, b.MountInfo.Mountdir)
+				err := utils.ExecuteCommandRun("mount", "-o", b.MountInfo.MntOpts, b.MountInfo.DevicePath, mountRoot)
 				if err != nil {
 					log.WithError(err).WithFields(log.Fields{
 						"volume": v.Name,
 						"dev":    b.MountInfo.DevicePath,
-						"path":   b.MountInfo.Mountdir,
+						"path":   mountRoot,
 					}).Error("brick mount failed")
 				}
 			}


### PR DESCRIPTION
- For auto provisioned volumes, Changed `Brick.MountInfo.Mountdir`
  to store only brick directory path after mount root(Similar to
  Snapshot bricks info)
- Added/Changed LV and TP names to match one naming convention(As
  described below)
- Auto provisioned bricks mount directory changed to
  `<rundir>/glusterd2/` similar to snapshot bricks

On Volume create (Example: Volume name = gv1)

- Brick Path: `/var/run/glusterd2/bricks/gv1/subvol1/brick1/brick`
- Brick Mountroot: `/var/run/glusterd2/bricks/gv1/subvol1/brick1`
- Thinpool Name: `tp_gv1_s1_b1`
- LV Name: `brick_gv1_s1_b1`

On Snapshot create (Example: Snapshot name = snap1, volume name = gv1)

- Brick Path: `/var/run/glusterd2/snaps/snap1/gv1/subvol1/brick1/brick`
- Brick Mountroot: `/var/run/glusterd2/snaps/snap1/gv1/subvol1/brick1`
- Thinpool Name: `tp_gv1_s1_b1` (This will not change)
- LV Name: `snap_snap1_gv1_s1_b1`

On Snapshot clone which creates new Volume (Example: Clone name = clone1)

- Brick Path: `/var/run/glusterd2/clones/clone1/subvol1/brick1/brick`
- Brick Mountroot: `/var/run/glusterd2/bricks/clone1/subvol1/brick1`
- Thinpool Name: `tp_gv1_s1_b1` (This will not change)
- LV Name: `brick_clone1_s1_b1`

Signed-off-by: Aravinda VK <avishwan@redhat.com>