### PR TITLE
Better support for environment variables in container image

### DIFF
--- a/extras/nightly-container/provision.yml
+++ b/extras/nightly-container/provision.yml
@@ -77,6 +77,33 @@
       args:
         warn: no
 
+    - name: Create override directory for glusterd2.service
+      file:
+        path: /etc/systemd/system/glusterd2.service.d
+        state: directory
+
+    # This makes systemd pass environment variables set for GD2 by kubernetes
+    - name: Enable PassEnvironment override for glusterd2.service
+      ini_file:
+        path: /etc/systemd/system/glusterd2.service.d/override.conf
+        section: Service
+        option: PassEnvironment
+        # PassEnvironment requires that each variable be mentioned individually
+        # More variables will need to be added here as required
+        value: GD2_ETCDENDPOINTS GD2_CLUSTER_ID GD2_RESTAUTH GD2_CLIENTADDRESS GD2_PEERADDRESS
+
+    - name: Create /etc/sysconfig/glusterd2/
+      file:
+        path: /etc/sysconfig/glusterd2
+        state: directory
+
+    - name: Disable embedded etcd for GD2
+      lineinfile:
+        path: /etc/sysconfig/glusterd2/noembed
+        create: yes
+        line: GD2_NOEMBED=true
+        state: present
+
     # Using direct systemctl here as the way the service/systemd modules work
     # requires dbus, which is not available in the container
     - name: Enable glusterd2.service
@@ -84,4 +111,3 @@
       args:
         warn: no
 
-## TODO: Customize GD2 config to use external etcd

--- a/extras/rpms/glusterd2.spec
+++ b/extras/rpms/glusterd2.spec
@@ -23,12 +23,12 @@
 
 %global gd2make %{__make} PREFIX=%{_prefix} EXEC_PREFIX=%{_exec_prefix} BINDIR=%{_bindir} SBINDIR=%{_sbindir} DATADIR=%{_datadir} LOCALSTATEDIR=%{_sharedstatedir} LOGDIR=%{_localstatedir}/log SYSCONFDIR=%{_sysconfdir} FASTBUILD=off
 
-%global gd2version 4.1.0
-%global gd2release 0
+%global gd2version 5.0.0
+%global gd2release rc0
 
 Name: %{repo}
-Version: 4.1.0
-Release: 1%{?dist}
+Version: %{gd2version}
+Release: %{gd2release}%{?dist}
 Summary: The GlusterFS management daemon (preview)
 License: GPLv2 or LGPLv3+
 URL: https://%{provider_prefix}
@@ -73,9 +73,10 @@ BuildRequires: golang(github.com/thejerf/suture)
 BuildRequires: golang(golang.org/x/net/context)
 BuildRequires: golang(golang.org/x/sys/unix)
 BuildRequires: golang(google.golang.org/grpc)
+BuildRequires: golang(go.opencensus.io)
 %endif
 
-Requires: glusterfs-server >= 4.1.0
+Requires: glusterfs-server >= 5.0.0
 Requires: /usr/bin/strings
 %{?systemd_requires}
 
@@ -83,7 +84,7 @@ Requires: /usr/bin/strings
 The new GlusterFS management framework and daemon, for GlusterFS-4.0.
 
 %prep
-%setup -q -n %{name}-v%{version}-0
+%setup -q -n %{name}-v%{gd2version}-%{gd2release}
 
 %build
 export GOPATH=$(pwd):%{gopath}
@@ -108,6 +109,8 @@ install -d -m 0755 %{buildroot}%{_sharedstatedir}/%{name}
 install -d -m 0755 %{buildroot}%{_localstatedir}/log/%{name}
 # Install logrotate config
 install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+# Setup sysconfig dir
+install -d -m 0755 %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
 %post
 %systemd_post %{name}.service
@@ -124,8 +127,14 @@ install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 %dir %{_localstatedir}/log/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %{_sysconfdir}/bash_completion.d/glustercli.sh
+%config %{_sysconfdir}/sysconfig/%{name}
 
 %changelog
+* Mon Sep 17 2018 Kaushal M <kshlmster@gmail.com> - 5.0.0-rc0
+- Create /etc/sysconfig/glusterd2
+- Add BuildRequires on golang(go.opencensus.io)
+- Update for v5.0.0-rc0
+
 * Fri Jun 15 2018 Kaushal M <kshlmster@gmail.com> - 4.1.0-1
 - Update to v4.1.0
 

--- a/extras/systemd/glusterd2.service
+++ b/extras/systemd/glusterd2.service
@@ -6,6 +6,7 @@ Before=network-online.target
 Conflicts=glusterd.service
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/glusterd2/*
 ExecStart=/usr/sbin/glusterd2 --config=/etc/glusterd2/glusterd2.toml
 KillMode=process
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,13 +14,14 @@ var (
 
 // MaxOpVersion and APIVersion supported
 const (
-	MaxOpVersion = 40100
+	MaxOpVersion = 50000
 	APIVersion   = 1
 )
 
 // GlusterdVersion and GitSHA
+// These are set as flags during build time. The current values are just placeholders
 var (
-	GlusterdVersion = "4.1.0"
+	GlusterdVersion = ""
 	GitSHA          = ""
 )
 


### PR DESCRIPTION
This PR enables a few settings in the glusterd2.service systemd unit to enable
better support for environment variables in containers.

Also, prepares for v5.0.0-rc0 tagging.