### PR TITLE
Implement brick multiplexing

### DIFF
--- a/e2e/brickmux_test.go
+++ b/e2e/brickmux_test.go
@@ -1,0 +1,280 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gluster/glusterd2/pkg/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBrickMux tests brick multiplexing.
+func TestBrickMux(t *testing.T) {
+	var err error
+
+	r := require.New(t)
+
+	tc, err := setupCluster(t, "./config/1.toml")
+	r.Nil(err)
+	defer teardownCluster(tc)
+
+	client, err = initRestclient(tc.gds[0])
+	r.Nil(err)
+	r.NotNil(client)
+
+	// Turn on brick mux cluster option
+	optReq := api.ClusterOptionReq{
+		Options: map[string]string{"cluster.brick-multiplex": "on"},
+	}
+	err = client.ClusterOptionSet(optReq)
+	r.Nil(err)
+
+	// Create a 1 x 3 volume
+	var brickPaths []string
+	for i := 1; i <= 3; i++ {
+		brickPath := testTempDir(t, "brick")
+		brickPaths = append(brickPaths, brickPath)
+	}
+
+	volname1 := formatVolName(t.Name())
+
+	createReq := api.VolCreateReq{
+		Name: volname1,
+		Subvols: []api.SubvolReq{
+			{
+				Type: "distribute",
+				Bricks: []api.BrickReq{
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[0]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[1]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[2]},
+				},
+			},
+		},
+		Force: true,
+	}
+	_, err = client.VolumeCreate(createReq)
+	r.Nil(err)
+
+	// start the volume
+	err = client.VolumeStart(volname1, false)
+	r.Nil(err)
+
+	// check bricks status and confirm that bricks have been multiplexed
+	bstatus, err := client.BricksStatus(volname1)
+	r.Nil(err)
+
+	// NOTE: Track these variables through-out the test.
+	pid := bstatus[0].Pid
+	port := bstatus[0].Port
+
+	for _, b := range bstatus {
+		r.Equal(pid, b.Pid)
+		r.Equal(port, b.Port)
+	}
+
+	// create another compatible volume
+
+	for i := 4; i <= 5; i++ {
+		brickPath := testTempDir(t, "brick")
+		brickPaths = append(brickPaths, brickPath)
+	}
+
+	volname2 := volname1 + "2"
+
+	createReq = api.VolCreateReq{
+		Name: volname2,
+		Subvols: []api.SubvolReq{
+			{
+				Type: "distribute",
+				Bricks: []api.BrickReq{
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[3]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[4]},
+				},
+			},
+		},
+		Force: true,
+	}
+	_, err = client.VolumeCreate(createReq)
+	r.Nil(err)
+
+	err = client.VolumeStart(volname2, false)
+	r.Nil(err)
+
+	// check bricks status and confirm that bricks have been multiplexed
+	// onto bricks of the first volume
+	bstatus, err = client.BricksStatus(volname2)
+	r.Nil(err)
+
+	// the pid and port variables now point to values from the old original volume
+	for _, b := range bstatus {
+		r.Equal(pid, b.Pid)
+		r.Equal(port, b.Port)
+	}
+
+	// kill the brick from first volume into which all the brick have been multiplexed
+	process, err := os.FindProcess(pid)
+	r.Nil(err, fmt.Sprintf("failed to find bricks pid: %s", err))
+	err = process.Signal(syscall.Signal(15))
+	r.Nil(err, fmt.Sprintf("failed to kill bricks: %s", err))
+
+	time.Sleep(time.Second * 1)
+	bstatus, err = client.BricksStatus(volname1)
+	r.Nil(err)
+	r.Equal(bstatus[0].Pid, 0)
+	r.Equal(bstatus[0].Port, 0)
+
+	// Second volume's bricks should become offline since brick from first volume has been killed
+	bstatus, err = client.BricksStatus(volname2)
+	r.Nil(err)
+	for _, b := range bstatus {
+		r.Equal(b.Online, false)
+	}
+
+	// force start the first and second volume
+	err = client.VolumeStart(volname1, true)
+	r.Nil(err)
+
+	err = client.VolumeStart(volname2, true)
+	r.Nil(err)
+
+	// first brick from first volume should now all bricks of first volume
+	// should be  be multiplexed into a new pid
+	bstatus, err = client.BricksStatus(volname1)
+	r.Nil(err)
+
+	pid = bstatus[0].Pid
+	port = bstatus[0].Port
+
+	// force start the second volume and the bricks of second volume should
+	// now be multiplexed into the pid in which bricks of first volume are multiplexed
+	bstatus, err = client.BricksStatus(volname2)
+	r.Nil(err)
+
+	for _, b := range bstatus {
+		r.Equal(pid, b.Pid)
+		r.Equal(port, b.Port)
+	}
+
+	// stop the second volume, make it incompatible for multiplexing and start it again.
+	// this should start the bricks as separate processes.
+	r.Nil(client.VolumeStop(volname2))
+
+	voloptReq := api.VolOptionReq{
+		Options: map[string]string{"write-behind.trickling-writes": "on"},
+	}
+	voloptReq.AllowAdvanced = true
+	err = client.VolumeSet(volname2, voloptReq)
+	r.Nil(err)
+
+	err = client.VolumeStart(volname2, false)
+	r.Nil(err)
+
+	bstatus, err = client.BricksStatus(volname2)
+	r.Nil(err)
+
+	// the pid and port variables point to values from the old values
+	// the bricks should have different values for pid and port as they
+	// are no longer multiplexed
+	for _, b := range bstatus {
+		r.NotEqual(pid, b.Pid)
+		r.NotEqual(port, b.Port)
+	}
+
+	r.Nil(client.VolumeStop(volname2))
+	r.Nil(client.VolumeStop(volname1))
+
+	r.Nil(client.VolumeDelete(volname2))
+	r.Nil(client.VolumeDelete(volname1))
+
+	for i := 6; i <= 36; i++ {
+		brickPath := testTempDir(t, "brick")
+		brickPaths = append(brickPaths, brickPath)
+	}
+
+	// Create 10 volumes and start all 10
+	// making all brick multiplexed into first brick of
+	// first volume.
+	index := 5
+	for i := 1; i <= 10; i++ {
+		createReq := api.VolCreateReq{
+			Name: volname1 + strconv.Itoa(i),
+			Subvols: []api.SubvolReq{
+				{
+					Type: "distribute",
+					Bricks: []api.BrickReq{
+						{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index]},
+						{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index+1]},
+						{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index+2]},
+					},
+				},
+			},
+			Force: true,
+		}
+		_, err = client.VolumeCreate(createReq)
+		r.Nil(err)
+
+		// start the volume
+		err = client.VolumeStart(volname1+strconv.Itoa(i), false)
+		r.Nil(err)
+
+		index = index + 3
+	}
+
+	// Check if the multiplexing was successful
+	for i := 1; i <= 10; i++ {
+
+		bstatus, err = client.BricksStatus(volname1 + strconv.Itoa(i))
+		r.Nil(err)
+
+		if i == 1 {
+			pid = bstatus[0].Pid
+			port = bstatus[0].Port
+		} else {
+			for _, b := range bstatus {
+				r.Equal(pid, b.Pid)
+				r.Equal(port, b.Port)
+			}
+		}
+
+	}
+
+	// Stop glusterd2 instance and kill the glusterfsd into
+	// whcih all bricks were multiplexed
+	r.Nil(tc.gds[0].Stop())
+	process, err = os.FindProcess(pid)
+	r.Nil(err, fmt.Sprintf("failed to find brick pid: %s", err))
+	err = process.Signal(syscall.Signal(15))
+	r.Nil(err, fmt.Sprintf("failed to kill brick: %s", err))
+
+	// Spawn glusterd2 instance
+	gd, err := spawnGlusterd(t, "./config/1.toml", false)
+	r.Nil(err)
+	r.True(gd.IsRunning())
+
+	// Check if all the bricks are multiplexed into the first brick
+	// of first volume, this time with a different pid and port.
+	for i := 1; i <= 10; i++ {
+
+		bstatus, err = client.BricksStatus(volname1 + strconv.Itoa(i))
+		r.Nil(err)
+		if i == 1 {
+			pid = bstatus[0].Pid
+			port = bstatus[0].Port
+		}
+		for _, b := range bstatus {
+			r.Equal(pid, b.Pid)
+			r.Equal(port, b.Port)
+		}
+	}
+
+	for i := 1; i <= 10; i++ {
+		r.Nil(client.VolumeStop(volname1 + strconv.Itoa(i)))
+		r.Nil(client.VolumeDelete(volname1 + strconv.Itoa(i)))
+	}
+	r.Nil(gd.Stop())
+}

