### PR TITLE
txn Lock: acquire cluster locks while creating a txn

### DIFF
--- a/glusterd2/store/store.go
+++ b/glusterd2/store/store.go
@@ -51,10 +51,11 @@ type GDStore struct {
 	// Un-namespaced Client for Auth, Cluster and Maintenance operations
 	*clientv3.Client
 
-	ee        *elasticetcd.ElasticEtcd
-	namespace string
-	stop      chan struct{}
-	stopOnce  sync.Once
+	ee              *elasticetcd.ElasticEtcd
+	namespace       string
+	stop            chan struct{}
+	stopOnce        sync.Once
+	NamespaceClient *clientv3.Client
 }
 
 // Init initializes the GD2 store
@@ -251,14 +252,15 @@ func newNamespacedStore(oc *clientv3.Client, conf *Config) (*GDStore, error) {
 	}
 
 	return &GDStore{
-		conf:      *conf,
-		KV:        kv,
-		Lease:     lease,
-		Watcher:   watcher,
-		Session:   session,
-		Client:    oc,
-		ee:        nil,
-		namespace: namespaceKey,
+		conf:            *conf,
+		KV:              kv,
+		Lease:           lease,
+		Watcher:         watcher,
+		Session:         session,
+		Client:          oc,
+		ee:              nil,
+		namespace:       namespaceKey,
+		NamespaceClient: nc,
 	}, nil
 }
 

--- a/glusterd2/transaction/lock.go
+++ b/glusterd2/transaction/lock.go
@@ -164,7 +164,7 @@ func (l Locks) lock(lockID string) error {
 	logger.Debug("attempting to obtain lock")
 
 	key := lockPrefix + lockID
-	s, err := concurrency.NewSession(store.Store.Client, concurrency.WithTTL(lockTTL))
+	s, err := concurrency.NewSession(store.Store.NamespaceClient, concurrency.WithTTL(lockTTL))
 	if err != nil {
 		return err
 	}

--- a/glusterd2/transactionv2/cleanuphandler/cleanup_handler.go
+++ b/glusterd2/transactionv2/cleanuphandler/cleanup_handler.go
@@ -2,7 +2,6 @@ package cleanuphandler
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -64,8 +63,7 @@ func WithElection(defaultSession *concurrency.Session) CleaupHandlerOptFunc {
 		if handler.session != nil {
 			session = handler.session
 		}
-		electionKeyPrefix := fmt.Sprintf("gluster-%s/", gdctx.MyClusterID.String()) + leaderKey
-		handler.election = concurrency.NewElection(session, electionKeyPrefix)
+		handler.election = concurrency.NewElection(session, leaderKey)
 		return nil
 	}
 }
@@ -151,7 +149,7 @@ func StartCleanupLeader() {
 	var err error
 
 	CleanupLeader, err = NewCleanupHandler(
-		WithSession(store.Store.Client, 60),
+		WithSession(store.Store.NamespaceClient, 60),
 		WithElection(store.Store.Session),
 	)
 

--- a/glusterd2/transactionv2/executor.go
+++ b/glusterd2/transactionv2/executor.go
@@ -60,14 +60,6 @@ func (e *executorImpl) Execute(txn *Txn) error {
 		return nil
 	}
 
-	if e.isInitiator(txn) {
-		if err := txn.acquireClusterLocks(); err != nil {
-			txn.Ctx.Logger().WithError(err).Error("error in acquiring cluster locks")
-			return err
-		}
-		defer txn.releaseLocks()
-	}
-
 	txn.Ctx.Logger().Info("transaction started on node")
 
 	failureChan := e.watchTxnForFailure(ctx, txn)
@@ -171,8 +163,4 @@ func (e *executorImpl) shouldRunTxn(txn *Txn) bool {
 	}
 	txn.Ctx.Logger().Debug("skipping txn on this node")
 	return false
-}
-
-func (e *executorImpl) isInitiator(txn *Txn) bool {
-	return uuid.Equal(txn.Initiator, e.selfNodeID)
 }

--- a/glusterd2/transactionv2/txnmanager.go
+++ b/glusterd2/transactionv2/txnmanager.go
@@ -192,7 +192,6 @@ func (tm *txnManager) watchRespToTxns(resp clientv3.WatchResponse) (txns []*Txn)
 			continue
 		}
 
-		txn.locks = transaction.Locks{}
 		txns = append(txns, txn)
 	}
 	return
@@ -226,7 +225,6 @@ func (tm *txnManager) GetTxnByUUID(id uuid.UUID) (*Txn, error) {
 	if err := json.Unmarshal(kv.Value, txn); err != nil {
 		return nil, err
 	}
-	txn.locks = make(map[string]*concurrency.Mutex)
 	return txn, nil
 }
 
@@ -246,7 +244,6 @@ func (tm *txnManager) GetTxns() (txns []*Txn) {
 		if err := json.Unmarshal(kv.Value, txn); err != nil {
 			continue
 		}
-		txn.locks = make(map[string]*concurrency.Mutex)
 		txns = append(txns, txn)
 	}
 	return
@@ -409,7 +406,7 @@ func (tm *txnManager) RemoveFailedTxns() {
 
 		if nodesRollbacked == len(txn.Nodes) {
 			txn.Ctx.Logger().Info("txn rolled back on all nodes, cleaning from store")
-			txn.done()
+			txn.removeContextData()
 			tm.RemoveTransaction(txn.ID)
 		}
 	}


### PR DESCRIPTION
 - all cluster locks should be aquired before starting a txn.
   We should acquire locks at the time of creating a txn.

 - use namespaced etcd client for creating a etcd Session in
   transaction.Lock and CleanupHandler

Signed-off-by: Oshank Kumar <okumar@redhat.com>