### PR TITLE
Improve getting/setting cluster options

### DIFF
--- a/glusterd2/volume/fs_utils.go
+++ b/glusterd2/volume/fs_utils.go
@@ -158,7 +158,7 @@ func GetMounts() ([]*Mntent, error) {
 
 //IsMountExist return success when mount point already exist
 //If mtab values is given, it does high level validation of mount
-//Else it will skip device verfication and just does xattr validation
+//Else it will skip device verification and just does xattr validation
 func IsMountExist(b *brick.Brickinfo, iD uuid.UUID, mtab []*Mntent) bool {
 
 	if _, err := os.Lstat(b.Path); err != nil {


### PR DESCRIPTION
 * Take lock when setting/updating cluster option.
 * Add support for custom validation function.
 * Fix crash in GetClusterOption() due to nil pointer access.

The first consumer of these fixes and improvements shall be brick multiplexing.
Updates #219