### PR TITLE
Add qsh to the list of required claims.

### DIFF
--- a/glusterd2/middleware/auth.go
+++ b/glusterd2/middleware/auth.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	requiredClaims = []string{"iss", "exp"}
+	requiredClaims = []string{"iss", "exp", "qsh"}
 )
 
 func getAuthSecret(issuer string) string {


### PR DESCRIPTION
qsh was added as a claim that must be included but was not added to the required claims validation.  This results in a confusing error message: 'invalid qsh claim in token' when no qsh claim is included.  With this PR, the error response will include the more informative error message: 'Token missing qsh Claim'.