### PR TITLE
Max-bricks-per-process option for brick multiplexing.

### DIFF
--- a/e2e/brickmux_test.go
+++ b/e2e/brickmux_test.go
@@ -42,6 +42,7 @@ func TestBrickMux(t *testing.T) {
 	}
 
 	volname1 := formatVolName(t.Name())
+	volname2 := volname1 + strconv.Itoa(2)
 
 	createReq := api.VolCreateReq{
 		Name: volname1,
@@ -83,8 +84,6 @@ func TestBrickMux(t *testing.T) {
 		brickPath := testTempDir(t, "brick")
 		brickPaths = append(brickPaths, brickPath)
 	}
-
-	volname2 := volname1 + "2"
 
 	createReq = api.VolCreateReq{
 		Name: volname2,
@@ -165,7 +164,7 @@ func TestBrickMux(t *testing.T) {
 	r.Nil(client.VolumeStop(volname2))
 
 	voloptReq := api.VolOptionReq{
-		Options: map[string]string{"write-behind.trickling-writes": "on"},
+		Options: map[string]string{"io-stats.count-fop-hits": "on"},
 	}
 	voloptReq.AllowAdvanced = true
 	err = client.VolumeSet(volname2, voloptReq)
@@ -276,5 +275,250 @@ func TestBrickMux(t *testing.T) {
 		r.Nil(client.VolumeStop(volname1 + strconv.Itoa(i)))
 		r.Nil(client.VolumeDelete(volname1 + strconv.Itoa(i)))
 	}
+
+	// Turn on brick mux max-bricks-per-process cluster option
+	optReq = api.ClusterOptionReq{
+		Options: map[string]string{"cluster.max-bricks-per-process": "5"},
+	}
+	err = client.ClusterOptionSet(optReq)
+	r.Nil(err)
+
+	for i := 36; i <= 100; i++ {
+		brickPath := testTempDir(t, "brick")
+		brickPaths = append(brickPaths, brickPath)
+	}
+
+	/* Test  for Testing max-bricks-per-process constraint while
+	multiplexing*/
+
+	// Create 10 volumes and start all 10
+	// making all brick multiplexed with the constraint that
+	// max-bricks-per-process is 5
+
+	index = 37
+	for i := 1; i <= 10; i++ {
+
+		createReq := api.VolCreateReq{
+			Name: volname1 + strconv.Itoa(i),
+			Subvols: []api.SubvolReq{
+				{
+					Type: "distribute",
+					Bricks: []api.BrickReq{
+						{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index]},
+						{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index+1]},
+					},
+				},
+			},
+			Force: true,
+		}
+
+		if i%2 != 0 {
+			createReq = api.VolCreateReq{
+				Name: volname1 + strconv.Itoa(i),
+				Subvols: []api.SubvolReq{
+					{
+						ReplicaCount: 2,
+						Type:         "replicate",
+						Bricks: []api.BrickReq{
+							{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index]},
+							{PeerID: tc.gds[0].PeerID(), Path: brickPaths[index+1]},
+						},
+					},
+				},
+				Force: true,
+			}
+
+		}
+		_, err = client.VolumeCreate(createReq)
+		r.Nil(err)
+		// start the volume
+		err = client.VolumeStart(volname1+strconv.Itoa(i), false)
+		r.Nil(err)
+
+		index = index + 2
+	}
+
+	// pidMap and portMap just to mantain count of every pid and port of
+	// bricks from all 5 volumes.
+	pidMap := make(map[int]int)
+	portMap := make(map[int]int)
+	for i := 1; i <= 10; i++ {
+		bstatus, err := client.BricksStatus(volname1 + strconv.Itoa(i))
+		r.Nil(err)
+		for _, b := range bstatus {
+			if _, ok := pidMap[b.Pid]; ok {
+				pidMap[b.Pid]++
+			} else {
+				pidMap[b.Pid] = 1
+			}
+
+			if _, ok := portMap[b.Port]; ok {
+				portMap[b.Port]++
+			} else {
+				portMap[b.Port] = 1
+			}
+
+		}
+	}
+
+	// Check if all pid's and ports's have count = 2 as mentioned in
+	// max-bricks-per-process
+	for _, v := range pidMap {
+		r.Equal(v, 5)
+	}
+
+	for _, v := range portMap {
+		r.Equal(v, 5)
+	}
+
+	r.Nil(gd.Stop())
+	for k := range pidMap {
+		process, err := os.FindProcess(k)
+		r.Nil(err, fmt.Sprintf("failed to find brick pid: %s", err))
+		err = process.Signal(syscall.Signal(15))
+		r.Nil(err, fmt.Sprintf("failed to kill brick: %s", err))
+	}
+
+	// Spawn glusterd2 instance
+	gd, err = spawnGlusterd(t, "./config/1.toml", false)
+	r.Nil(err)
+	r.True(gd.IsRunning())
+
+	time.Sleep(10 * time.Millisecond)
+
+	pidMap = make(map[int]int)
+	portMap = make(map[int]int)
+	for i := 1; i <= 10; i++ {
+		bstatus, err := client.BricksStatus(volname1 + strconv.Itoa(i))
+		r.Nil(err)
+		for _, b := range bstatus {
+			if _, ok := pidMap[b.Pid]; ok {
+				pidMap[b.Pid]++
+			} else {
+				pidMap[b.Pid] = 1
+			}
+
+			if _, ok := portMap[b.Port]; ok {
+				portMap[b.Port]++
+			} else {
+				portMap[b.Port] = 1
+			}
+
+		}
+	}
+
+	// Check if all pid's and ports's have count = 2 as mentioned in
+	// max-bricks-per-process
+	for _, v := range pidMap {
+		r.Equal(v, 5)
+	}
+
+	for _, v := range portMap {
+		r.Equal(v, 5)
+	}
+
+	for i := 1; i <= 10; i++ {
+		r.Nil(client.VolumeStop(volname1 + strconv.Itoa(i)))
+		r.Nil(client.VolumeDelete(volname1 + strconv.Itoa(i)))
+	}
+
+	// Create two volumes with different options, so that bricks from these
+	// two volumes are multiplexed into bricks from their own volume. Also,
+	// check if among three bricks of a volume 2 bricks have same pid and
+	// port while 1 brick has a different pid and port, since num  of bricks
+	// are 3 and max-bricks-per-process is set as 2.
+
+	// Turn on brick mux cluster option
+	optReq = api.ClusterOptionReq{
+		Options: map[string]string{"cluster.max-bricks-per-process": "2"},
+	}
+	err = client.ClusterOptionSet(optReq)
+	r.Nil(err)
+
+	createReq = api.VolCreateReq{
+		Name: volname1,
+		Subvols: []api.SubvolReq{
+			{
+				ReplicaCount: 3,
+				Type:         "replicate",
+				Bricks: []api.BrickReq{
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[51]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[52]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[53]},
+				},
+			},
+		},
+		Force: true,
+	}
+	_, err = client.VolumeCreate(createReq)
+	r.Nil(err)
+
+	// start the volume
+	err = client.VolumeStart(volname1, false)
+	r.Nil(err)
+
+	createReq = api.VolCreateReq{
+		Name: volname2,
+		Subvols: []api.SubvolReq{
+			{
+				Type: "distribute",
+				Bricks: []api.BrickReq{
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[48]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[49]},
+					{PeerID: tc.gds[0].PeerID(), Path: brickPaths[50]},
+				},
+			},
+		},
+		Force: true,
+	}
+	_, err = client.VolumeCreate(createReq)
+	r.Nil(err)
+
+	// Setting an option in second volume so that  second volume doesn't
+	// multiplex its brick into first volume
+	var optionReq api.VolOptionReq
+	optionReq.Options = map[string]string{"io-stats.count-fop-hits": "on"}
+	optionReq.AllowAdvanced = true
+
+	r.Nil(client.VolumeSet(volname2, optionReq))
+
+	// start the volume
+	err = client.VolumeStart(volname2, false)
+	r.Nil(err)
+
+	bstatus, err = client.BricksStatus(volname1)
+	r.Nil(err)
+
+	// Keep track of used unique pids and ports used in multiplexing bricks
+	// of  volname1 and calculate length length of maps, which should be equal to 2
+	pidMap = make(map[int]int)
+	portMap = make(map[int]int)
+	for _, b := range bstatus {
+		pidMap[b.Pid] = 1
+		portMap[b.Port] = 1
+	}
+	r.Equal(len(pidMap), 2)
+	r.Equal(len(portMap), 2)
+
+	bstatus2, err := client.BricksStatus(volname2)
+	r.Nil(err)
+
+	// Keep track of used unique pids and ports used in multiplexing bricks
+	// of  volname1 and calculate length length of maps, which should be equal to 2
+	pidMap = make(map[int]int)
+	portMap = make(map[int]int)
+	for _, b := range bstatus2 {
+		pidMap[b.Pid] = 1
+		portMap[b.Port] = 1
+	}
+	r.Equal(len(pidMap), 2)
+	r.Equal(len(portMap), 2)
+
+	r.Nil(client.VolumeStop(volname1))
+	r.Nil(client.VolumeDelete(volname1))
+
+	r.Nil(client.VolumeStop(volname2))
+	r.Nil(client.VolumeDelete(volname2))
+
 	r.Nil(gd.Stop())
 }

