### PR TITLE
 log: Turn off standard library logging

### DIFF
--- a/glusterd2/xlator/load.go
+++ b/glusterd2/xlator/load.go
@@ -137,7 +137,7 @@ func loadXlator(xlPath string) (*Xlator, error) {
 
 	if vfunc, ok := validationFuncs[xl.ID]; ok {
 		log.WithField("xlator",
-			xl.ID).Info("Registered validation function for xlator")
+			xl.ID).Debug("Registered validation function for xlator")
 		xl.Validate = vfunc
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"io"
+	"io/ioutil"
 	stdlog "log"
 	"os"
 	"path"
@@ -43,7 +44,11 @@ func openLogFile(filepath string) (io.WriteCloser, error) {
 
 func setLogOutput(w io.Writer) {
 	log.SetOutput(w)
-	stdlog.SetOutput(log.StandardLogger().Writer())
+
+	// turn off standard library logging
+	// see https://github.com/golang/go/issues/19957
+	stdlog.SetFlags(0)
+	stdlog.SetOutput(ioutil.Discard)
 }
 
 // Init initializes the default logrus logger


### PR DESCRIPTION
The benign log messages logged by `net/rpc` package's `server.Register()`
is very annoying. The enhancement introduced by bdaa2c9 (PR #1237)
amplified this already excessive logging.

Logging by code in standard library is now disabled. Earlier it was
being redirected to logrus's io.Writer.
