### PR TITLE
Fix issues reported by Go Report Card

### DIFF
--- a/e2e/lvmtest/lvmtest.go
+++ b/e2e/lvmtest/lvmtest.go
@@ -202,6 +202,10 @@ func Cleanup(baseWorkdir, prefix string, brickCount int) {
 
 	vg := fmt.Sprintf("%s_vg_", lvmPrefix)
 	out, err := exec.Command(lvm.LVSCommand, "--noheadings", "-o", "vg_name").Output()
+	if err != nil {
+		// TODO: log failure here
+		return
+	}
 	for _, entry := range strings.Split(string(out), "\n") {
 		if strings.HasPrefix(entry, vg) {
 			exec.Command(lvm.RemoveCommand, "-f", entry)

--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -247,6 +247,7 @@ func testSnapshotStatusForceActivate(t *testing.T) {
 	r.Nil(err)
 
 	err = daemon.Kill(result.BrickStatus[0].Brick.Pid, true)
+	r.Nil(err)
 	err = client.SnapshotActivate(snapshotActivateReq, snapName)
 	if err == nil {
 		msg := "snapshot activate should have failed"
@@ -288,6 +289,7 @@ func testSnapshotRestore(t *testing.T) {
 	r.Nil(err)
 
 	err = daemon.Kill(result.BrickStatus[0].Brick.Pid, true)
+	r.Nil(err)
 	err = client.VolumeStop(snapTestName)
 	r.Nil(err)
 
@@ -361,7 +363,7 @@ func testSnapshotValidation(t *testing.T) {
 	r.Nil(client.VolumeStop(clonename), "volume stop failed")
 
 	err = client.VolumeDelete(clonename)
-	r.NotNil(errors.New("Volume delete succeeded when snapshot is existing for the volume"))
+	r.NotNil(err, "Volume delete succeeded when snapshot is existing for the volume")
 }
 
 func testCloneDelete(t *testing.T) {

--- a/e2e/volume_ops_test.go
+++ b/e2e/volume_ops_test.go
@@ -322,6 +322,7 @@ func testVolumeStart(t *testing.T) {
 	r.Nil(client.VolumeStart(volname, false), "volume start failed")
 
 	bricks, err := client.BricksStatus(volname)
+	r.Nil(err)
 	for index := range bricks {
 		r.NotZero(bricks[index].Port)
 		r.True(bricks[index].Online)
@@ -332,6 +333,7 @@ func testVolumeStart(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	bricks, err = client.BricksStatus(volname)
+	r.Nil(err)
 	for index := range bricks {
 		r.NotZero(bricks[index].Port)
 		r.True(bricks[index].Online)
@@ -348,6 +350,7 @@ func testVolumeStart(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	bricks, err = client.BricksStatus(volname)
+	r.Nil(err)
 	for index := range bricks {
 		if bricks[index].Info.Path == killBrick {
 			r.Zero(bricks[index].Port)
@@ -360,6 +363,7 @@ func testVolumeStart(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	bricks, err = client.BricksStatus(volname)
+	r.Nil(err)
 	for index := range bricks {
 		if bricks[index].Info.Path == killBrick {
 			r.NotZero(bricks[index].Port)
@@ -511,6 +515,7 @@ func TestVolumeOptions(t *testing.T) {
 	defer teardownCluster(tc)
 
 	brickDir, err := ioutil.TempDir(baseLocalStateDir, t.Name())
+	r.Nil(err)
 	defer os.RemoveAll(brickDir)
 
 	brickPath, err := ioutil.TempDir(brickDir, "brick")

--- a/glustercli/cmd/utils_test.go
+++ b/glustercli/cmd/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestHumanReadable checks if the funtion returns the right size with unit
+// TestHumanReadable checks if the function returns the right size with unit
 // for the input given in MB
 func TestHumanReadable(t *testing.T) {
 	assert.Equal(t, "20.0 MB", humanReadable(20))

--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -163,9 +163,5 @@ func (b *Brickinfo) Validate(check InitChecks, allLocalBricks []Brickinfo) error
 	}
 
 	// mandatory check that cannot be skipped forcefully
-	if err = isBrickInActiveUse(b.Path, allLocalBricks); err != nil {
-		return err
-	}
-
-	return nil
+	return isBrickInActiveUse(b.Path, allLocalBricks)
 }

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -74,13 +74,12 @@ func populateSubvols(volinfo *volume.Volinfo, req *api.VolCreateReq) error {
 		name := fmt.Sprintf("%s-%s-%d", volinfo.Name, strings.ToLower(subvolreq.Type), idx)
 
 		ty := volume.SubvolDistribute
+
 		switch subvolreq.Type {
 		case "replicate":
 			ty = volume.SubvolReplicate
 		case "disperse":
 			ty = volume.SubvolDisperse
-		default:
-			ty = volume.SubvolDistribute
 		}
 
 		s := volume.Subvol{

--- a/glusterd2/commands/volumes/volume-list.go
+++ b/glusterd2/commands/volumes/volume-list.go
@@ -44,7 +44,7 @@ func volumeListHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func createVolumeListResp(ctx context.Context, volumes []*volume.Volinfo) *api.VolumeListResp {
-	ctx, span := trace.StartSpan(ctx, "createVolumeListResp")
+	_, span := trace.StartSpan(ctx, "createVolumeListResp")
 	defer span.End()
 
 	var resp = make(api.VolumeListResp, len(volumes))

--- a/glusterd2/gdctx/id.go
+++ b/glusterd2/gdctx/id.go
@@ -79,7 +79,7 @@ func (uc *uuidConfig) reload(init bool) error {
 			return err
 		}
 
-		// If initalizing, ignore ENOENT error
+		// If initializing, ignore ENOENT error
 		if !os.IsNotExist(err) {
 			return err
 		}

--- a/glusterd2/gdctx/id_test.go
+++ b/glusterd2/gdctx/id_test.go
@@ -79,7 +79,7 @@ func testUpdateClusterID(t *testing.T) {
 func testSaveFile(t *testing.T) {
 	resetEnv(t)
 
-	// Storing the randomly initalized ids in a fresh uuidConfig and saving it file
+	// Storing the randomly initialized ids in a fresh uuidConfig and saving it file
 	c1 := newUUIDConfig()
 	peerID := c1.GetString(peerIDKey)
 	clusterID := c1.GetString(clusterIDKey)

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.WithError(err).Fatal("Failed to get and set hostname or IP")
 	}
 
-	// Initalize and parse CLI flags
+	// Initialize and parse CLI flags
 	initFlags()
 
 	if showvers, _ := flag.CommandLine.GetBool("version"); showvers {

--- a/glusterd2/servers/sunrpc/handshake_prog.go
+++ b/glusterd2/servers/sunrpc/handshake_prog.go
@@ -113,6 +113,7 @@ func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 		err      error
 		addrs    []string
 		respDict map[string]string
+		volinfo  *volume.Volinfo
 	)
 
 	_, err = dict.Unserialize(args.Xdata)
@@ -145,7 +146,7 @@ func (p *GfHandshake) ServerGetspec(args *GfGetspecReq, reply *GfGetspecRsp) err
 
 	if (args.Flags & gfGetspecFlagServersList) != 0 {
 
-		volinfo, err := volume.GetVolume(volfileID)
+		volinfo, err = volume.GetVolume(volfileID)
 		if err != nil {
 			log.WithError(err).WithField("volume", volfileID).Warn("failed to get volinfo from store")
 			// Currently there's no easy way to distinguish between

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -37,6 +37,7 @@ func TestParseHostAndBrickPath(t *testing.T) {
 	h, b, e = ParseHostAndBrickPath(brickPath)
 	assert.Nil(t, e)
 	assert.Equal(t, brick, b)
+	assert.Equal(t, h, "abc")
 
 	h, b, e = ParseHostAndBrickPath("invalid brick")
 	assert.NotNil(t, e)

--- a/plugins/glustershd/transactions.go
+++ b/plugins/glustershd/transactions.go
@@ -89,12 +89,11 @@ func txnSelfHeal(c transaction.TxnCtx) error {
 		return err
 	}
 
-	reqDict := make(map[string]string)
 	req := &brick.GfBrickOpReq{
 		Name: "",
 		Op:   int(brick.OpBrickXlatorOp),
 	}
-	reqDict = selectHxlatorsWithBricks(&volinfo, healType)
+	reqDict := selectHxlatorsWithBricks(&volinfo, healType)
 	req.Input, err = dict.Serialize(reqDict)
 	if err != nil {
 		c.Logger().WithError(err).WithField(


### PR DESCRIPTION
Current report:
https://goreportcard.com/report/github.com/gluster/glusterd2

* Fix typos reported by misspell tool.
* golint: Fix redundant returning of error.
* Fix ineffectual assignments detected by ineffassign.

Fixing gocyclo warnings needs more involved work to do it right
when we split long functions to smaller ones. That hasn't been
addressed in this PR.