### PR TITLE
gd2 smoke: Improve debuggability of few e2e failures

### DIFF
--- a/e2e/glustershd_test.go
+++ b/e2e/glustershd_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path"
 	"syscall"
 	"testing"
@@ -142,8 +141,8 @@ func testGranularEntryHeal(t *testing.T, tc *testCluster) {
 
 	host, _, _ := net.SplitHostPort(tc.gds[0].ClientAddress)
 	err = mountVolume(host, volname, mntPath)
-	defer exec.Command("umount", "-l", mntPath).Run()
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
+	defer syscall.Unmount(mntPath, syscall.MNT_FORCE|syscall.MNT_DETACH)
 
 	getBricksStatus, err := client.BricksStatus(volname)
 	r.Nil(err, fmt.Sprintf("brick status operation failed: %s", err))
@@ -181,8 +180,7 @@ func testGranularEntryHeal(t *testing.T, tc *testCluster) {
 	optionReq.Advanced = true
 	r.NotNil(client.VolumeSet(volname, optionReq))
 
-	umntCmd := exec.Command("umount", mntPath)
-	err = umntCmd.Run()
+	err = syscall.Unmount(mntPath, 0)
 	r.Nil(err)
 
 	// Stop Volume

--- a/e2e/lvmtest/lvmtest.go
+++ b/e2e/lvmtest/lvmtest.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gluster/glusterd2/glusterd2/snapshot/lvm"
@@ -91,7 +92,7 @@ func deleteLV(num int, force bool) error {
 		brickPath := fmt.Sprintf("%s_mnt", prefix)
 		vg := fmt.Sprintf("%s_vg_%d", lvmPrefix, i)
 
-		if _, err := exec.Command("umount", "-f", brickPath).Output(); err != nil && !force {
+		if err := syscall.Unmount(brickPath, syscall.MNT_FORCE); err != nil && !force {
 			return err
 		}
 		if err := os.RemoveAll(brickPath); err != nil && !force {
@@ -192,7 +193,7 @@ func Cleanup(baseWorkdir, prefix string, brickCount int) {
 		if strings.HasPrefix(m.MntDir, baseWorkdir) {
 
 			//Remove any dangling mount pounts
-			exec.Command("umount", "-f", "-l", m.MntDir).Output()
+			syscall.Unmount(m.MntDir, syscall.MNT_FORCE|syscall.MNT_DETACH)
 		}
 	}
 

--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"syscall"
 	"testing"
 	"time"
@@ -318,8 +317,7 @@ func testRestoredVolumeMount(t *testing.T, tc *testCluster) {
 	err = testMount(mntPath)
 	r.Nil(err)
 
-	umntCmd := exec.Command("umount", mntPath)
-	err = umntCmd.Run()
+	err = syscall.Unmount(mntPath, 0)
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }
 
@@ -341,8 +339,7 @@ func testSnapshotMount(t *testing.T, tc *testCluster) {
 		r.Nil(errors.New("snapshot volume is Read Only File System"))
 	}
 
-	umntCmd := exec.Command("umount", mntPath)
-	err = umntCmd.Run()
+	err = syscall.Unmount(mntPath, 0)
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }
 

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -179,7 +179,7 @@ func cleanupAllBrickMounts(t *testing.T) {
 			}
 
 			testlog(t, fmt.Sprintf("cleanupAllBrickMounts(): umounting %s", parts[2]))
-			err = exec.Command("umount", "--force", "--lazy", parts[2]).Run()
+			syscall.Unmount(parts[2], syscall.MNT_FORCE|syscall.MNT_DETACH)
 			if err != nil {
 				testlog(t, fmt.Sprintf("`umount %s` failed: %s", parts[2], err))
 			}

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -129,7 +129,10 @@ func teardownCluster(tc *testCluster) error {
 }
 
 func initRestclient(gdp *gdProcess) (*restclient.Client, error) {
-	secret := getAuth(gdp.LocalStateDir)
+	secret, err := getAuthSecret(gdp.LocalStateDir)
+	if err != nil {
+		return nil, err
+	}
 	return restclient.New("http://"+gdp.ClientAddress, "glustercli", secret, "", false)
 }
 
@@ -287,16 +290,20 @@ func testTempDir(t *testing.T, prefix string) string {
 	return d
 }
 
-func getAuth(path string) string {
-	filepath := path + "/auth"
-	if _, err := os.Stat(filepath); !os.IsNotExist(err) {
-		s, err := ioutil.ReadFile(filepath)
-		if err != nil {
-			panic("unable to read auth file")
-		}
-		return string(s)
+func getAuthSecret(localstatedir string) (string, error) {
+	var secret string
+
+	authFile := filepath.Join(localstatedir, "auth")
+	b, err := ioutil.ReadFile(authFile)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
 	}
-	return ""
+
+	if len(b) > 0 {
+		secret = string(b)
+	}
+
+	return secret, nil
 }
 
 func numberOfLvs(vgname string) (int, error) {

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -451,8 +451,7 @@ func testMountUnmount(t *testing.T, v string, tc *testCluster) {
 	err = testMount(mntPath)
 	r.Nil(err)
 
-	umntCmd := exec.Command("umount", mntPath)
-	err = umntCmd.Run()
+	err = syscall.Unmount(mntPath, 0)
 	r.Nil(err, fmt.Sprintf("unmount failed: %s", err))
 }
 

--- a/glusterd2/commands/peers/deletepeer.go
+++ b/glusterd2/commands/peers/deletepeer.go
@@ -88,8 +88,8 @@ func deletePeerHandler(w http.ResponseWriter, r *http.Request) {
 	// potentially still send commands to the cluster
 	rsp, err := client.LeaveCluster()
 	if err != nil {
-		logger.WithError(err).Error("sending Leave request failed")
-		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, "failed to send leave cluster request")
+		logger.WithError(err).Error("client.LeaveCluster() failed")
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	} else if Error(rsp.Err) != ErrNone {
 		err = Error(rsp.Err)

--- a/glusterd2/commands/volumes/volume-smartvol-txn.go
+++ b/glusterd2/commands/volumes/volume-smartvol-txn.go
@@ -197,7 +197,7 @@ func txnCleanBricks(c transaction.TxnCtx) error {
 		}
 
 		// Remove Thin Pool if LV count is zero, Thinpool will
-		// more Lvs in case of snapshots and clones
+		// have more LVs in case of snapshots and clones
 		numLvs, err := deviceutils.NumberOfLvs(vgname, tpname)
 		if err != nil {
 			c.Logger().WithError(err).WithFields(log.Fields{

--- a/plugins/device/deviceutils/utils.go
+++ b/plugins/device/deviceutils/utils.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/gluster/glusterd2/pkg/utils"
 )
@@ -127,7 +128,7 @@ func BrickMount(dev, mountdir string) error {
 
 // BrickUnmount unmounts the Brick
 func BrickUnmount(mountdir string) error {
-	return utils.ExecuteCommandRun("umount", mountdir)
+	return syscall.Unmount(mountdir, syscall.MNT_FORCE)
 }
 
 // RemoveLV removes Logical Volume


### PR DESCRIPTION
Contains a bunch of small code changes (not really fixes) that help debugging
seen failures or mitigate some of them:

* client.LeaveCluster: Return actual error to client
* e2e: Use http client with timeout and adjust wait time
* Use syscall to unmount
* e2e: Return error if auth secret file cannot be read

Updates https://github.com/gluster/glusterd2/issues/1220
Updates https://github.com/gluster/glusterd2/issues/1222