--- a/glusterd2/brickmux/compat.go
+++ b/glusterd2/brickmux/compat.go
@@ -6,16 +6,60 @@ import (
 
 	"github.com/gluster/glusterd2/glusterd2/brick"
 	"github.com/gluster/glusterd2/glusterd2/daemon"
+	"github.com/gluster/glusterd2/glusterd2/pmap"
 	"github.com/gluster/glusterd2/glusterd2/volume"
+
+	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // ErrNoCompat is error returned when no compatible bricks can be found
 var ErrNoCompat = errors.New("no compatible bricks found to be multiplexed onto")
 
+// validateBmuxTarget validates whether target volume has any valid brick in
+// which current brick can be multiplexed into. Useful in case when
+// max-brick-per-process(> 0) has been set by user
+func validateBmuxTarget(b *brick.Brickinfo, volinfo *volume.Volinfo, maxBricksPerProcess int) *brick.Brickinfo {
+	var targetBrick *brick.Brickinfo
+	for _, localbrick := range volinfo.GetLocalBricks() {
+		if uuid.Equal(b.ID, localbrick.ID) {
+			continue
+		}
+
+		brickDaemon, err := brick.NewGlusterfsd(localbrick)
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"volume": volinfo.Name,
+				"brick":  b.Path}).Error("failed to retrieve brick daemon object")
+			continue
+		}
+		if running, _ := daemon.IsRunning(brickDaemon); !running {
+			continue
+		}
+
+		// Look for port for the brick path of target volume
+		port, err := pmap.RegistrySearch(localbrick.Path)
+		if err != nil {
+			continue
+		}
+		// return number of bricks already attached to a port
+		numOfBricksBmuxedOnPort, err := pmap.GetNumOfBricksOnPort(port)
+		if err != nil {
+			continue
+		}
+		if numOfBricksBmuxedOnPort == maxBricksPerProcess {
+			continue
+		}
+		targetBrick = &localbrick
+		break
+	}
+	return targetBrick
+}
+
 // findCompatibleBrick first finds a compatible volume for multiplexing by
 // comparing volumes having same set of volume options set and then picks a
 // brick from the compatible volume.