--- a/glusterd2/brickmux/compat.go
+++ b/glusterd2/brickmux/compat.go
@@ -1,0 +1,74 @@
+package brickmux
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/gluster/glusterd2/glusterd2/brick"
+	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+)
+
+// ErrNoCompat is error returned when no compatible bricks can be found
+var ErrNoCompat = errors.New("no compatible bricks found to be multiplexed onto")
+
+// findCompatibleBrick first finds a compatible volume for multiplexing by
+// comparing volumes having same set of volume options set and then picks a
+// brick from the compatible volume.
+func findCompatibleBrick(b *brick.Brickinfo, brickVolinfo *volume.Volinfo, volumes []*volume.Volinfo) (*brick.Brickinfo, error) {
+
+	startedVolsPresent := false
+	for _, v := range volumes {
+		if v.State == volume.VolStarted {
+			startedVolsPresent = true
+			break
+		}
+	}
+
+	var targetVolume *volume.Volinfo
+	if !startedVolsPresent {
+		// no started volumes present; allow bricks belonging to volume
+		// that's about to be started to be multiplexed to the same
+		// process
+		targetVolume = brickVolinfo
+	} else {
+		for _, v := range volumes {
+			if len(v.GetLocalBricks()) == 0 {
+				// skip volumes that doesn't have bricks on this machine
+				continue
+			}
+			if v.State != volume.VolStarted {
+				// if volume isn't started, we can't multiplex.
+				continue
+			}
+			if reflect.DeepEqual(v.Options, brickVolinfo.Options) {
+				// compare volume options of volumes
+				targetVolume = v
+				break
+			}
+		}
+	}
+
+	if targetVolume == nil {
+		return nil, ErrNoCompat
+	}
+
+	var targetBrick *brick.Brickinfo
+	for _, localBrick := range targetVolume.GetLocalBricks() {
+		if b.ID.String() == localBrick.ID.String() {
+			continue
+		}
+
+		brickDaemon, _ := brick.NewGlusterfsd(localBrick)
+		if running, _ := daemon.IsRunning(brickDaemon); running {
+			targetBrick = &localBrick
+			break
+		}
+	}
+
+	if targetBrick == nil {
+		return nil, ErrNoCompat
+	}
+
+	return targetBrick, nil
+}

