### PR TITLE
Removing volume stop from replace-brick e2e test case

### DIFF
--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -112,6 +112,10 @@ func testReplaceBrick(t *testing.T) {
 	volinfo, err = client.VolumeCreate(createReq)
 	r.Nil(err)
 
+	// Start volume
+	err = client.VolumeStart(smartvolname, true)
+	r.Nil(err)
+
 	oldBrickPath = volinfo.Subvols[0].Bricks[0].Path
 	oldBrickPeerID = volinfo.Subvols[0].Bricks[0].PeerID
 	excludePeer := []string{peerinfo.ID.String()}
@@ -126,6 +130,7 @@ func testReplaceBrick(t *testing.T) {
 	r.Nil(err)
 
 	r.NotEqual(peerinfo.ID, oldBrickPeerID)
+
 	err = client.VolumeStop(smartvolname)
 	r.Nil(err)
 	err = (client.VolumeDelete(smartvolname))


### PR DESCRIPTION
Since volume was not started, volume stop was unnecessarily placed in the e2e test case.