### PR TITLE
Add logging if there is an error in CLI

### DIFF
--- a/glustercli/cmd/glustershd.go
+++ b/glustercli/cmd/glustershd.go
@@ -164,6 +164,11 @@ var selfHealSplitBrainCmd = &cobra.Command{
 		}
 		err := client.SelfHealSplitBrain(volname, operation, req)
 		if err != nil {
+			if GlobalFlag.Verbose {
+				log.WithError(err).WithFields(log.Fields{
+					"volume":    volname,
+					"operation": operation}).Error("failed to resolve split brain")
+			}
 			failure(fmt.Sprintf("Failed to resolve split-brain for volume %s\n", volname), err, 1)
 		}
 		fmt.Printf("Split Brain Resolution successful on volume %s \n", volname)

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -94,19 +94,34 @@ func init() {
 func smartVolumeCreate(cmd *cobra.Command, args []string) {
 	size, err := sizeToBytes(flagCreateVolumeSize)
 	if err != nil {
-		failure("Invalid Volume Size specified", nil, 1)
+		if GlobalFlag.Verbose {
+			log.WithError(err).WithFields(log.Fields{
+				"volume": args[0],
+				"size":   flagCreateVolumeSize}).Error("invalid volume size")
+		}
+		failure("Invalid Volume Size specified", err, 1)
 	}
 
 	// if average file size is specified for arbiter brick calculation
 	// else default is taken.
 	avgFileSize, err := sizeToBytes(flagAverageFileSize)
 	if err != nil {
-		failure("Invalid File Size specified", nil, 1)
+		if GlobalFlag.Verbose {
+			log.WithError(err).WithFields(log.Fields{
+				"volume": args[0],
+				"size":   flagCreateVolumeSize}).Error("invalid file size")
+		}
+		failure("Invalid File Size specified", err, 1)
 	}
 
 	maxBrickSize, err := sizeToBytes(flagCreateMaxBrickSize)
 	if err != nil {
-		failure("Invalid Max Brick size Size specified", nil, 1)
+		if GlobalFlag.Verbose {
+			log.WithError(err).WithFields(log.Fields{
+				"volume": args[0],
+				"size":   flagCreateVolumeSize}).Error("invalid max brick size")
+		}
+		failure("Invalid Max Brick Size specified", err, 1)
 	}
 
 	req := api.VolCreateReq{

--- a/glustercli/cmd/volume.go
+++ b/glustercli/cmd/volume.go
@@ -508,6 +508,11 @@ var volumeExpandCmd = &cobra.Command{
 		if flagExpandCmdSize != "" {
 			size, err = sizeToBytes(flagExpandCmdSize)
 			if err != nil {
+				if GlobalFlag.Verbose {
+					log.WithError(err).WithFields(log.Fields{
+						"volume": volname,
+						"size":   flagExpandCmdSize}).Error("invalid volume size")
+				}
 				failure("Invalid Volume Size specified", nil, 1)
 			}
 		}


### PR DESCRIPTION
add logging if there is an error in CLI, with the help of `-v` flag user should
be able to check the failure logs.

Fixes #1414
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>