### PR TITLE
tracing: Add attributes to volume create spans to enable trace filtering.

### DIFF
--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -199,6 +199,13 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Add attributes to the span with info that can be viewed along with traces.
+	// The attributes can also be used to filter traces on the tracing UI.
+	span.AddAttributes(
+		trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),
+		trace.StringAttribute("volName", req.Name),
+	)
+
 	if err := txn.Do(); err != nil {
 		status, err := restutils.ErrToStatusCode(err)
 		restutils.SendHTTPError(ctx, w, status, err)

--- a/glusterd2/transaction/rpc-service.go
+++ b/glusterd2/transaction/rpc-service.go
@@ -39,9 +39,11 @@ func (p *txnSvc) RunStep(rpcCtx context.Context, req *TxnStepReq) (*TxnStepResp,
 	logger.Debug("RunStep request received")
 
 	if rpcCtx != nil {
+		_, span := trace.StartSpan(rpcCtx, req.StepFunc)
 		reqID := ctx.GetTxnReqID()
-		spanName := req.StepFunc + " ReqID:" + reqID
-		_, span := trace.StartSpan(rpcCtx, spanName)
+		span.AddAttributes(
+			trace.StringAttribute("reqID", reqID),
+		)
 		defer span.End()
 	}
 

--- a/glusterd2/transaction/step.go
+++ b/glusterd2/transaction/step.go
@@ -150,9 +150,11 @@ func runStepFuncLocally(origCtx context.Context, stepName string, ctx TxnCtx) er
 	var err error
 
 	if origCtx != nil {
+		_, span := trace.StartSpan(origCtx, stepName)
 		reqID := ctx.GetTxnReqID()
-		spanName := stepName + " ReqID:" + reqID
-		_, span := trace.StartSpan(origCtx, spanName)
+		span.AddAttributes(
+			trace.StringAttribute("reqID", reqID),
+		)
 		defer span.End()
 	}
 


### PR DESCRIPTION
Add attributes like request ID, volume name, volume size to volume create
tracing spans. This allows traces to be filtered based on the attribute
specified on the tracing UI. This will be very helpful when dealing with
multiple traces during debugging.

closes #1185 