### PR TITLE
Make Volume name mandatory in Volume create request

### DIFF
--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -229,19 +229,6 @@ func testSmartVolumeDistributeDisperse(t *testing.T) {
 	checkZeroLvs(r)
 }
 
-func testSmartVolumeWithoutName(t *testing.T) {
-	r := require.New(t)
-
-	createReq := api.VolCreateReq{
-		Size: 20,
-	}
-	volinfo, err := client.VolumeCreate(createReq)
-	r.Nil(err)
-
-	r.Nil(client.VolumeDelete(volinfo.Name))
-	checkZeroLvs(r)
-}
-
 // TestSmartVolume creates a volume and starts it, runs further tests on it and
 // finally deletes the volume
 func TestSmartVolume(t *testing.T) {
@@ -281,7 +268,6 @@ func TestSmartVolume(t *testing.T) {
 	t.Run("Smartvol Disperse Volume", testSmartVolumeDisperse)
 	t.Run("Smartvol Distributed-Replicate Volume", testSmartVolumeDistributeReplicate)
 	t.Run("Smartvol Distributed-Disperse Volume", testSmartVolumeDistributeDisperse)
-	t.Run("Smartvol Without Name", testSmartVolumeWithoutName)
 
 	// // Device Cleanup
 	r.Nil(loopDevicesCleanup(t))

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -46,8 +46,6 @@ func TestVolume(t *testing.T) {
 	r.Nil(err)
 	r.NotNil(client)
 
-	t.Run("CreateWithoutName", tc.wrap(testVolumeCreateWithoutName))
-
 	// Create the volume
 	t.Run("Create", tc.wrap(testVolumeCreate))
 	// Expand the volume
@@ -76,33 +74,6 @@ func TestVolume(t *testing.T) {
 	t.Run("SelfHeal", tc.wrap(testSelfHeal))
 	t.Run("GranularEntryHeal", tc.wrap(testGranularEntryHeal))
 
-}
-
-func testVolumeCreateWithoutName(t *testing.T, tc *testCluster) {
-	r := require.New(t)
-
-	var brickPaths []string
-	for i := 1; i <= 2; i++ {
-		brickPath := testTempDir(t, "brick")
-		brickPaths = append(brickPaths, brickPath)
-	}
-
-	// create 2x2 dist-rep volume
-	createReq := api.VolCreateReq{
-		Subvols: []api.SubvolReq{
-			{
-				Bricks: []api.BrickReq{
-					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[0]},
-					{PeerID: tc.gds[1].PeerID(), Path: brickPaths[1]},
-				},
-			},
-		},
-		Force: true,
-	}
-	volinfo, err := client.VolumeCreate(createReq)
-	r.Nil(err)
-
-	r.Nil(client.VolumeDelete(volinfo.Name))
 }
 
 func testVolumeCreate(t *testing.T, tc *testCluster) {

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -16,7 +16,6 @@ const (
 )
 
 var (
-	flagCreateVolumeName              string
 	flagCreateStripeCount             int
 	flagCreateReplicaCount            int
 	flagCreateArbiterCount            int
@@ -42,16 +41,15 @@ var (
 	flagCreateSubvolZoneOverlap     bool
 
 	volumeCreateCmd = &cobra.Command{
-		Use:   "create [--name <volname>] [<brick> [<brick>]...|--size <size>]",
+		Use:   "create <volname> [<brick> [<brick>]...|--size <size>]",
 		Short: volumeCreateHelpShort,
 		Long:  volumeCreateHelpLong,
-		Args:  cobra.MinimumNArgs(0),
+		Args:  cobra.MinimumNArgs(1),
 		Run:   volumeCreateCmdRun,
 	}
 )
 
 func init() {
-	volumeCreateCmd.Flags().StringVar(&flagCreateVolumeName, "name", "", "Volume Name")
 	volumeCreateCmd.Flags().IntVar(&flagCreateStripeCount, "stripe", 0, "Stripe Count")
 	volumeCreateCmd.Flags().IntVar(&flagCreateReplicaCount, "replica", 0, "Replica Count")
 	volumeCreateCmd.Flags().IntVar(&flagCreateArbiterCount, "arbiter", 0, "Arbiter Count")
@@ -93,7 +91,7 @@ func smartVolumeCreate(cmd *cobra.Command, args []string) {
 	}
 
 	req := api.VolCreateReq{
-		Name:                    flagCreateVolumeName,
+		Name:                    args[0],
 		Transport:               flagCreateTransport,
 		Size:                    size,
 		ReplicaCount:            flagCreateReplicaCount,
@@ -116,7 +114,7 @@ func smartVolumeCreate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		if GlobalFlag.Verbose {
 			log.WithError(err).WithField(
-				"volume", flagCreateVolumeName).Error("volume creation failed")
+				"volume", args[0]).Error("volume creation failed")
 		}
 		failure("Volume creation failed", err, 1)
 	}
@@ -130,23 +128,12 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if len(args) < 1 {
+	if len(args) < 2 {
 		failure("Bricks not specified", nil, 1)
 	}
 
-	volname := flagCreateVolumeName
-	brickArgs := args
-	if volname == "" {
-		// check if the first arg is volume name or brick:
-		// bricks have host:path or peer-id:path format
-		// volume names don't allow : character
-		if !strings.Contains(args[0], ":") {
-			// old backward compatible style:
-			// glustercli volume create <volname> <bricks...>
-			volname = args[0]
-			brickArgs = args[1:]
-		}
-	}
+	volname := args[0]
+	brickArgs := args[1:]
 
 	bricks, err := bricksAsUUID(brickArgs)
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -112,11 +112,6 @@ func volumeCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate Volume name if not provided
-	if req.Name == "" {
-		req.Name = volume.GenerateVolumeName()
-	}
-
 	if err := validateVolCreateReq(&req); err != nil {
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, err)
 		return

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -24,11 +24,6 @@ var (
 	volumeNameRE = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 )
 
-// GenerateVolumeName generates volume name as vol_<random-id>
-func GenerateVolumeName() string {
-	return "vol_" + uuid.NewRandom().String()
-}
-
 // IsValidName validates Volume name
 func IsValidName(name string) bool {
 	return volumeNameRE.MatchString(name)


### PR DESCRIPTION
- CSI driver also passes Volume name to Volume create API
- Mandatory Volume name also helps to ignore
  duplicate(accidental/network failure) Volume create
  API requests(Discussed here
  https://github.com/gluster/glusterd2/issues/919#issuecomment-401022413)
- Applications can generate name and can pass to API, not much benefit
  of auto generating name from glusterd2
- Supporting both the syntax in CLI adds confusion

Signed-off-by: Aravinda VK <avishwan@redhat.com>