### PR TITLE
Fix issue while doing `gofmt` tests

### DIFF
--- a/test/020-gofmt.sh
+++ b/test/020-gofmt.sh
@@ -9,7 +9,7 @@ RETVAL=0
 GENERATED_FILES="*(.pb|_string).go"
 
 for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -print | grep -E -v "$GENERATED_FILES"); do
-	gofmt -s -l "$file"
+	test -z "$(gofmt -s -l "$file")"
 	if [[ $? -ne 0 ]]; then
 		echo -e "$file does not conform to gofmt rules. Run: gofmt -s -w $file"
 		RETVAL=1


### PR DESCRIPTION
`gofmt` is returning zero even if format is not proper. Instead it
returns list of files which are not properly formatted.

This issue in golang repo suggested to use `test -z` for the same
https://github.com/golang/go/issues/24230

Signed-off-by: Aravinda VK <avishwan@redhat.com>