### PR TITLE
glusterd2: gluster volume info to display the capacity of the volume.

### DIFF
--- a/glustercli/cmd/snapshot-info.go
+++ b/glustercli/cmd/snapshot-info.go
@@ -48,6 +48,9 @@ func snapshotInfoDisplay(snap api.SnapGetResp) {
 	fmt.Println("State:", vol.State)
 	fmt.Println("Origin Volume name:", snap.ParentVolName)
 	fmt.Println("Snap Creation Time:", snap.CreatedAt.Format("Mon Jan _2 2006 15:04:05 GMT"))
+	if vol.Capacity != 0 {
+		fmt.Println("Snapshot Volume Capactiy: ", humanReadable(vol.Capacity))
+	}
 	fmt.Println("Labels:", "To Be Added")
 	fmt.Println("Snapshot Description:", snap.Description)
 	fmt.Println()

--- a/glustercli/cmd/utils.go
+++ b/glustercli/cmd/utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -55,6 +56,35 @@ func sizeToMb(value string) (uint64, error) {
 		size = sizeValue
 	}
 	return size, nil
+}
+
+// logn is used to find the unit size the given MB belongs to.
+// 1024 MB will return 1
+// 1048576 MB will return 2 and so on
+func logn(n, b float64) float64 {
+	return math.Log(n) / math.Log(b)
+}
+
+// humanReadable converts size given in MB into a more human readable unit
+//
+// humanReadable(1024) returns 1.0 GB
+// humanReadable(1536) returns 1.5 GB
+// humanReadable(1048576) returns 1.0 TB
+func humanReadable(value uint64) string {
+	units := []string{"MB", "GB", "TB", "PB", "EB"}
+	// If less than 1024MB we return it as such
+	if value < 1024 {
+		return fmt.Sprintf("%.1f MB", float64(value))
+	}
+	e := math.Floor(logn(float64(value), 1024))
+	suffix := units[int(e)]
+	size := math.Floor(float64(value)/math.Pow(1024, e)*10+0.5) / 10
+	f := "%.0f %s"
+	if size < 10 {
+		f = "%.1f %s"
+	}
+
+	return fmt.Sprintf(f, size, suffix)
 }
 
 func readString(prompt string, args ...interface{}) string {

--- a/glustercli/cmd/utils_test.go
+++ b/glustercli/cmd/utils_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHumanReadable checks if the funtion returns the right size with unit
+// for the input given in MB
+func TestHumanReadable(t *testing.T) {
+	assert.Equal(t, "20.0 MB", humanReadable(20))
+	assert.Equal(t, "1.0 GB", humanReadable(1024))
+	assert.Equal(t, "1.5 GB", humanReadable(1536))
+	assert.Equal(t, "1.0 TB", humanReadable(1048576))
+}

--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -293,6 +293,9 @@ func volumeInfoDisplay(vol api.VolumeGetResp) {
 	fmt.Println("Type:", vol.Type)
 	fmt.Println("Volume ID:", vol.ID)
 	fmt.Println("State:", vol.State)
+	if vol.Capacity != 0 {
+		fmt.Println("Capactiy: ", humanReadable(vol.Capacity))
+	}
 	fmt.Println("Transport-type:", vol.Transport)
 	fmt.Println("Options:")
 	for key, value := range vol.Options {

--- a/glusterd2/commands/snapshot/snapshot-create.go
+++ b/glusterd2/commands/snapshot/snapshot-create.go
@@ -625,6 +625,9 @@ func duplicateVolinfo(vol, v *volume.Volinfo) {
 	v.Transport = vol.Transport
 	v.DistCount = vol.DistCount
 	v.Type = vol.Type
+	if vol.Capacity != 0 {
+		v.Capacity = vol.Capacity
+	}
 
 	v.Metadata = vol.Metadata
 	if v.Metadata == nil {

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -140,6 +140,10 @@ func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
 		volinfo.Options = make(map[string]string)
 	}
 
+	if req.Size != 0 {
+		volinfo.Capacity = req.Size
+	}
+
 	if req.Transport != "" {
 		volinfo.Transport = req.Transport
 	} else {

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -96,6 +96,7 @@ type Volinfo struct {
 	GraphMap  map[string]string
 	Metadata  map[string]string
 	SnapList  []string
+	Capacity  uint64
 }
 
 // VolAuth represents username and password used by trusted/internal clients

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -204,6 +204,7 @@ func CreateVolumeInfoResp(v *Volinfo) *api.VolumeInfo {
 		Type:      api.VolType(v.Type),
 		Transport: v.Transport,
 		DistCount: v.DistCount,
+		Capacity:  v.Capacity,
 		State:     api.VolState(v.State),
 		Options:   v.Options,
 		Subvols:   CreateSubvolInfo(&v.Subvols),

--- a/pkg/api/volume_resp.go
+++ b/pkg/api/volume_resp.go
@@ -70,6 +70,7 @@ type VolumeInfo struct {
 	Subvols                 []Subvol          `json:"subvols"`
 	Metadata                map[string]string `json:"metadata"`
 	SnapList                []string          `json:"snap-list"`
+	Capacity                uint64            `json:"capacity,omitempty"`
 }
 
 // VolumeStatusResp response contains the statuses of all bricks of the volume.


### PR DESCRIPTION
this command is used to display the status of all the volumes.

Updates #1136 
Signed-off-by: Hari Gowtham <hgowtham@redhat.com>