### PR TITLE
Add total and used field to device response

### DIFF
--- a/plugins/device/api/resp.go
+++ b/plugins/device/api/resp.go
@@ -10,7 +10,9 @@ import (
 type Info struct {
 	Device        string    `json:"device"`
 	State         string    `json:"state"`
-	AvailableSize uint64    `json:"available-size"`
+	AvailableSize uint64    `json:"free-size"`
+	TotalSize     uint64    `json:"total-size"`
+	UsedSize      uint64    `json:"used-size"`
 	ExtentSize    uint64    `json:"extent-size"`
 	Used          bool      `json:"device-used"`
 	PeerID        uuid.UUID `json:"peer-id"`

--- a/plugins/device/deviceutils/store-utils.go
+++ b/plugins/device/deviceutils/store-utils.go
@@ -109,6 +109,7 @@ func UpdateDeviceFreeSize(peerID, device string) error {
 		return err
 	}
 	dev.AvailableSize = availableSize
+	dev.UsedSize = dev.TotalSize - availableSize
 	dev.ExtentSize = extentSize
 	return AddOrUpdateDevice(*dev)
 }
@@ -127,6 +128,7 @@ func UpdateDeviceFreeSizeByVg(peerID, vgname string) error {
 				return err
 			}
 			dev.AvailableSize = availableSize
+			dev.UsedSize = dev.TotalSize - availableSize
 			dev.ExtentSize = extentSize
 			return AddOrUpdateDevice(dev)
 		}

--- a/plugins/device/transaction.go
+++ b/plugins/device/transaction.go
@@ -48,6 +48,8 @@ func txnPrepareDevice(c transaction.TxnCtx) error {
 		Device:        device,
 		State:         deviceapi.DeviceEnabled,
 		AvailableSize: availableSize,
+		TotalSize:     availableSize,
+		UsedSize:      0,
 		ExtentSize:    extentSize,
 		PeerID:        peerID,
 	}


### PR DESCRIPTION
it will be user-friendly if we have total, free and used fields in device response.

total size= total size of the device.
free size= available size of the device for volume creation.
used size= space used for volume creation.

```
[root@dhcp43-209 build]# curl http://10.70.43.209:24007/v1/devices |python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   794  100   794    0     0   395k      0 --:--:-- --:--:-- --:--:--  775k
[
    {
        "device": "/dev/vdb",
        "device-used": false,
        "extent-size": 4194304,
        "free-size": 0,
        "peer-id": "335f3b47-cdc6-46ad-806e-6340f867c428",
        "state": "enabled",
        "total-size": 0,
        "used-size": 0
    },
    {
        "device": "/dev/vdc",
        "device-used": false,
        "extent-size": 4194304,
        "free-size": 203763482624,
        "peer-id": "335f3b47-cdc6-46ad-806e-6340f867c428",
        "state": "enabled",
        "total-size": 214609952768,
        "used-size": 10846470144
    },
    {
        "device": "/dev/vdb",
        "device-used": false,
        "extent-size": 4194304,
        "free-size": 203763482624,
        "peer-id": "7d0df840-698a-4604-acf0-457fe87e4641",
        "state": "enabled",
        "total-size": 214609952768,
        "used-size": 10846470144
    },
    {
        "device": "/dev/vdb",
        "device-used": false,
        "extent-size": 4194304,
        "free-size": 203763482624,
        "peer-id": "e0567090-202a-429c-a13e-408a5f36e312",
        "state": "enabled",
        "total-size": 214609952768,
        "used-size": 10846470144
    }
]

```
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>