### PR TITLE
Fix capitalized error message format.

### DIFF
--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -13,18 +13,18 @@ import (
 func brickSizeTest(brickpath string, min uint64, max uint64) error {
 	var fstat syscall.Statfs_t
 	if err := syscall.Statfs(brickpath, &fstat); err != nil {
-		return fmt.Errorf("Unable to get size info of Brick(%s) %v", brickpath, err)
+		return fmt.Errorf("unable to get size info of Brick(%s) %v", brickpath, err)
 	}
 
 	if &fstat != nil {
 		value := uint64((fstat.Blocks * uint64(fstat.Bsize)) / (1024 * 1024))
 		if value < min || value > max {
-			return fmt.Errorf("Brick(%s) size mismatch, Expected: %d-%d, got: %d", brickpath, min, max, value)
+			return fmt.Errorf("Brick(%s) size mismatch, expected: %d-%d, got: %d", brickpath, min, max, value)
 		}
 		return nil
 	}
 
-	return fmt.Errorf("Unable to get size info of Brick(%s)", brickpath)
+	return fmt.Errorf("unable to get size info of Brick(%s)", brickpath)
 }
 
 func checkZeroLvs(r *require.Assertions) {

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -300,7 +300,7 @@ func addThinArbiter(req *api.VolCreateReq, thinArbiter string) error {
 
 	s := strings.Split(thinArbiter, ":")
 	if len(s) != 2 && len(s) != 3 {
-		return fmt.Errorf("Thin arbiter brick must be of the form <host>:<brick> or <host>:<brick>:<port>")
+		return fmt.Errorf("thin arbiter brick must be of the form <host>:<brick> or <host>:<brick>:<port>")
 	}
 
 	// TODO: If required, handle this in a generic way, just like other

--- a/glusterd2/brick/validation.go
+++ b/glusterd2/brick/validation.go
@@ -122,7 +122,7 @@ func validateBrickWasUsed(brickPath string) error {
 			if err != nil {
 				continue
 			} else if size > 0 {
-				return fmt.Errorf("Xattr %s already present on %s", key, path)
+				return fmt.Errorf("xattr %s already present on %s", key, path)
 			} else {
 				return nil
 			}
@@ -151,7 +151,7 @@ func isBrickInActiveUse(brickPath string, allLocalBricks []Brickinfo) error {
 				brickPath, b.VolumeName, b.VolumeID)
 		}
 		if strings.HasPrefix(brickPath, b.Path) {
-			return fmt.Errorf("Path %s is a subdirectory of another existing brick with path %s belonging to volume (name=%s;id=%s)",
+			return fmt.Errorf("path %s is a subdirectory of another existing brick with path %s belonging to volume (name=%s;id=%s)",
 				brickPath, b.Path, b.VolumeName, b.VolumeID)
 		}
 	}

--- a/glusterd2/commands/volumes/common.go
+++ b/glusterd2/commands/volumes/common.go
@@ -39,21 +39,21 @@ func validateOptions(opts map[string]string, flags api.VolOptionFlags) error {
 
 		switch {
 		case !o.IsSettable():
-			return fmt.Errorf("Option %s cannot be set", k)
+			return fmt.Errorf("option %s cannot be set", k)
 
 		case o.IsAdvanced() && !flags.AllowAdvanced:
-			return fmt.Errorf("Option %s is an advanced option. To set it pass the advanced flag", k)
+			return fmt.Errorf("option %s is an advanced option. To set it pass the advanced flag", k)
 
 		case o.IsExperimental() && !flags.AllowExperimental:
-			return fmt.Errorf("Option %s is an experimental option. To set it pass the experimental flag", k)
+			return fmt.Errorf("option %s is an experimental option. To set it pass the experimental flag", k)
 
 		case o.IsDeprecated() && !flags.AllowDeprecated:
 			// TODO: Return deprecation version and alternative option if available
-			return fmt.Errorf("Option %s will be deprecated in future releases. To set it pass the deprecated flag", k)
+			return fmt.Errorf("option %s will be deprecated in future releases. To set it pass the deprecated flag", k)
 		}
 
 		if err := o.Validate(v); err != nil {
-			return fmt.Errorf("Failed to validate value(%s) for key(%s): %s", k, v, err.Error())
+			return fmt.Errorf("failed to validate value(%s) for key(%s): %s", k, v, err.Error())
 		}
 		// TODO: Check op-version
 	}

--- a/glusterd2/middleware/auth.go
+++ b/glusterd2/middleware/auth.go
@@ -71,24 +71,24 @@ func Auth(next http.Handler) http.Handler {
 		token, err := jwt.Parse(authHeaderParts[1], func(token *jwt.Token) (interface{}, error) {
 			claims, ok := token.Claims.(jwt.MapClaims)
 			if !ok {
-				return nil, fmt.Errorf("Unable to parse Token claims")
+				return nil, fmt.Errorf("unable to parse Token claims")
 			}
 
 			// Error if required claims are not sent by Client
 			for _, claimName := range requiredClaims {
 				if _, claimOk := claims[claimName]; !claimOk {
-					return nil, fmt.Errorf("Token missing %s Claim", claimName)
+					return nil, fmt.Errorf("token missing %s Claim", claimName)
 				}
 			}
 
 			// Validate the JWT Signing Algo
 			if _, tokenOk := token.Method.(*jwt.SigningMethodHMAC); !tokenOk {
-				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 
 			secret := getAuthSecret(claims["iss"].(string))
 			if secret == "" {
-				return nil, fmt.Errorf("Invalid App ID: %s", claims["iss"])
+				return nil, fmt.Errorf("invalid App ID: %s", claims["iss"])
 			}
 			// Check qsh claim
 			if claims["qsh"] != utils.GenerateQsh(r) {

--- a/glusterd2/snapshot/lvm/lvm.go
+++ b/glusterd2/snapshot/lvm/lvm.go
@@ -180,7 +180,7 @@ func UpdateFsLabel(DevicePath, FsType string) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("Changing file-system label of %s is not supported as of now", FsType)
+		return fmt.Errorf("changing file-system label of %s is not supported as of now", FsType)
 	}
 	return nil
 }

--- a/glusterd2/xlator/load.go
+++ b/glusterd2/xlator/load.go
@@ -172,7 +172,7 @@ func loadAllXlators() (map[string]*Xlator, error) {
 
 	xlatorsDir := getXlatorsDir()
 	if xlatorsDir == "" {
-		return nil, fmt.Errorf("No xlators dir found")
+		return nil, fmt.Errorf("no xlators dir found")
 	}
 	log.WithField("xlatordir", xlatorsDir).Debug("Xlators dir found")
 

--- a/pkg/api/brickutils.go
+++ b/pkg/api/brickutils.go
@@ -16,7 +16,7 @@ func (req *VolCreateReq) Nodes() ([]uuid.UUID, error) {
 				nodesMap[brick.PeerID] = true
 				u := uuid.Parse(brick.PeerID)
 				if u == nil {
-					return nil, fmt.Errorf("Failed to parse peer ID: %s", brick.PeerID)
+					return nil, fmt.Errorf("failed to parse peer ID: %s", brick.PeerID)
 				}
 				nodes = append(nodes, u)
 			}
@@ -34,7 +34,7 @@ func (req *VolExpandReq) Nodes() ([]uuid.UUID, error) {
 			nodesMap[brick.PeerID] = true
 			u := uuid.Parse(brick.PeerID)
 			if u == nil {
-				return nil, fmt.Errorf("Failed to parse peer ID: %s", brick.PeerID)
+				return nil, fmt.Errorf("failed to parse peer ID: %s", brick.PeerID)
 			}
 			nodes = append(nodes, u)
 		}

--- a/plugins/bitrot/validate.go
+++ b/plugins/bitrot/validate.go
@@ -33,7 +33,7 @@ func validateOptions(v *volume.Volinfo, key string, value string) error {
 			return nil
 		}
 		return fmt.Errorf(
-			"Invalid value specified for option '%s'. Possible values: {%s}",
+			"invalid value specified for option '%s'. Possible values: {%s}",
 			key, strings.Join(acceptedFrequencyValues, ", "))
 	case "scrub-state":
 		acceptedScrubStateValues := []string{"pause", "resume"}
@@ -41,7 +41,7 @@ func validateOptions(v *volume.Volinfo, key string, value string) error {
 			return nil
 		}
 		return fmt.Errorf(
-			"invalid value specified for option '%s'. possible values: {%s}",
+			"invalid value specified for option '%s'. Possible values: {%s}",
 			key, strings.Join(acceptedScrubStateValues, ", "))
 
 	}

--- a/plugins/dht/validate.go
+++ b/plugins/dht/validate.go
@@ -16,7 +16,7 @@ func validateOptions(v *volume.Volinfo, key, value string) error {
 			if v, ok := v.Options["features.cache-invalidation"]; ok && v == "on" {
 				return nil
 			}
-			return fmt.Errorf("Enable \"features.cache-invalidation\" before enabling %s", key)
+			return fmt.Errorf("enable \"features.cache-invalidation\" before enabling %s", key)
 		}
 	}
 	return nil


### PR DESCRIPTION
As mentioned in the error-handling section of [coding conventions](https://github.com/gluster/glusterd2/blob/master/doc/coding.md#error-handling) below:
```
* Error strings should not start with a capital letter.
```
This pull request does what #902 have done that set the first letter of error message to lowercase. Note that the names of struct definitions are already ignored, such as `BrickType`, etc.

Signed-off-by: imjoey <majunjiev@gmail.com>