--- a/glusterd2/brickmux/demultiplex.go
+++ b/glusterd2/brickmux/demultiplex.go
@@ -1,0 +1,73 @@
+package brickmux
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gluster/glusterd2/glusterd2/brick"
+	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/pmap"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// IsLastBrickInProc returns true if the brick specified is the last brick
+// present in the brick process.
+func IsLastBrickInProc(b brick.Brickinfo) bool {
+
+	port, err := pmap.RegistrySearch(b.Path)
+	if err != nil {
+		return false
+	}
+
+	return len(pmap.GetBricksOnPort(port)) == 1
+}
+
+// Demultiplex sends a detach request to the brick process which the
+// specified brick is multiplexed onto.
+func Demultiplex(b brick.Brickinfo) error {
+
+	log.WithField("brick", b.String()).Debug("get brick daemon for demultiplex process")
+	brickDaemon, err := brick.NewGlusterfsd(b)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{"brick": b.String(),
+		"socketFile": brickDaemon.SocketFile()}).Debug("starting demultiplex process")
+
+	client, err := daemon.GetRPCClient(brickDaemon)
+	if err != nil {
+		return err
+	}
+
+	req := &brick.GfBrickOpReq{
+		Name: b.Path,
+		Op:   int(brick.OpBrickTerminate),
+	}
+
+	log.WithField("brick", b.String()).Debug("detach request sent")
+	var rsp brick.GfBrickOpRsp
+	if err := client.Call("Brick.OpBrickTerminate", req, &rsp); err != nil {
+		return err
+	}
+
+	if rsp.OpRet != 0 {
+		return fmt.Errorf("detach brick RPC request failed; OpRet = %d", rsp.OpRet)
+	}
+	log.WithField("brick", b.String()).Debug("detach request succeded with result")
+
+	// TODO: Find an alternative to substitute the sleep.
+	// There might be some changes on glusterfsd side related to socket
+	// files used while brick signout,
+	// make appropriate changes once glusterfsd side is fixed.
+	time.Sleep(time.Millisecond * 200)
+
+	log.WithField("brick", b.String()).Debug("deleting brick socket and pid file")
+	os.Remove(brickDaemon.PidFile())
+	os.Remove(brickDaemon.SocketFile())
+	log.WithField("brick", b.String()).Debug("deleted brick socket and pid file")
+
+	return nil
+}

