### PR TITLE
Changes in format to run glfsheal to get heal info.

### DIFF
--- a/plugins/glustershd/rest.go
+++ b/plugins/glustershd/rest.go
@@ -61,7 +61,7 @@ func runGlfshealBin(volname string, args []string) (string, error) {
 func getHealInfo(volname string, option string) (string, error) {
 	var options []string
 	glusterdSockpath := path.Join(config.GetString("rundir"), "glusterd2.socket")
-	options = append(options, option, "xml", "glusterd-sock", glusterdSockpath)
+	options = append(options, option, "--xml", "glusterd-sock", glusterdSockpath)
 
 	return runGlfshealBin(volname, options)
 }


### PR DESCRIPTION
Change in format to run glfsheal to fetch heal info.

Previously it was -
glfsheal volname xml glusterd-sock <socket-filename.socket>

There might have been some new introductions on glusterfs side.
https://review.gluster.org/#/c/glusterfs/+/21501/

 The new format is -
glfsheal volname --xml glusterd-sock <socket-filename.socket>

This should resolve the CI errors related to heal.

Signed-off-by: Vishal Pandey <vpandey@redhat.com>