### PR TITLE
Volume expand fails to start bricks when volume is in started state

### DIFF
--- a/glusterd2/commands/volumes/volume-expand.go
+++ b/glusterd2/commands/volumes/volume-expand.go
@@ -27,6 +27,8 @@ func registerVolExpandStepFuncs() {
 		{"vol-expand.ValidateBricks", validateBricks},
 		{"vol-expand.InitBricks", initBricks},
 		{"vol-expand.UndoInitBricks", undoInitBricks},
+		{"vol-expand.GenerateBrickVolfiles", txnGenerateBrickVolfiles},
+		{"vol-expand.GenerateBrickVolfiles.Undo", txnDeleteBrickVolfiles},
 		{"vol-expand.StartBrick", startBricksOnExpand},
 		{"vol-expand.UndoStartBrick", undoStartBricksOnExpand},
 		{"vol-expand.UpdateVolinfo", updateVolinfoOnExpand},
@@ -133,6 +135,12 @@ func volumeExpandHandler(w http.ResponseWriter, r *http.Request) {
 		{
 			DoFunc: "vol-expand.UpdateVolinfo",
 			Nodes:  []uuid.UUID{gdctx.MyUUID},
+		},
+		{
+			DoFunc:   "vol-expand.GenerateBrickVolfiles",
+			UndoFunc: "vol-expand.GenerateBrickVolfiles.Undo",
+			Nodes:    nodes,
+			Skip:     (volinfo.State != volume.VolStarted),
 		},
 		{
 			DoFunc:   "vol-expand.StartBrick",


### PR DESCRIPTION
Fixes [#1329](https://github.com/gluster/glusterd2/issues/1329)

Volume expand fails to start bricks when volume is in started state but works fine when volume is in Stopped/Created state

Fix - Brick Volfiles need to be generated beafore starting the bricks.