### PR TITLE
minimum brick size validation during Volume create

### DIFF
--- a/e2e/smartvol_ops_test.go
+++ b/e2e/smartvol_ops_test.go
@@ -141,13 +141,24 @@ func testReplaceBrick(t *testing.T) {
 func testSmartVolumeDistribute(t *testing.T) {
 	r := require.New(t)
 	smartvolname := formatVolName(t.Name())
-	// create Distribute 3 Volume
+
+	// Too small brick size as a result of asked distribute size
 	createReq := api.VolCreateReq{
+		Name:               smartvolname,
+		Size:               20 * gutils.MiB,
+		DistributeCount:    3,
+		SubvolZonesOverlap: true,
+	}
+	volinfo, err := client.VolumeCreate(createReq)
+	r.NotNil(err)
+
+	// create Distribute 3 Volume
+	createReq = api.VolCreateReq{
 		Name:            smartvolname,
 		Size:            60 * gutils.MiB,
 		DistributeCount: 3,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, err = client.VolumeCreate(createReq)
 	r.Nil(err)
 	r.Len(volinfo.Subvols, 3)
 	r.Equal("Distribute", volinfo.Type.String())
@@ -306,13 +317,23 @@ func testSmartVolumeDisperse(t *testing.T) {
 
 	smartvolname := formatVolName(t.Name())
 
-	// create Disperse Volume
+	// Too small brick size as a result of asked disperse size
 	createReq := api.VolCreateReq{
+		Name:               smartvolname,
+		Size:               20 * gutils.MiB,
+		DisperseCount:      3,
+		SubvolZonesOverlap: true,
+	}
+	volinfo, err := client.VolumeCreate(createReq)
+	r.NotNil(err)
+
+	// create Disperse Volume
+	createReq = api.VolCreateReq{
 		Name:          smartvolname,
 		Size:          40 * gutils.MiB,
 		DisperseCount: 3,
 	}
-	volinfo, err := client.VolumeCreate(createReq)
+	volinfo, err = client.VolumeCreate(createReq)
 	r.Nil(err)
 
 	r.Len(volinfo.Subvols, 1)

--- a/glusterd2/bricksplanner/planner.go
+++ b/glusterd2/bricksplanner/planner.go
@@ -136,6 +136,9 @@ func getBricksLayout(req *api.VolCreateReq) ([]api.SubvolReq, error) {
 		for j := 0; j < subvolplanner.BricksCount(); j++ {
 			eachBrickSize := subvolplanner.BrickSize(j)
 			brickType := subvolplanner.BrickType(j)
+			if eachBrickSize < minBrickSize {
+				return nil, errors.New("brick size is too small")
+			}
 			eachBrickTpSize := uint64(float64(eachBrickSize) * req.SnapshotReserveFactor)
 
 			bricks = append(bricks, api.BrickReq{


### PR DESCRIPTION
Auto provisioned volume does not validate the minimum brick size.
If the size is too small then the volume creation errors out.

The validation is done after the bricksize calculation.

Fixes: #1389
Signed-off-by: Hari Gowtham <hgowtham@redhat.com>