--- a/glusterd2/brickmux/multiplex.go
+++ b/glusterd2/brickmux/multiplex.go
@@ -1,0 +1,104 @@
+package brickmux
+
+import (
+	"fmt"
+	"net/rpc"
+	"os"
+
+	"github.com/gluster/glusterd2/glusterd2/brick"
+	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/pmap"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func undoMultiplex(client *rpc.Client, b *brick.Brickinfo) {
+	req := &brick.GfBrickOpReq{
+		Name: b.Path,
+		Op:   int(brick.OpBrickTerminate),
+	}
+
+	var rsp brick.GfBrickOpRsp
+	client.Call("Brick.OpBrickTerminate", req, &rsp)
+}
+
+// Multiplex the specified brick onto a compatible running brick process.
+func Multiplex(b brick.Brickinfo, v *volume.Volinfo, volumes []*volume.Volinfo, logger log.FieldLogger) error {
+
+	targetBrick, err := findCompatibleBrick(&b, v, volumes)
+	if err != nil {
+		return err
+	}
+
+	targetBrickProc, err := brick.NewGlusterfsd(*targetBrick)
+	if err != nil {
+		return err
+	}
+
+	targetBrickPort, err := pmap.RegistrySearch(targetBrick.Path)
+	if err != nil {
+		return err
+	}
+
+	// send attach request to target brick process
+
+	client, err := daemon.GetRPCClient(targetBrickProc)
+	if err != nil {
+		return err
+	}
+
+	logger.WithFields(log.Fields{"brick": b.String(),
+		"targetBrick": targetBrick.Path}).Info("found compatible brick process")
+	logger.WithField("targetBrickSocketFile", targetBrickProc.SocketFile()).Debug("target brick socket file")
+
+	volfileID := brick.GetVolfileID(b.VolumeName, b.Path)
+	volfilePath, err := getBrickVolfilePath(volfileID)
+	if err != nil {
+		return err
+	}
+
+	req := &brick.GfBrickOpReq{
+		Name: volfilePath,
+		Op:   int(brick.OpBrickAttach),
+	}
+
+	logger.WithField("brick", b.Path).Debug("send brick attach RPC")
+	var rsp brick.GfBrickOpRsp
+	if err := client.Call("Brick.OpBrickAttach", req, &rsp); err != nil {
+		return err
+	}
+
+	if rsp.OpRet != 0 {
+		logger.WithError(err).WithField(
+			"brick", b.String()).Error("failed to send attach RPC request")
+		return fmt.Errorf("attach brick RPC request failed; OpRet = %d", rsp.OpRet)
+	}
+	logger.WithError(err).WithField(
+		"brick", b.String()).Error("attach RPC request succeeded")
+
+	brickProc, err := brick.NewGlusterfsd(b)
+	if err != nil {
+		undoMultiplex(client, &b)
+		return err
+	}
+
+	// create Unix Domain Socket hardlink
+	os.Remove(brickProc.SocketFile())
+	if err := os.Link(targetBrickProc.SocketFile(), brickProc.SocketFile()); err != nil {
+		undoMultiplex(client, &b)
+		return err
+	}
+
+	// create duplicate pidfile for the multiplexed brick
+	ok, pid := daemon.IsRunning(targetBrickProc)
+	if !ok {
+		return fmt.Errorf("brick process not running/found")
+	}
+	daemon.WritePidToFile(pid, brickProc.PidFile())
+
+	// update pmap registry (this is redundant as each brick now signs in)
+	pmap.RegistryExtend(b.Path, targetBrickPort, pid)
+
+	return nil
+}