-func findCompatibleBrick(b *brick.Brickinfo, brickVolinfo *volume.Volinfo, volumes []*volume.Volinfo) (*brick.Brickinfo, error) {
+func findCompatibleBrick(b *brick.Brickinfo, brickVolinfo *volume.Volinfo, volumes []*volume.Volinfo, maxBricksPerProcess int) (*brick.Brickinfo, error) {
 
 	startedVolsPresent := false
 	for _, v := range volumes {
@@ -25,15 +69,24 @@ func findCompatibleBrick(b *brick.Brickinfo, brickVolinfo *volume.Volinfo, volum
 		}
 	}
 
+	var targetBrick *brick.Brickinfo
 	var targetVolume *volume.Volinfo
 	if !startedVolsPresent {
 		// no started volumes present; allow bricks belonging to volume
 		// that's about to be started to be multiplexed to the same
 		// process
 		targetVolume = brickVolinfo
+		if maxBricksPerProcess > 0 {
+			targetBrick = validateBmuxTarget(b, brickVolinfo, maxBricksPerProcess)
+			if targetBrick == nil {
+				return nil, ErrNoCompat
+			}
+		}
 	} else {
+		// atleast one started volume present
 		for _, v := range volumes {
-			if len(v.GetLocalBricks()) == 0 {
+			localBricks := v.GetLocalBricks()
+			if len(localBricks) == 0 {
 				// skip volumes that doesn't have bricks on this machine
 				continue
 			}
@@ -41,34 +94,49 @@ func findCompatibleBrick(b *brick.Brickinfo, brickVolinfo *volume.Volinfo, volum
 				// if volume isn't started, we can't multiplex.
 				continue
 			}
+			// compare volume options of volumes
 			if reflect.DeepEqual(v.Options, brickVolinfo.Options) {
-				// compare volume options of volumes
 				targetVolume = v
+				if maxBricksPerProcess > 0 {
+					targetBrick = validateBmuxTarget(b, targetVolume, maxBricksPerProcess)
+					if targetBrick == nil {
+						continue
+					}
+				}
 				break
+			}
+		}
+		// If any of the started volumes doesn't qualify as a
+		//targetBrick and a targetVolume,
+		// then look for an eligible bricks in current volume.
+		// Current volume is not present in started volumes list at this
+		// step therefore need to evaluate target brick for current
+		// volume seperately.
+		if targetBrick == nil && maxBricksPerProcess > 0 {
+			targetBrick = validateBmuxTarget(b, brickVolinfo, maxBricksPerProcess)
+			if targetBrick == nil {
+				return nil, ErrNoCompat
 			}
 		}
 	}
 
+	// Useful in case with no target Volume and no max-brick-per-process
+	// constraint
+	// consider multiplexing all bricks of current volume into first brick
+	// of current volume. Handled seperately since current volume still not
+	// considered in started volumes list. Executed when
+	// max-bricks-per-process = 0.
 	if targetVolume == nil {
-		return nil, ErrNoCompat
+		targetVolume = brickVolinfo
 	}
-
-	var targetBrick *brick.Brickinfo
-	for _, localBrick := range targetVolume.GetLocalBricks() {
-		if b.ID.String() == localBrick.ID.String() {
-			continue
-		}
-
-		brickDaemon, _ := brick.NewGlusterfsd(localBrick)
-		if running, _ := daemon.IsRunning(brickDaemon); running {
-			targetBrick = &localBrick
-			break
-		}
-	}
-
+	// if target volume exists and target brick has not been evaluated yet.
+	// Useful in case of max-bricks-per-process  = 0.
 	if targetBrick == nil {
-		return nil, ErrNoCompat
-	}
+		targetBrick = validateBmuxTarget(b, targetVolume, maxBricksPerProcess)
+		if targetBrick == nil {
+			return nil, ErrNoCompat
+		}
 
+	}
 	return targetBrick, nil
 }

--- a/glusterd2/brickmux/multiplex.go
+++ b/glusterd2/brickmux/multiplex.go
@@ -25,8 +25,12 @@ func undoMultiplex(client *rpc.Client, b *brick.Brickinfo) {
 
 // Multiplex the specified brick onto a compatible running brick process.
 func Multiplex(b brick.Brickinfo, v *volume.Volinfo, volumes []*volume.Volinfo, logger log.FieldLogger) error {
+	maxBricksPerProcess, err := getMaxBricksPerProcess()
+	if err != nil {
+		return err
+	}
 
-	targetBrick, err := findCompatibleBrick(&b, v, volumes)
+	targetBrick, err := findCompatibleBrick(&b, v, volumes, maxBricksPerProcess)
 	if err != nil {
 		return err
 	}

--- a/glusterd2/brickmux/option.go
+++ b/glusterd2/brickmux/option.go
@@ -1,11 +1,15 @@
 package brickmux
 
 import (
+	"strconv"
+
 	"github.com/gluster/glusterd2/glusterd2/options"
+	"github.com/gluster/glusterd2/pkg/errors"
 )
 
 const (
-	brickMuxOpKey = "cluster.brick-multiplex"
+	brickMuxOpKey               = "cluster.brick-multiplex"
+	brickMuxMaxBricksPerProcKey = "cluster.max-bricks-per-process"
 )
 
 // Enabled returns true if brick multiplexing has been enabled and returns
@@ -25,11 +29,33 @@ func Enabled() (bool, error) {
 	return ok, nil
 }
 
+func getMaxBricksPerProcess() (int, error) {
+	value, err := options.GetClusterOption(brickMuxMaxBricksPerProcKey)
+	if err != nil {
+		return -1, err
+	}
+
+	maxBricksPerProcess, err := strconv.Atoi(value)
+	if err != nil {
+		return -1, err
+	}
+
+	return maxBricksPerProcess, nil
+}
+
 // validateOption validates brick mux options
 func validateOption(option, value string) error {
+	if option == "cluster.max-bricks-per-process" {
+		_, err := strconv.Atoi(value)
+		if err != nil {
+			return errors.ErrInvalidIntValue
+		}
+	}
+
 	return nil
 }
 
 func init() {
 	options.RegisterClusterOpValidationFunc(brickMuxOpKey, validateOption)
+	options.RegisterClusterOpValidationFunc(brickMuxMaxBricksPerProcKey, validateOption)
 }

--- a/glusterd2/options/cluster.go
+++ b/glusterd2/options/cluster.go
@@ -31,7 +31,7 @@ var ClusterOptMap = map[string]*ClusterOption{
 	"cluster.op-version":             {"cluster.op-version", strconv.Itoa(gdctx.OpVersion), OptionTypeInt, nil},
 	"cluster.max-op-version":         {"cluster.max-op-version", strconv.Itoa(gdctx.OpVersion), OptionTypeInt, nil},
 	"cluster.brick-multiplex":        {"cluster.brick-multiplex", "off", OptionTypeBool, nil},
-	"cluster.max-bricks-per-process": {"cluster.max-bricks-per-process", "0", OptionTypeInt, nil},
+	"cluster.max-bricks-per-process": {"cluster.max-bricks-per-process", "250", OptionTypeInt, nil},
 	"cluster.localtime-logging":      {"cluster.localtime-logging", "off", OptionTypeBool, nil},
 }
 

--- a/glusterd2/pmap/pmap.go
+++ b/glusterd2/pmap/pmap.go
@@ -34,3 +34,9 @@ func GetBricksOnPort(port int) []string {
 
 	return bricks
 }
+
+// GetNumOfBricksOnPort returns count of bricks attached to a port while
+// useful while multiplexing with max-bricks-per-process constraint
+func GetNumOfBricksOnPort(port int) (int, error) {
+	return registry.NumOfBricksOnPort(port)
+}

--- a/glusterd2/pmap/registry.go
+++ b/glusterd2/pmap/registry.go
@@ -107,6 +107,22 @@ func (r *pmapRegistry) SearchByBrickPath(brickpath string) (int, error) {
 	return -1, fmt.Errorf("SearchByBrickPath: port for brick %s not found", brickpath)
 }
 
+// NumOfBricksOnPort returns number of bricks attached to a port. Called during
+// brick multiplexing when there is a max-brick-per-process constraint
+func (r *pmapRegistry) NumOfBricksOnPort(port int) (int, error) {
+	if port < portMin || port > portMax {
+		return -1, fmt.Errorf("registry.NumOfBricksOnPort: invalid port %d", port)
+	}
+
+	r.RLock()
+	defer r.RUnlock()
+	if bricks, ok := r.Ports[port]; ok {
+		return len(bricks), nil
+	}
+
+	return -1, fmt.Errorf("NumOfBricksOnPort: port %d not found in registry", port)
+}
+
 // RemoveByConn deletes port map entry by brick process's TCP connection.
 // There will be only one TCP connection per brick process, regardless of
 // number of bricks in the process.

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -70,4 +70,5 @@ var (
 	ErrVolumeBricksMountFailed         = errors.New("failed to get mount point entries for the volume bricks")
 	ErrBrickMountFailed                = errors.New("failed to mount brick")
 	ErrReservedGroupProfile            = errors.New("reserved group profile")
+	ErrInvalidIntValue                 = errors.New("error parsing the value. Make sure the value is a valid integer")
 )


### PR DESCRIPTION
Fixes [#1304](https://github.com/gluster/glusterd2/issues/1304)

Implement max-bricks-per-process cluster option for brick multiplexing.