### PR TITLE
transaction: resume txn if a peer restarts

### DIFF
--- a/glusterd2/transactionv2/engine.go
+++ b/glusterd2/transactionv2/engine.go
@@ -97,11 +97,11 @@ func (txnEng *Engine) Execute(ctx context.Context, txn *Txn) {
 
 	switch status.State {
 	case txnPending:
-		if err := txnEng.executor.Execute(txn); err != nil {
+		if err := txnEng.executor.Execute(ctx, txn); err != nil {
 			txn.Ctx.Logger().WithError(err).Error("error in executing transaction")
 		}
 	case txnRunning:
-		if err := txnEng.executor.Resume(txn); err != nil {
+		if err := txnEng.executor.Resume(ctx, txn); err != nil {
 			txn.Ctx.Logger().WithError(err).Error("error in resuming transaction")
 		}
 	}

--- a/glusterd2/transactionv2/tracingexecutor.go
+++ b/glusterd2/transactionv2/tracingexecutor.go
@@ -1,0 +1,37 @@
+package transaction
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+)
+
+func newtracingExecutor(next Executor) Executor {
+	return &tracingExecutor{next}
+}
+
+// tracingExecutor is middleware to record trace info.
+// It will record the trace info and execute the next executor
+type tracingExecutor struct {
+	next Executor
+}
+
+// Execute will record trace info for Execute operation.
+func (t *tracingExecutor) Execute(ctx context.Context, txn *Txn) error {
+	ctx, span := trace.StartSpan(ctx, "txnEng.executor.Execute/")
+	defer span.End()
+	span.AddAttributes(
+		trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),
+	)
+	return t.next.Execute(ctx, txn)
+}
+
+// Resume will record trace info for Resume operation.
+func (t *tracingExecutor) Resume(ctx context.Context, txn *Txn) error {
+	ctx, span := trace.StartSpan(ctx, "txnEng.executor.Resume/")
+	defer span.End()
+	span.AddAttributes(
+		trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),
+	)
+	return t.next.Resume(ctx, txn)
+}

--- a/glusterd2/transactionv2/txnmanager.go
+++ b/glusterd2/transactionv2/txnmanager.go
@@ -182,7 +182,7 @@ func (tm *txnManager) kvToFailedTxn(kv *mvccpb.KeyValue, nodeID uuid.UUID) *Txn 
 func (tm *txnManager) watchRespToTxns(resp clientv3.WatchResponse) (txns []*Txn) {
 	for _, event := range resp.Events {
 		prefix, id := path.Split(string(event.Kv.Key))
-		if uuid.Parse(id) == nil || !strings.HasSuffix(prefix, PendingTxnPrefix) {
+		if uuid.Parse(id) == nil || prefix != PendingTxnPrefix {
 			continue
 		}
 
@@ -234,8 +234,8 @@ func (tm *txnManager) GetTxns() (txns []*Txn) {
 		return
 	}
 	for _, kv := range resp.Kvs {
-		_, id := path.Split(string(kv.Key))
-		if uuid.Parse(id) == nil {
+		preifx, id := path.Split(string(kv.Key))
+		if uuid.Parse(id) == nil || preifx != PendingTxnPrefix {
 			continue
 		}
 

--- a/glusterd2/transactionv2/txnmanager.go
+++ b/glusterd2/transactionv2/txnmanager.go
@@ -234,8 +234,8 @@ func (tm *txnManager) GetTxns() (txns []*Txn) {
 		return
 	}
 	for _, kv := range resp.Kvs {
-		preifx, id := path.Split(string(kv.Key))
-		if uuid.Parse(id) == nil || preifx != PendingTxnPrefix {
+		prefix, id := path.Split(string(kv.Key))
+		if uuid.Parse(id) == nil || prefix != PendingTxnPrefix {
 			continue
 		}
 


### PR DESCRIPTION
If a peer restarts then it should check for pending
transactions and resume all the pending transaction.

Signed-off-by: Oshank Kumar <okumar@redhat.com>