### PR TITLE
Tracing: Trace volume list operation

### DIFF
--- a/glusterd2/commands/peers/deletepeer.go
+++ b/glusterd2/commands/peers/deletepeer.go
@@ -1,6 +1,7 @@
 package peercommands
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gluster/glusterd2/glusterd2/events"
@@ -123,7 +124,7 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 func bricksExist(id string) (bool, error) {
 	pid := uuid.Parse(id)
 
-	vols, err := volume.GetVolumes()
+	vols, err := volume.GetVolumes(context.TODO())
 	if err != nil {
 		return true, err
 	}

--- a/glusterd2/commands/peers/peer-rpc-svc.go
+++ b/glusterd2/commands/peers/peer-rpc-svc.go
@@ -63,7 +63,7 @@ func (p *PeerService) Join(ctx context.Context, req *JoinReq) (*JoinRsp, error) 
 		return &JoinRsp{"", int32(ErrAnotherCluster)}, nil
 	}
 
-	volumes, err := volume.GetVolumes()
+	volumes, err := volume.GetVolumes(context.TODO())
 	if err != nil {
 		logger.WithError(err).Error("failed to connect to store")
 		return &JoinRsp{"", int32(ErrFailedToConnectToStore)}, nil

--- a/glusterd2/commands/volumes/volume-list.go
+++ b/glusterd2/commands/volumes/volume-list.go
@@ -1,16 +1,23 @@
 package volumecommands
 
 import (
+	"context"
 	"net/http"
+	"strconv"
 
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/api"
+
+	"go.opencensus.io/trace"
 )
 
 func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
+	ctx, span := trace.StartSpan(ctx, "/volumeListHandler")
+	defer span.End()
+
 	keys, keyFound := r.URL.Query()["key"]
 	values, valueFound := r.URL.Query()["value"]
 	filterParams := make(map[string]string)
@@ -21,16 +28,25 @@ func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 	if valueFound {
 		filterParams["value"] = values[0]
 	}
-	volumes, err := volume.GetVolumes(filterParams)
+	volumes, err := volume.GetVolumes(ctx, filterParams)
 	if err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
-	resp := createVolumeListResp(volumes)
+
+	// Add the count of volumes being listed as an attribute in the span
+	span.AddAttributes(
+		trace.StringAttribute("numVols", strconv.Itoa(len(volumes))),
+	)
+
+	resp := createVolumeListResp(ctx, volumes)
 	restutils.SendHTTPResponse(ctx, w, http.StatusOK, resp)
 }
 
-func createVolumeListResp(volumes []*volume.Volinfo) *api.VolumeListResp {
+func createVolumeListResp(ctx context.Context, volumes []*volume.Volinfo) *api.VolumeListResp {
+	ctx, span := trace.StartSpan(ctx, "createVolumeListResp")
+	defer span.End()
+
 	var resp = make(api.VolumeListResp, len(volumes))
 
 	for index, v := range volumes {

--- a/glusterd2/store/store.go
+++ b/glusterd2/store/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/clientv3/namespace"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -192,6 +193,10 @@ func Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.
 	if ctx == context.TODO() {
 		ctx, cancel = context.WithTimeout(context.Background(), getTimeout*time.Second)
 		defer cancel()
+	} else {
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "store.Get")
+		defer span.End()
 	}
 
 	defer storeCounters.Add("get", 1)

--- a/glusterd2/utils/mount.go
+++ b/glusterd2/utils/mount.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gluster/glusterd2/glusterd2/volume"
@@ -11,7 +12,7 @@ import (
 
 // MountLocalBricks mounts bricks of auto provisioned volumes
 func MountLocalBricks() error {
-	volumes, err := volume.GetVolumes()
+	volumes, err := volume.GetVolumes(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/glusterd2/volgen/generate.go
+++ b/glusterd2/volgen/generate.go
@@ -1,6 +1,8 @@
 package volgen
 
 import (
+	"context"
+
 	"github.com/gluster/glusterd2/glusterd2/snapshot"
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/utils"
@@ -131,7 +133,7 @@ func generateBrickLevelVolfiles(clusterinfo []*volume.Volinfo, xopts *map[string
 
 // Generate generates all the volfiles(Cluster/Volume/Brick)
 func Generate() error {
-	clusterinfo, err := volume.GetVolumes()
+	clusterinfo, err := volume.GetVolumes(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path"
@@ -50,7 +51,7 @@ func GetRedundancy(disperse uint) int {
 // isBrickPathAvailable validates whether the brick is consumed by other
 // volume
 func isBrickPathAvailable(peerID uuid.UUID, brickPath string) error {
-	volumes, e := GetVolumes()
+	volumes, e := GetVolumes(context.TODO())
 	if e != nil || volumes == nil {
 		// In case cluster doesn't have any volumes configured yet,
 		// treat this as success

--- a/plugins/bitrot/transactions.go
+++ b/plugins/bitrot/transactions.go
@@ -1,6 +1,7 @@
 package bitrot
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gluster/glusterd2/glusterd2/brick"
@@ -20,7 +21,7 @@ const (
 
 // IsBitrotAffectedNode returns true if there are local bricks of volume on which bitrot is enabled
 func IsBitrotAffectedNode() bool {
-	volumes, e := volume.GetVolumes()
+	volumes, e := volume.GetVolumes(context.TODO())
 	if e != nil {
 		log.WithError(e).Error("Failed to get volumes")
 		return false

--- a/plugins/quota/actor.go
+++ b/plugins/quota/actor.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"context"
 	"os"
 	"path"
 
@@ -57,7 +58,7 @@ func (actor *quotadActor) Do(v *volume.Volinfo, key, value string, volOp xlator.
 		return err
 	}
 
-	volumes, err := volume.GetVolumes()
+	volumes, err := volume.GetVolumes(context.TODO())
 	if err != nil {
 		logger.WithError(err).Error("failed to get volumes")
 		return err


### PR DESCRIPTION
Add instrumentation to trace volume list operation. Add the count of the
number of volumes listed by the command as an attribute in the top level
span of the trace.

Closes #1196 