### PR TITLE
populate vendor/ from Gopkg.lock without updating it first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ vendor-update:
 
 vendor-install:
 	@echo Installing vendored packages
-	@$(DEPENV) dep ensure
+	@$(DEPENV) dep ensure -vendor-only
 	@echo
 
 test: check-reqs


### PR DESCRIPTION
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>