### PR TITLE
Do not allocate memory manually while creating RPC buffer

### DIFF
--- a/pkg/sunrpc/record.go
+++ b/pkg/sunrpc/record.go
@@ -98,7 +98,7 @@ func ReadFullRecord(conn io.Reader) ([]byte, error) {
 	// In almost all cases, RPC message contain only one fragment which
 	// is not too big in size. But set a cap on buffer size to prevent
 	// rogue clients from filling up memory.
-	record := bytes.NewBuffer(make([]byte, 0, maxRecordSize))
+	record := bytes.NewBuffer([]byte{})
 	var fragmentHeader uint32
 	for {
 		// Read record fragment header
@@ -112,7 +112,7 @@ func ReadFullRecord(conn io.Reader) ([]byte, error) {
 			return nil, ErrInvalidFragmentSize
 		}
 
-		if int(fragmentSize) > (record.Cap() - record.Len()) {
+		if int(fragmentSize) > (maxRecordSize - record.Len()) {
 			return nil, ErrRPCMessageSizeExceeded
 		}
 


### PR DESCRIPTION
Sunrpc Read buffer was created by allocating `1MiB` each time when
client connects. Go can automatically expand the buffer when required
so now empty buffer is initialized.(`1MiB` per brick connect is `1GB`
for 1000 bricks)

Signed-off-by: Aravinda VK <avishwan@redhat.com>