### PR TITLE
gd2: fixed tlsmatcher to be used to multiplex tls connection

### DIFF
--- a/glusterd2/servers/rest/rest.go
+++ b/glusterd2/servers/rest/rest.go
@@ -69,7 +69,7 @@ func NewMuxed(m cmux.CMux) *GDRest {
 	keyfile := config.GetString("key-file")
 
 	if certfile != "" && keyfile != "" {
-		if l, err := tlsListener(m.Match(tlsmatcher.TLS12), certfile, keyfile); err != nil {
+		if l, err := tlsListener(m.Match(tlsmatcher.TLS12, tlsmatcher.TLS11, tlsmatcher.TLS10), certfile, keyfile); err != nil {
 			// TODO: Don't use Fatal(), bubble up error till main()
 			// NOTE: Methods of suture.Service interface do not return error
 			log.WithError(err).WithFields(log.Fields{


### PR DESCRIPTION
We should read tls version from handshake layer not from the record layer.
It is the Handshake layer version number that is important.

Signed-off-by: Oshank Kumar <okumar@redhat.com>