### PR TITLE
Arbiter brick size calculation for smart volume creation.

### DIFF
--- a/glusterd2/bricksplanner/subvoltype_replicate.go
+++ b/glusterd2/bricksplanner/subvoltype_replicate.go
@@ -2,7 +2,11 @@ package bricksplanner
 
 import (
 	"github.com/gluster/glusterd2/pkg/api"
+	"github.com/gluster/glusterd2/plugins/device/deviceutils"
 )
+
+// defaultLeastArbiterSize is the size (in KB) the arbiter brick will be assigned to if the brick size is less than 100M.
+const defaultLeastArbiterSize = 100000
 
 type replicaSubvolPlanner struct {
 	subvolSize       uint64
@@ -17,8 +21,23 @@ func (s *replicaSubvolPlanner) Init(req *api.VolCreateReq, subvolSize uint64) {
 	s.replicaCount = req.ReplicaCount
 	s.arbiterCount = req.ArbiterCount
 	s.brickSize = s.subvolSize
-	// TODO: Calculate Arbiter brick size
-	s.arbiterBrickSize = s.subvolSize
+	// TODO: the size is calculated in KB, should be changed as per the default.
+	// default avgFileSize needs to be changed from 1M to 64K as well.
+	// Now we are receiving 1M as default from cli so having it as 1M here as well,
+	var avgFileSize uint64 = 1024
+	if req.AverageFileSize != 0 {
+		avgFileSize = deviceutils.MbToKb(req.AverageFileSize)
+	}
+	arbiterSize := uint64((4.0) * (float64(subvolSize) / float64(avgFileSize)))
+	// Assigning arbiter brick size to be bricksize if its lesser than 100M
+	if arbiterSize < defaultLeastArbiterSize {
+		if defaultLeastArbiterSize > subvolSize {
+			arbiterSize = subvolSize
+		} else {
+			arbiterSize = defaultLeastArbiterSize
+		}
+	}
+	s.arbiterBrickSize = arbiterSize
 }
 
 func (s *replicaSubvolPlanner) BricksCount() int {

--- a/glusterd2/commands/volumes/volume-smartvol-txn.go
+++ b/glusterd2/commands/volumes/volume-smartvol-txn.go
@@ -59,7 +59,13 @@ func txnPrepareBricks(c transaction.TxnCtx) error {
 			}
 
 			// Make Filesystem
-			err = deviceutils.MakeXfs(b.DevicePath)
+			mkfsOpts := []string{}
+			if b.Type == "arbiter" {
+				mkfsOpts = []string{"-i", "size=512", "-n", "size=8192", "-i", "maxpct=0"}
+			} else {
+				mkfsOpts = []string{"-i", "size=512", "-n", "size=8192"}
+			}
+			err = deviceutils.MakeXfs(b.DevicePath, mkfsOpts...)
 			if err != nil {
 				c.Logger().WithError(err).WithField("dev", b.DevicePath).Error("mkfs.xfs failed")
 				return err

--- a/pkg/api/volume_req.go
+++ b/pkg/api/volume_req.go
@@ -48,6 +48,7 @@ type VolCreateReq struct {
 	DistributeCount         int               `json:"distribute,omitempty"`
 	ReplicaCount            int               `json:"replica,omitempty"`
 	ArbiterCount            int               `json:"arbiter,omitempty"`
+	AverageFileSize         uint64            `json:"average-file-size,omitempty"`
 	DisperseCount           int               `json:"disperse,omitempty"`
 	DisperseRedundancyCount int               `json:"disperse-redundancy,omitempty"`
 	DisperseDataCount       int               `json:"disperse-data,omitempty"`

--- a/plugins/device/deviceutils/utils.go
+++ b/plugins/device/deviceutils/utils.go
@@ -81,7 +81,10 @@ func GetPoolMetadataSize(poolsize uint64) uint64 {
 	metadataSize := uint64(float64(poolsize) * 0.005)
 	if metadataSize > GbToKb(maxMetadataSizeGb) {
 		metadataSize = GbToKb(maxMetadataSizeGb)
+	} else if metadataSize == 0 {
+		metadataSize = 64
 	}
+
 	return metadataSize
 }
 
@@ -108,12 +111,11 @@ func CreateLV(vgname, tpname, lvname string, lvsize uint64) error {
 }
 
 // MakeXfs creates XFS filesystem
-func MakeXfs(dev string) error {
+func MakeXfs(dev string, mkfsOpts ...string) error {
+	mkfsOpts = append([]string{dev}, mkfsOpts...)
 	// TODO: Adjust -d su=<>,sw=<> based on RAID/JBOD
 	return utils.ExecuteCommandRun("mkfs.xfs",
-		"-i", "size=512",
-		"-n", "size=8192",
-		dev,
+		mkfsOpts...,
 	)
 }
 


### PR DESCRIPTION
This patch creates the arbiter brick for the smart volume as per the
calculation:

brick size = 4 KB * ( size in KB of largest data brick in volume or
replica set / average file size in KB)

Signed-off-by: Hari Gowtham <hgowtham@redhat.com>