### PR TITLE
fix issue in e2e 

### DIFF
--- a/e2e/glustershd_test.go
+++ b/e2e/glustershd_test.go
@@ -142,7 +142,8 @@ func testGranularEntryHeal(t *testing.T, tc *testCluster) {
 	host, _, _ := net.SplitHostPort(tc.gds[0].ClientAddress)
 	err = mountVolume(host, volname, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
-	defer syscall.Unmount(mntPath, syscall.MNT_FORCE|syscall.MNT_DETACH)
+
+	defer syscall.Unmount(mntPath, syscall.MNT_FORCE)
 
 	getBricksStatus, err := client.BricksStatus(volname)
 	r.Nil(err, fmt.Sprintf("brick status operation failed: %s", err))

--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -314,6 +314,8 @@ func testRestoredVolumeMount(t *testing.T, tc *testCluster) {
 	err := mountVolume(host, snapTestName, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	defer syscall.Unmount(mntPath, syscall.MNT_FORCE)
+
 	err = testMount(mntPath)
 	r.Nil(err)
 
@@ -332,6 +334,8 @@ func testSnapshotMount(t *testing.T, tc *testCluster) {
 
 	err := mountVolume(host, volID, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
+
+	defer syscall.Unmount(mntPath, syscall.MNT_FORCE)
 
 	newDir := mntPath + "/Dir"
 	err = syscall.Mkdir(newDir, 0755)

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -444,6 +444,8 @@ func testMountUnmount(t *testing.T, v string, tc *testCluster) {
 	err := mountVolume(host, v, mntPath)
 	r.Nil(err, fmt.Sprintf("mount failed: %s", err))
 
+	defer syscall.Unmount(mntPath, syscall.MNT_FORCE)
+
 	err = testMount(mntPath)
 	r.Nil(err)
 

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -383,9 +383,7 @@ func testVolumeInfo(t *testing.T) {
 }
 
 func testVolumeStatus(t *testing.T) {
-	if _, err := os.Lstat("/dev/fuse"); os.IsNotExist(err) {
-		t.Skip("skipping mount /dev/fuse unavailable")
-	}
+	checkFuseAvailable(t)
 	r := require.New(t)
 
 	_, err := client.VolumeStatus(volname)
@@ -435,9 +433,7 @@ func testVolumeMount(t *testing.T, tc *testCluster) {
 }
 
 func testMountUnmount(t *testing.T, v string, tc *testCluster) {
-	if _, err := os.Lstat("/dev/fuse"); os.IsNotExist(err) {
-		t.Skip("skipping mount /dev/fuse unavailable")
-	}
+	checkFuseAvailable(t)
 	r := require.New(t)
 
 	mntPath := testTempDir(t, "mnt")


### PR DESCRIPTION
remove code duplication in volume_ops_test
call checkFuseAvailable from utils package to avoid code duplication.

after volume mount even if some of the operations fail on the volume. we should umount the volume
calling umount in defer immediately after the volume mount will ensure to call the umount if some operation
fails.
Partial: #1235 

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>