--- a/glusterd2/brickmux/option.go
+++ b/glusterd2/brickmux/option.go
@@ -1,0 +1,35 @@
+package brickmux
+
+import (
+	"github.com/gluster/glusterd2/glusterd2/options"
+)
+
+const (
+	brickMuxOpKey = "cluster.brick-multiplex"
+)
+
+// Enabled returns true if brick multiplexing has been enabled and returns
+// falls otherwise.
+func Enabled() (bool, error) {
+
+	value, err := options.GetClusterOption(brickMuxOpKey)
+	if err != nil {
+		return false, err
+	}
+
+	ok, err := options.StringToBoolean(value)
+	if err != nil {
+		return false, err
+	}
+
+	return ok, nil
+}
+
+// validateOption validates brick mux options
+func validateOption(option, value string) error {
+	return nil
+}
+
+func init() {
+	options.RegisterClusterOpValidationFunc(brickMuxOpKey, validateOption)
+}

--- a/glusterd2/brickmux/reconcile.go
+++ b/glusterd2/brickmux/reconcile.go
@@ -1,0 +1,83 @@
+package brickmux
+
+import (
+	"context"
+	"os"
+
+	"github.com/gluster/glusterd2/glusterd2/brick"
+	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/volume"
+	"github.com/gluster/glusterd2/pkg/errors"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Reconcile will multiplex bricks on (re)start of glusterd2.
+func Reconcile() error {
+
+	bmuxEnabled, err := Enabled()
+	if err != nil {
+		return err
+	}
+
+	if !bmuxEnabled {
+		return nil
+	}
+
+	volumes, err := volume.GetVolumes(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	var bricks []brick.Brickinfo
+	for _, v := range volumes {
+		if v.State == volume.VolStarted {
+			bricks = append(bricks, v.GetLocalBricks()...)
+		}
+	}
+
+	// convert it to map for easier lookup below
+	volumeMap := make(map[string]*volume.Volinfo)
+	for _, volume := range volumes {
+		volumeMap[volume.ID.String()] = volume
+	}
+
+	for _, b := range bricks {
+		d, err := brick.NewGlusterfsd(b)
+		if err != nil {
+			return err
+		}
+
+		if running, _ := daemon.IsRunning(d); running {
+			continue
+		} else {
+			// cleanup stale pidfile
+			os.Remove(d.PidFile())
+		}
+
+		err = Multiplex(b, volumeMap[b.VolumeID.String()], volumes, log.StandardLogger())
+		switch err {
+		case nil:
+			// successfully multiplexed
+			continue
+		case ErrNoCompat:
+			// something changed between restart and we can't find
+			// a compatible brick process.
+			// do nothing, fallback to starting a separate process
+			log.WithField("brick", b.String()).Warn(err)
+		default:
+			// log and move on, do not exit; this behaviour can be changed later if necessarry
+			log.WithField("brick", b.String()).WithError(err).Error("brickmux.Multiplex failed")
+			continue
+		}
+
+		if err := b.StartBrick(log.StandardLogger()); err != nil {
+			if err == errors.ErrProcessAlreadyRunning {
+				continue
+			}
+			log.WithField("brick", b.String()).WithError(err).Error("failed to start brick process")
+		}
+	}
+
+	return nil
+}

--- a/glusterd2/brickmux/utils.go
+++ b/glusterd2/brickmux/utils.go
@@ -1,0 +1,22 @@
+package brickmux
+
+import (
+	"os"
+	"path"
+
+	config "github.com/spf13/viper"
+)
+
+// getBrickVolfilePath returns path correspponding to the volfileID. Since, brick volfiles are now stored on
+// disk, added a check to ensure the volfile exists on the path.
+func getBrickVolfilePath(volfileID string) (string, error) {
+
+	volfilePath := path.Join(config.GetString("localstatedir"),
+		"volfiles", volfileID+".vol")
+
+	if _, err := os.Stat(volfilePath); os.IsNotExist(err) {
+		return "", err
+	}
+
+	return volfilePath, nil
+}

--- a/glusterd2/daemon/utils.go
+++ b/glusterd2/daemon/utils.go
@@ -68,3 +68,19 @@ func GetProcess(pid int) (*os.Process, error) {
 
 	return process, nil
 }
+
+// IsRunning returns true if the specified daemon is running and returns
+// false otherwise.
+func IsRunning(d Daemon) (bool, int) {
+
+	pid, err := ReadPidFromFile(d.PidFile())
+	if err != nil {
+		return false, -1
+	}
+
+	if _, err := GetProcess(pid); err != nil {
+		return false, -1
+	}
+
+	return true, pid
+}

--- a/glusterd2/main.go
+++ b/glusterd2/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gluster/glusterd2/glusterd2/brickmux"
 	"github.com/gluster/glusterd2/glusterd2/commands/volumes"
 	"github.com/gluster/glusterd2/glusterd2/daemon"
 	"github.com/gluster/glusterd2/glusterd2/events"
@@ -151,6 +152,11 @@ func main() {
 	// Restart previously running daemons
 	daemon.StartAllDaemons()
 
+	// Reconcile multiplexed bricks
+	if err := brickmux.Reconcile(); err != nil {
+		log.WithError(err).Fatal("bmux.Reconcile() failed")
+	}
+
 	// Use the main goroutine as signal handling loop
 	sigCh := make(chan os.Signal)
 	signal.Notify(sigCh)
@@ -205,6 +211,7 @@ func createDirectories() error {
 		path.Join(config.GetString("hooksdir"), "delete/post"),
 		path.Join(config.GetString("hooksdir"), "add-brick/post"),
 		path.Join(config.GetString("hooksdir"), "remove-brick/post"),
+		path.Join(config.GetString("localstatedir"), "vols"),
 		"/var/run/gluster", // issue #476
 	}
 	for _, dirpath := range dirs {

--- a/glusterd2/pmap/pmap.go
+++ b/glusterd2/pmap/pmap.go
@@ -14,3 +14,23 @@ func RegistrySearch(brickpath string) (int, error) {
 func ProcessDisconnect(conn net.Conn) error {
 	return registry.RemovePortByConn(conn)
 }
+
+// RegistryExtend adds a brick entry to pmap registry and is used during
+// multiplexing a brick.
+func RegistryExtend(brickpath string, port int, pid int) {
+	registry.Update(port, brickpath, nil, pid)
+}
+
+// GetBricksOnPort returns a list of bricks that are multiplexed onto a single
+// process that is listening on the port specified.
+func GetBricksOnPort(port int) []string {
+	var bricks []string
+
+	if m, ok := registry.Ports[port]; ok {
+		for path := range m {
+			bricks = append(bricks, path)
+		}
+	}
+
+	return bricks
+}

--- a/glusterd2/pmap/registry_test.go
+++ b/glusterd2/pmap/registry_test.go
@@ -23,7 +23,7 @@ func TestRegistry(t *testing.T) {
 
 	// test sign in path
 	for i := basePort; i <= (basePort + 100); i++ {
-		err := r.Update(i, fmt.Sprintf("/tmp/brick%d", i), nil)
+		err := r.Update(i, fmt.Sprintf("/tmp/brick%d", i), nil, 0)
 		assert.NoError(err)
 	}
 
@@ -31,10 +31,10 @@ func TestRegistry(t *testing.T) {
 		assert.NotZero(v)
 	}
 
-	err := r.Update(math.MaxInt32, "some_brick", nil)
+	err := r.Update(math.MaxInt32, "some_brick", nil, 0)
 	assert.Error(err)
 
-	err = r.Update(-1, "some_brick", nil)
+	err = r.Update(-1, "some_brick", nil, 0)
 	assert.Error(err)
 
 	// test port search

--- a/glusterd2/pmap/rpc_prog.go
+++ b/glusterd2/pmap/rpc_prog.go
@@ -114,6 +114,7 @@ func (p *GfPortmap) PortByBrick(args *PortByBrickReq, reply *PortByBrickRsp) err
 type SignInReq struct {
 	Brick string
 	Port  int
+	Pid   int
 }
 
 // SignInRsp is response sent to a SignInReq request
@@ -138,7 +139,9 @@ func (p *GfPortmap) SignIn(args *SignInReq, reply *SignInRsp) error {
 		"port":    args.Port,
 	}).Debug("brick signed in")
 
-	registry.Update(args.Port, args.Brick, conn)
+	// TODO: Add Pid field to SignInReq and pass it here when
+	// https://review.gluster.org/21503 gets in.
+	registry.Update(args.Port, args.Brick, conn, args.Pid)
 
 	return nil
 }


### PR DESCRIPTION
This PR adds support for multiple brick translator stacks running in
a single brick server process. Multiplexing is controlled by the
`cluster.brick-multiplex` global option. By default it's off, and
bricks are started in separate processes as before. If multiplexing is
enabled, then *compatible* bricks (those with the same volume options)
will be started in the same process.

Multiplexing and demultiplexing involves sending an RPC request from
glusterd2 to brick process.

**Pidfile and socket files:**
* Each multiplexed brick will have a separate pidfile (returned by
  `PidFile()` method of `Daemon` interface).
* As multiplexed bricks will have only one server xlator, it will be
  listening on only one Unix Domain Socket file. A hardlink to this
  socketfile is created per multiplexed brick. Hence, glusterd2
  will separate connection for each multiplexed brick.

**Differences from glusterd1's implementation:**
No dynamic information about port is stored on disk or in etcd. Unlike
glusterd1, all multiplexed bricks in a brick process will now sign in
on reconnection (https://review.gluster.org/21503). This make it easy
for glusterd2 to repopulate its pmap registry on restart. This is a
much simpler approach as against what glusterd1 has to do i.e, read
`/proc/<brick-pid>/fd/` and read stored port information.

**Bonus:**
Sign in RPC request has been modified (https://review.gluster.org/21503)
to send PID of the brick process. Glusterd2 can (in future) rely on this
instead of having to read/manage pidfiles.

**Code organisation:**
For easier review, most of the brick multiplexing code has been kept
separate in 'brickmux' package. Minimal changes have been introduced
to other existing packages. However, there's an opportunity for a
future refactor which can converge 'brickmux', 'brick' and 'pmap'
packages.

**Using brick multiplexing:**
```sh
$ glustercli volume set all cluster.brick-multiplex on
$ glustercli volume set all cluster.brick-multiplex off
```

**What's not been done (not GCS priority per se):**
* Brick multiplexing hasn't been implemented for volume expand operation
  i.e add brick.
* 'cluster.max-bricks-per-process' option hasn't been implemented. This
  means all compatible bricks shall be multiplexed to one single brick
  process.
* Turning on/off brick multiplexing with volumes actively running has
  no effect. In GCS production, brick multiplexing shall only be turned
  on at the beginning.

Reference (glusterd1 implementation):
https://review.gluster.org/16496

Closes #219 
Signed-off-by: Prashanth Pai <ppai@redhat.com>