### PR TITLE
Fix #1321: remove session references

### DIFF
--- a/pkg/sunrpc/servercodec.go
+++ b/pkg/sunrpc/servercodec.go
@@ -124,6 +124,8 @@ func (c *serverCodec) WriteResponse(resp *rpc.Response, result interface{}) erro
 }
 
 func (c *serverCodec) Close() error {
+	// Do not leak the read-buffer
+	c.recordReader = nil
 	if c.closed {
 		return nil
 	}


### PR DESCRIPTION
acceptLoop keeps a list of all sessions, and each session keeps a reference to the memory block allocated as a read buffer. This reference is there even if the session closes, so as long as acceptLoop runs, memory keeps growing. This should fix it by doing two things: 1) When session closes, remove the reference to the buffer. But that will still continue to leak sessions, because nothing removes elements from the session list. So, 2) remove the logic that keep track of sessions, instead, run two goroutines for each session, one to keep the session and run the server, and the other to terminate the first one when needed.

I don't have the infra to verify this, so let me know how it goes.