### PR TITLE
Fix TestWriteStatedump test

### DIFF
--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -163,7 +163,7 @@ func main() {
 			}
 		case unix.SIGUSR1:
 			log.Info("Received SIGUSR1. Dumping statedump")
-			utils.WriteStatedump()
+			utils.WriteStatedump(config.GetString("rundir"))
 		default:
 			continue
 		}

--- a/pkg/utils/statedump.go
+++ b/pkg/utils/statedump.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	config "github.com/spf13/viper"
 )
 
 // WriteStatedump writes statedump information to a file. The file name is
-// of the format glusterd2.<pid>.dump.<timestamp>
-func WriteStatedump() {
+// of the format glusterd2.<pid>.dump.<timestamp>. This file will be
+// written to the directory passed.
+func WriteStatedump(dirpath string) {
 
 	// Run the expvar http handler
 	w := httptest.NewRecorder()
@@ -27,10 +27,9 @@ func WriteStatedump() {
 		return
 	}
 
-	dumpDir := config.GetString("rundir")
 	dumpFileName := fmt.Sprintf("glusterd2.%s.dump.%s",
 		strconv.Itoa(os.Getpid()), strconv.Itoa(int(time.Now().Unix())))
-	dumpPath := path.Join(dumpDir, dumpFileName)
+	dumpPath := path.Join(dirpath, dumpFileName)
 
 	if err := ioutil.WriteFile(dumpPath, respBody, 0644); err != nil {
 		log.WithError(err).WithField("file", dumpPath).Error("Failed to write statedump to file")

--- a/pkg/utils/statedump_test.go
+++ b/pkg/utils/statedump_test.go
@@ -2,18 +2,26 @@ package utils
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteStatedump(t *testing.T) {
-	filename := fmt.Sprintf("glusterd2.%s.dump.%s",
-		strconv.Itoa(os.Getpid()), strconv.Itoa(int(time.Now().Unix())))
-	WriteStatedump()
-	assert.FileExists(t, filename)
-	os.Remove(filename)
+	r := require.New(t)
+
+	dir, err := ioutil.TempDir("", t.Name())
+	r.Nil(err)
+	defer os.RemoveAll(dir)
+
+	WriteStatedump(dir)
+
+	filePattern := fmt.Sprintf("glusterd2.%s.dump.*", strconv.Itoa(os.Getpid()))
+	matches, err := filepath.Glob(filepath.Join(dir, filePattern))
+	r.Nil(err)
+	r.NotEmpty(matches)
 }

--- a/plugins/georeplication/init.go
+++ b/plugins/georeplication/init.go
@@ -81,13 +81,13 @@ func (p *Plugin) RestRoutes() route.Routes {
 			HandlerFunc:  georepConfigGetHandler,
 		},
 		route.Route{
-			Name:        "GeoReplicationConfigSet",
-			Method:      "POST",
-			Pattern:     "/geo-replication/{mastervolid}/{remotevolid}/config",
-			Version:     1,
+			Name:         "GeoReplicationConfigSet",
+			Method:       "POST",
+			Pattern:      "/geo-replication/{mastervolid}/{remotevolid}/config",
+			Version:      1,
 			RequestType:  utils.GetTypeString((*georepapi.GeorepOption)(nil)),
 			ResponseType: utils.GetTypeString((*georepapi.GeorepOption)(nil)),
-			HandlerFunc: georepConfigSetHandler,
+			HandlerFunc:  georepConfigSetHandler,
 		},
 		route.Route{
 			Name:        "GeoReplicationConfigReset",


### PR DESCRIPTION
The unit test `TestWriteStatedump` uses a filename derived from current
timestamp and the actual code (`WriteStatedump`) being tested also uses
filename of the same pattern but that one may have another timestamp as
that code executes slightly later. Hence, it can so happen that the file
name written by `WriteStatedump()` is different than the filename expected
by the test. As these two timestamps are at seconds level granularity,
we didn't see it fail earlier.

This change modifies the test to look for a pattern that resembles
statedump file.
