### PR TITLE
Use glusterfs binary to mount

### DIFF
--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -316,6 +316,9 @@ func testRestoredVolumeMount(t *testing.T, tc *testCluster) {
 	err := mountVolume(host, snapTestName, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	err = testMount(mntPath)
+	r.Nil(err)
+
 	umntCmd := exec.Command("umount", mntPath)
 	err = umntCmd.Run()
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))

--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -312,12 +312,11 @@ func testRestoredVolumeMount(t *testing.T, tc *testCluster) {
 	defer os.RemoveAll(mntPath)
 
 	host, _, _ := net.SplitHostPort(tc.gds[0].ClientAddress)
-	mntCmd := exec.Command("mount", "-t", "glusterfs", host+":"+snapTestName, mntPath)
-	umntCmd := exec.Command("umount", mntPath)
 
-	err := mntCmd.Run()
+	err := mountVolume(host, snapTestName, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	umntCmd := exec.Command("umount", mntPath)
 	err = umntCmd.Run()
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }
@@ -329,12 +328,9 @@ func testSnapshotMount(t *testing.T, tc *testCluster) {
 	defer os.RemoveAll(mntPath)
 
 	host, _, _ := net.SplitHostPort(tc.gds[0].ClientAddress)
+	volID := fmt.Sprintf("/snaps/%s", snapname)
 
-	volID := fmt.Sprintf("%s:/snaps/%s", host, snapname)
-	mntCmd := exec.Command("mount", "-t", "glusterfs", volID, mntPath)
-	umntCmd := exec.Command("umount", mntPath)
-
-	err := mntCmd.Run()
+	err := mountVolume(host, volID, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
 	newDir := mntPath + "/Dir"
@@ -343,6 +339,7 @@ func testSnapshotMount(t *testing.T, tc *testCluster) {
 		r.Nil(errors.New("snapshot volume is Read Only File System"))
 	}
 
+	umntCmd := exec.Command("umount", mntPath)
 	err = umntCmd.Run()
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -324,4 +325,27 @@ func mountVolume(server, volfileID, mountPath string) error {
 	}
 
 	return cmd.Wait()
+}
+
+// testMount checks if a file can be created and written on the mountpoint
+// path passed.
+func testMount(path string) error {
+	f, err := ioutil.TempFile(path, "testMount")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	payload := "glusterIsAwesome"
+	n, err := f.Write([]byte(payload))
+	if err != nil {
+		return err
+	}
+
+	if n != len(payload) {
+		return errors.New("testMount(): f.Write() failed")
+	}
+
+	return nil
 }

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -305,3 +305,23 @@ func numberOfLvs(vgname string) (int, error) {
 	}
 	return nlv, err
 }
+
+func mountVolume(server, volfileID, mountPath string) error {
+
+	// Add port later if needed. Right now all mount talks to first
+	// instance of glusterd2 in cluster which listens on default port
+	// 24007
+
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf(" --volfile-server %s", server))
+	buffer.WriteString(fmt.Sprintf(" --volfile-id %s ", volfileID))
+	buffer.WriteString(mountPath)
+
+	args := strings.Fields(buffer.String())
+	cmd := exec.Command("glusterfs", args...)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -390,12 +390,11 @@ func testMountUnmount(t *testing.T, v string, tc *testCluster) {
 	defer os.RemoveAll(mntPath)
 
 	host, _, _ := net.SplitHostPort(tc.gds[0].ClientAddress)
-	mntCmd := exec.Command("mount", "-t", "glusterfs", host+":"+v, mntPath)
-	umntCmd := exec.Command("umount", mntPath)
 
-	err := mntCmd.Run()
+	err := mountVolume(host, v, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	umntCmd := exec.Command("umount", mntPath)
 	err = umntCmd.Run()
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -394,6 +394,9 @@ func testMountUnmount(t *testing.T, v string, tc *testCluster) {
 	err := mountVolume(host, v, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	err = testMount(mntPath)
+	r.Nil(err)
+
 	umntCmd := exec.Command("umount", mntPath)
 	err = umntCmd.Run()
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))


### PR DESCRIPTION
..as `mount.glusterfs` utility might be installed in non-standard
location in test environments.

Besides, mounts in real code (volume status) already uses the binary
to mount and not the mount utility script.

Signed-off-by: Prashanth Pai <ppai@redhat.com>