### PR TITLE
add regex for different volume size format

### DIFF
--- a/glustercli/cmd/utils.go
+++ b/glustercli/cmd/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	validSizeFormat = regexp.MustCompile(`^([0-9]+)([GMKT])?$`)
+	validSizeFormat = regexp.MustCompile(`^([0-9]+)\s*([kKmMgGtT]?[iI]?[bB]?)$`)
 )
 
 func formatBoolYesNo(value bool) string {
@@ -37,9 +37,8 @@ func sizeToBytes(value string) (uint64, error) {
 	if len(sizeParts) == 0 {
 		return 0, errors.New("invalid size format")
 	}
-
-	// If Size unit is specified as M/K/G/T, Default Size unit is M
-	sizeUnit := "M"
+	// If Size unit is specified as M/K/G/T, Default Size unit is bytes
+	var sizeUnit string
 	if len(sizeParts) == 3 {
 		sizeUnit = sizeParts[2]
 	}
@@ -50,25 +49,27 @@ func sizeToBytes(value string) (uint64, error) {
 	}
 
 	var size uint64
-	switch sizeUnit {
-	case "K", "KiB":
+	switch strings.ToLower(sizeUnit) {
+	case "k", "kib":
 		size = sizeValue * utils.KiB
-	case "KB":
+	case "kb":
 		size = sizeValue * utils.KB
-	case "M", "MiB":
+	case "m", "mib":
 		size = sizeValue * utils.MiB
-	case "MB":
+	case "mb":
 		size = sizeValue * utils.MB
-	case "G", "GiB":
+	case "g", "gib":
 		size = sizeValue * utils.GiB
-	case "GB":
+	case "gb":
 		size = sizeValue * utils.GB
-	case "T", "TiB":
+	case "t", "tib":
 		size = sizeValue * utils.TiB
-	case "TB":
+	case "tb":
 		size = sizeValue * utils.TB
-	default:
+	case "b", "":
 		size = sizeValue
+	default:
+		return 0, fmt.Errorf("invalid size unit specified %s", sizeUnit)
 	}
 	return size, nil
 }


### PR DESCRIPTION
we should be able to create volume size with
different formats like KB, Kib, Mb, MiB etc

Fixes: #1398

```
    [root@dhcp43-209 build]# ./glustercli volume create size1 --size=20MB --replica=3 -v
    size1 Volume created successfully
    Volume ID:  b2693574-8489-4d4b-94ab-3564776d1cce
    
    [root@dhcp43-209 build]# ./glustercli volume create size2 --size=20MiB --replica=3 -v
    size2 Volume created successfully
    Volume ID:  b1153478-4912-4481-a047-8d67258ab08c
    
    [root@dhcp43-209 build]# ./glustercli volume create size3 --size=20M --replica=3 -v
    size3 Volume created successfully
    Volume ID:  8ac1c9a5-cc84-45ec-b382-eff17369d024
    
    [root@dhcp43-209 build]# ./glustercli volume create size35 --size=20 --replica=3 -v
    size35 Volume created successfully
    Volume ID:  560da74f-b7cf-466c-994c-0f03ba07bb24
    
    [root@dhcp43-209 build]# ./glustercli volume create size --size=21mb --replica=3 -v
    7size Volume created successfully
    Volume ID:  638d4108-bf2e-48e9-9d1d-982a34882586
    
    [root@dhcp43-209 build]# ./glustercli volume create sizes6 --size=20971520 --replica=3 -v
    sizes6 Volume created successfully
    Volume ID:  c4de7f7e-e4b4-46e6-80d1-92a9e060c4c0
    
    [root@dhcp43-209 build]# ./glustercli volume create size6 --size=20971520sadf --replica=3 -v
    Invalid Volume Size specified
    ```

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>