### PR TITLE
Support for loopback bricks

### DIFF
--- a/e2e/snapshot_ops_test.go
+++ b/e2e/snapshot_ops_test.go
@@ -392,11 +392,11 @@ func testSnapshotOnSmartVol(t *testing.T, tc *testCluster) {
 	r.Nil(prepareLoopDevice(devicesDir+"/gluster_dev2.img", "6", "500M"))
 
 	// brickCount+1
-	_, err := client.DeviceAdd(tc.gds[0].PeerID(), "/dev/gluster_loop5")
+	_, err := client.DeviceAdd(tc.gds[0].PeerID(), "/dev/gluster_loop5", api.ProvisionerTypeLvm)
 	r.Nil(err)
 
 	// brickCount+2
-	_, err = client.DeviceAdd(tc.gds[1].PeerID(), "/dev/gluster_loop6")
+	_, err = client.DeviceAdd(tc.gds[1].PeerID(), "/dev/gluster_loop6", api.ProvisionerTypeLvm)
 	r.Nil(err)
 
 	smartvolname := formatVolName(t.Name())

--- a/glustercli/cmd/device.go
+++ b/glustercli/cmd/device.go
@@ -17,7 +17,10 @@ const (
 	helpDeviceInfoCmd = "Get device info"
 )
 
+var flagDeviceAddProvisioner string
+
 func init() {
+	deviceAddCmd.Flags().StringVar(&flagDeviceAddProvisioner, "provisioner", "lvm", "Provisioner Type(lvm, loop)")
 	deviceCmd.AddCommand(deviceAddCmd)
 	deviceCmd.AddCommand(deviceInfoCmd)
 }
@@ -111,7 +114,7 @@ var deviceAddCmd = &cobra.Command{
 		peerid := args[0]
 		devname := args[1]
 
-		_, err := client.DeviceAdd(peerid, devname)
+		_, err := client.DeviceAdd(peerid, devname, flagDeviceAddProvisioner)
 
 		if err != nil {
 			if GlobalFlag.Verbose {

--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -41,6 +41,7 @@ var (
 	flagCreateSubvolZoneOverlap     bool
 	flagAverageFileSize             string
 	flagCreateMaxBrickSize          string
+	flagProvisionerType             string
 
 	volumeCreateCmd = &cobra.Command{
 		Use:   "create <volname> [<brick> [<brick>]...|--size <size>]",
@@ -87,6 +88,7 @@ func init() {
 	volumeCreateCmd.Flags().BoolVar(&flagCreateSubvolZoneOverlap, "subvols-zones-overlap", false, "Brick belonging to other Sub volume can be created in the same zone")
 	volumeCreateCmd.Flags().StringVar(&flagAverageFileSize, "average-file-size", "1M", "Average size of the files")
 	volumeCreateCmd.Flags().StringVar(&flagCreateMaxBrickSize, "max-brick-size", "", "Max brick size for auto distribute count")
+	volumeCreateCmd.Flags().StringVar(&flagProvisionerType, "provisioner", "lvm", "Brick Provisioner Type(lvm, loop)")
 
 	volumeCmd.AddCommand(volumeCreateCmd)
 }
@@ -144,6 +146,7 @@ func smartVolumeCreate(cmd *cobra.Command, args []string) {
 		ExcludeZones:            flagCreateExcludeZones,
 		SubvolZonesOverlap:      flagCreateSubvolZoneOverlap,
 		Force:                   flagCreateForce,
+		ProvisionerType:         flagProvisionerType,
 	}
 
 	vol, err := client.VolumeCreate(req)

--- a/glusterd2/brick/types.go
+++ b/glusterd2/brick/types.go
@@ -38,6 +38,7 @@ type DeviceInfo struct {
 	LvName     string
 	VgName     string
 	RootDevice string
+	TotalSize  uint64
 }
 
 // Brickinfo is the static information about the brick

--- a/glusterd2/bricksplanner/planner.go
+++ b/glusterd2/bricksplanner/planner.go
@@ -141,6 +141,13 @@ func getBricksLayout(req *api.VolCreateReq) ([]api.SubvolReq, error) {
 			}
 			eachBrickTpSize := uint64(float64(eachBrickSize) * req.SnapshotReserveFactor)
 
+			mntopts := "rw,inode64,noatime,nouuid,discard"
+			if req.ProvisionerType == api.ProvisionerTypeLoop {
+				mntopts += ",loop"
+			}
+
+			tpsize := lvmutils.NormalizeSize(eachBrickTpSize)
+			tpmsize := lvmutils.GetPoolMetadataSize(eachBrickTpSize)
 			bricks = append(bricks, api.BrickReq{
 				Type:           brickType,
 				Path:           fmt.Sprintf("%s/%s/subvol%d/brick%d/brick", bricksMountRoot, req.Name, i+1, j+1),
@@ -148,10 +155,11 @@ func getBricksLayout(req *api.VolCreateReq) ([]api.SubvolReq, error) {
 				TpName:         fmt.Sprintf("tp_%s_s%d_b%d", req.Name, i+1, j+1),
 				LvName:         fmt.Sprintf("brick_%s_s%d_b%d", req.Name, i+1, j+1),
 				Size:           lvmutils.NormalizeSize(eachBrickSize),
-				TpSize:         lvmutils.NormalizeSize(eachBrickTpSize),
-				TpMetadataSize: lvmutils.GetPoolMetadataSize(eachBrickTpSize),
+				TpSize:         tpsize,
+				TpMetadataSize: tpmsize,
+				TotalSize:      tpsize + tpmsize,
 				FsType:         "xfs",
-				MntOpts:        "rw,inode64,noatime,nouuid",
+				MntOpts:        mntopts,
 			})
 		}
 
@@ -198,19 +206,20 @@ func PlanBricks(req *api.VolCreateReq) error {
 		// with device with expected space available.
 		numBricksAllocated := 0
 		for bidx, b := range sv.Bricks {
-			totalsize := b.TpSize + b.TpMetadataSize
-
 			for _, vg := range availableVgs {
 				_, zoneUsed := zones[vg.Zone]
-				if vg.AvailableSize >= totalsize && !zoneUsed && !vg.Used {
+				if vg.AvailableSize >= b.TotalSize && !zoneUsed && !vg.Used {
 					subvols[idx].Bricks[bidx].PeerID = vg.PeerID
 					subvols[idx].Bricks[bidx].VgName = vg.Name
 					subvols[idx].Bricks[bidx].RootDevice = vg.Device
 					subvols[idx].Bricks[bidx].DevicePath = "/dev/" + vg.Name + "/" + b.LvName
+					if req.ProvisionerType == api.ProvisionerTypeLoop {
+						subvols[idx].Bricks[bidx].DevicePath = vg.Device + "/" + b.TpName + "/" + b.LvName + ".img"
+					}
 
 					zones[vg.Zone] = struct{}{}
 					numBricksAllocated++
-					vg.AvailableSize -= totalsize
+					vg.AvailableSize -= b.TotalSize
 					vg.Used = true
 					break
 				}
@@ -227,19 +236,20 @@ func PlanBricks(req *api.VolCreateReq) error {
 		// but enough space is available in the devices
 		for bidx := numBricksAllocated; bidx < len(sv.Bricks); bidx++ {
 			b := sv.Bricks[bidx]
-			totalsize := b.TpSize + b.TpMetadataSize
-
 			for _, vg := range availableVgs {
 				_, zoneUsed := zones[vg.Zone]
-				if vg.AvailableSize >= totalsize && !zoneUsed {
+				if vg.AvailableSize >= b.TotalSize && !zoneUsed {
 					subvols[idx].Bricks[bidx].PeerID = vg.PeerID
 					subvols[idx].Bricks[bidx].VgName = vg.Name
 					subvols[idx].Bricks[bidx].RootDevice = vg.Device
 					subvols[idx].Bricks[bidx].DevicePath = "/dev/" + vg.Name + "/" + b.LvName
+					if req.ProvisionerType == api.ProvisionerTypeLoop {
+						subvols[idx].Bricks[bidx].DevicePath = vg.Device + "/" + b.TpName + "/" + b.LvName + ".img"
+					}
 
 					zones[vg.Zone] = struct{}{}
 					numBricksAllocated++
-					vg.AvailableSize -= totalsize
+					vg.AvailableSize -= b.TotalSize
 					vg.Used = true
 					break
 				}

--- a/glusterd2/commands/snapshot/snapshot-clone.go
+++ b/glusterd2/commands/snapshot/snapshot-clone.go
@@ -229,6 +229,7 @@ func createCloneVolinfo(c transaction.TxnCtx) error {
 	newVol.ID = uuid.NewRandom()
 	newVol.Name = clonename
 	newVol.VolfileID = clonename
+	newVol.ProvisionerType = volinfo.ProvisionerType
 
 	if err = createSnapSubvols(newVol, volinfo, nodeData); err != nil {
 		log.WithError(err).WithFields(log.Fields{

--- a/glusterd2/commands/snapshot/snapshot-create.go
+++ b/glusterd2/commands/snapshot/snapshot-create.go
@@ -757,6 +757,11 @@ func snapshotCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if vol.ProvisionerType != api.ProvisionerTypeLvm && vol.ProvisionerType != "" {
+		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, gderrors.ErrSnapNotSupported)
+		return
+	}
+
 	txn.Nodes = vol.Nodes()
 	txn.Steps = []*transaction.Step{
 		{

--- a/glusterd2/commands/snapshot/snapshot-restore.go
+++ b/glusterd2/commands/snapshot/snapshot-restore.go
@@ -216,6 +216,7 @@ func createRestoreVolinfo(snapinfo *snapshot.Snapinfo, vol *volume.Volinfo) volu
 	newVol.Transport = snapVol.Transport
 	newVol.Type = snapVol.Type
 	newVol.VolfileID = newVol.Name
+	newVol.ProvisionerType = snapVol.ProvisionerType
 	for idx, subvol := range snapVol.Subvols {
 		subvolType := volume.SubvolTypeToString(subvol.Type)
 		name := fmt.Sprintf("%s-%s-%d", vol.Name, strings.ToLower(subvolType), idx)
@@ -294,7 +295,7 @@ func cleanParentBricks(c transaction.TxnCtx) error {
 		return err
 	}
 
-	return volume.CleanBricks(&volinfo)
+	return volume.CleanBricksLvm(&volinfo)
 }
 
 func registerSnapRestoreStepFuncs() {

--- a/glusterd2/commands/volumes/brick-replace-txn.go
+++ b/glusterd2/commands/volumes/brick-replace-txn.go
@@ -8,12 +8,18 @@ import (
 )
 
 func prepareBricks(c transaction.TxnCtx) error {
+	var volInfo volume.Volinfo
+	if err := c.Get("volinfo", &volInfo); err != nil {
+		return err
+	}
 	var req api.BrickReq
 	if err := c.Get("newBrick", &req); err != nil {
 		return err
 	}
-	err := PrepareBrick(req, c)
-	return err
+	if volInfo.ProvisionerType == api.ProvisionerTypeLoop {
+		return PrepareBrickLoop(req, c)
+	}
+	return PrepareBrickLvm(req, c)
 }
 
 func replaceVolinfo(c transaction.TxnCtx) error {

--- a/glusterd2/commands/volumes/brick-replace.go
+++ b/glusterd2/commands/volumes/brick-replace.go
@@ -104,12 +104,13 @@ LOOP:
 
 	subvolumes := make([]api.SubvolReq, 0)
 	volreq := api.VolCreateReq{
-		Subvols:      subvolumes,
-		Size:         vol.Capacity,
-		LimitPeers:   req.LimitPeers,
-		LimitZones:   req.LimitZones,
-		ExcludePeers: req.ExcludePeers,
-		ExcludeZones: req.ExcludeZones,
+		Subvols:         subvolumes,
+		Size:            vol.Capacity,
+		LimitPeers:      req.LimitPeers,
+		LimitZones:      req.LimitZones,
+		ExcludePeers:    req.ExcludePeers,
+		ExcludeZones:    req.ExcludeZones,
+		ProvisionerType: vol.ProvisionerType,
 	}
 	availableVgs, err := bricksplanner.GetAvailableVgs(&volreq)
 	if err != nil {

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -126,7 +126,6 @@ func populateSubvols(volinfo *volume.Volinfo, req *api.VolCreateReq) error {
 }
 
 func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
-
 	volinfo := &volume.Volinfo{
 		ID:                    uuid.NewRandom(),
 		Name:                  req.Name,
@@ -136,6 +135,7 @@ func newVolinfo(req *api.VolCreateReq) (*volume.Volinfo, error) {
 		DistCount:             len(req.Subvols),
 		SnapList:              []string{},
 		SnapshotReserveFactor: req.SnapshotReserveFactor,
+		ProvisionerType:       req.ProvisionerType,
 		Auth: volume.VolAuth{
 			Username: uuid.NewRandom().String(),
 			Password: uuid.NewRandom().String(),

--- a/glusterd2/commands/volumes/volume-create.go
+++ b/glusterd2/commands/volumes/volume-create.go
@@ -151,6 +151,10 @@ func CreateVolume(ctx context.Context, req api.VolCreateReq) (status int, err er
 		return http.StatusBadRequest, gderrors.ErrReservedGroupProfile
 	}
 
+	if req.ProvisionerType == "" {
+		req.ProvisionerType = api.ProvisionerTypeLvm
+	}
+
 	if req.Size > 0 {
 		applyDefaults(&req)
 

--- a/glusterd2/volume/struct.go
+++ b/glusterd2/volume/struct.go
@@ -99,6 +99,7 @@ type Volinfo struct {
 	SnapList              []string
 	SnapshotReserveFactor float64
 	Capacity              uint64
+	ProvisionerType       string
 }
 
 // VolAuth represents username and password used by trusted/internal clients
@@ -181,6 +182,7 @@ func NewBrickEntries(bricks []api.BrickReq, volName, volfileID string, volID uui
 			TpName:     b.TpName,
 			VgName:     b.VgName,
 			RootDevice: b.RootDevice,
+			TotalSize:  b.TotalSize,
 		}
 
 		binfo.PType = ptype

--- a/pkg/api/volume_req.go
+++ b/pkg/api/volume_req.go
@@ -7,6 +7,7 @@ type BrickReq struct {
 	Path           string `json:"path"`
 	TpMetadataSize uint64 `json:"metadata-size,omitempty"`
 	TpSize         uint64 `json:"thinpool-size,omitempty"`
+	TotalSize      uint64 `json:"total-size,omitempty"`
 	VgName         string `json:"vg-name,omitempty"`
 	RootDevice     string `json:"root-device,omitempty"`
 	TpName         string `json:"thinpool-name,omitempty"`
@@ -62,6 +63,7 @@ type VolCreateReq struct {
 	ExcludeZones            []string          `json:"exclude-zones,omitempty"`
 	SubvolZonesOverlap      bool              `json:"subvolume-zones-overlap,omitempty"`
 	SubvolType              string            `json:"subvolume-type,omitempty"`
+	ProvisionerType         string            `json:"provisioner"`
 	VolOptionReq
 }
 

--- a/pkg/api/volume_resp.go
+++ b/pkg/api/volume_resp.go
@@ -2,6 +2,13 @@ package api
 
 import "github.com/pborman/uuid"
 
+const (
+	// ProvisionerTypeLoop represents loop device based provisioner
+	ProvisionerTypeLoop = "loop"
+	// ProvisionerTypeLvm represents LVM based provisioner
+	ProvisionerTypeLvm = "lvm"
+)
+
 // BrickInfo contains the static information about the brick.
 // Clients should NOT use this struct directly.
 type BrickInfo struct {

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -74,4 +74,5 @@ var (
 	ErrConnectingHost                  = errors.New("could not connect to host. Make sure host address is valid, network connection is active and gd2 is up and running")
 	ErrBlockVolNotFound                = errors.New("block volume not found")
 	ErrBlockHostVolNotFound            = errors.New("block hosting volume not found")
+	ErrSnapNotSupported                = errors.New("snapshot not supported")
 )

--- a/pkg/lvmutils/utils.go
+++ b/pkg/lvmutils/utils.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/utils"
@@ -131,22 +130,6 @@ func CreateLV(vgname, tpname, lvname string, lvsize uint64) error {
 		"--name", lvname,
 		vgname+"/"+tpname,
 	)
-}
-
-// MountLV mounts the brick LV
-func MountLV(dev, mountdir, mountOpts string) error {
-	args := []string{}
-	if mountOpts != "" {
-		args = append(args, "-o", mountOpts)
-	}
-	args = append(args, dev, mountdir)
-
-	return utils.ExecuteCommandRun("mount", args...)
-}
-
-// UnmountLV unmounts the Brick
-func UnmountLV(mountdir string) error {
-	return syscall.Unmount(mountdir, syscall.MNT_FORCE)
 }
 
 // IsDependentLvsError returns true if the error related to dependent Lvs exists

--- a/pkg/restclient/device.go
+++ b/pkg/restclient/device.go
@@ -9,10 +9,11 @@ import (
 )
 
 // DeviceAdd registers device
-func (c *Client) DeviceAdd(peerid, device string) (deviceapi.AddDeviceResp, error) {
+func (c *Client) DeviceAdd(peerid, device, provType string) (deviceapi.AddDeviceResp, error) {
 	var deviceinfo deviceapi.AddDeviceResp
 	req := deviceapi.AddDeviceReq{
-		Device: device,
+		Device:          device,
+		ProvisionerType: provType,
 	}
 	err := c.post("/v1/devices/"+peerid, req, http.StatusCreated, &deviceinfo)
 	return deviceinfo, err

--- a/plugins/device/api/req.go
+++ b/plugins/device/api/req.go
@@ -10,7 +10,8 @@ const (
 
 // AddDeviceReq structure
 type AddDeviceReq struct {
-	Device string `json:"device"`
+	Device          string `json:"device"`
+	ProvisionerType string `json:"provisioner"`
 }
 
 // EditDeviceReq structure

--- a/plugins/device/api/resp.go
+++ b/plugins/device/api/resp.go
@@ -8,14 +8,15 @@ import (
 
 // Info represents structure in which devices are to be store in Peer Metadata
 type Info struct {
-	Device        string    `json:"device"`
-	State         string    `json:"state"`
-	AvailableSize uint64    `json:"free-size"`
-	TotalSize     uint64    `json:"total-size"`
-	UsedSize      uint64    `json:"used-size"`
-	ExtentSize    uint64    `json:"extent-size"`
-	Used          bool      `json:"device-used"`
-	PeerID        uuid.UUID `json:"peer-id"`
+	Device          string    `json:"device"`
+	ProvisionerType string    `json:"provisioner"`
+	State           string    `json:"state"`
+	AvailableSize   uint64    `json:"free-size"`
+	TotalSize       uint64    `json:"total-size"`
+	UsedSize        uint64    `json:"used-size"`
+	ExtentSize      uint64    `json:"extent-size"`
+	Used            bool      `json:"device-used"`
+	PeerID          uuid.UUID `json:"peer-id"`
 }
 
 // VgName returns name for LVM Vg

--- a/plugins/device/rest.go
+++ b/plugins/device/rest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/peer"
 	restutils "github.com/gluster/glusterd2/glusterd2/servers/rest/utils"
 	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/pkg/api"
 	"github.com/gluster/glusterd2/pkg/errors"
 	deviceapi "github.com/gluster/glusterd2/plugins/device/api"
 	"github.com/gluster/glusterd2/plugins/device/deviceutils"
@@ -32,6 +33,10 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 		logger.WithError(err).Error("Failed to unmarshal request")
 		restutils.SendHTTPError(ctx, w, http.StatusBadRequest, errors.ErrJSONParsingFailed)
 		return
+	}
+
+	if req.ProvisionerType == "" {
+		req.ProvisionerType = api.ProvisionerTypeLvm
 	}
 
 	txn, err := transaction.NewTxnWithLocks(ctx, peerID)
@@ -80,9 +85,9 @@ func deviceAddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = txn.Ctx.Set("device", &req.Device)
+	err = txn.Ctx.Set("req", &req)
 	if err != nil {
-		logger.WithError(err).WithField("key", "device").Error("Failed to set key in transaction context")
+		logger.WithError(err).WithField("key", "req").Error("Failed to set key in transaction context")
 		restutils.SendHTTPError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}

--- a/plugins/device/transaction.go
+++ b/plugins/device/transaction.go
@@ -1,7 +1,11 @@
 package device
 
 import (
+	"os"
+
 	"github.com/gluster/glusterd2/glusterd2/transaction"
+	"github.com/gluster/glusterd2/pkg/api"
+	"github.com/gluster/glusterd2/pkg/fsutils"
 	"github.com/gluster/glusterd2/pkg/lvmutils"
 	deviceapi "github.com/gluster/glusterd2/plugins/device/api"
 	"github.com/gluster/glusterd2/plugins/device/deviceutils"
@@ -10,31 +14,37 @@ import (
 )
 
 func txnPrepareDevice(c transaction.TxnCtx) error {
+	var req deviceapi.AddDeviceReq
+	if err := c.Get("req", &req); err != nil {
+		c.Logger().WithError(err).WithField("key", "req").Error("Failed to get key from transaction context")
+		return err
+	}
+	if req.ProvisionerType == api.ProvisionerTypeLoop {
+		return txnPrepareDeviceLoop(req, c)
+	}
+	return txnPrepareDeviceLvm(req, c)
+}
+
+func txnPrepareDeviceLvm(req deviceapi.AddDeviceReq, c transaction.TxnCtx) error {
 	var peerID uuid.UUID
 	if err := c.Get("peerid", &peerID); err != nil {
 		c.Logger().WithError(err).WithField("key", "peerid").Error("Failed to get key from transaction context")
 		return err
 	}
 
-	var device string
-	if err := c.Get("device", &device); err != nil {
-		c.Logger().WithError(err).WithField("key", "device").Error("Failed to get key from transaction context")
+	deviceInfo := deviceapi.Info{Device: req.Device}
+
+	err := lvmutils.CreatePV(req.Device)
+	if err != nil {
+		c.Logger().WithError(err).WithField("device", req.Device).Error("Failed to create physical volume")
 		return err
 	}
-
-	deviceInfo := deviceapi.Info{Device: device}
-
-	err := lvmutils.CreatePV(device)
+	err = lvmutils.CreateVG(req.Device, deviceInfo.VgName())
 	if err != nil {
-		c.Logger().WithError(err).WithField("device", device).Error("Failed to create physical volume")
-		return err
-	}
-	err = lvmutils.CreateVG(device, deviceInfo.VgName())
-	if err != nil {
-		c.Logger().WithError(err).WithField("device", device).Error("Failed to create volume group")
-		errPV := lvmutils.RemovePV(device)
+		c.Logger().WithError(err).WithField("device", req.Device).Error("Failed to create volume group")
+		errPV := lvmutils.RemovePV(req.Device)
 		if errPV != nil {
-			c.Logger().WithError(err).WithField("device", device).Error("Failed to remove physical volume")
+			c.Logger().WithError(err).WithField("device", req.Device).Error("Failed to remove physical volume")
 		}
 		return err
 	}
@@ -44,13 +54,49 @@ func txnPrepareDevice(c transaction.TxnCtx) error {
 		return err
 	}
 	deviceInfo = deviceapi.Info{
-		Device:        device,
-		State:         deviceapi.DeviceEnabled,
-		AvailableSize: availableSize,
-		TotalSize:     availableSize,
-		UsedSize:      0,
-		ExtentSize:    extentSize,
-		PeerID:        peerID,
+		Device:          req.Device,
+		State:           deviceapi.DeviceEnabled,
+		AvailableSize:   availableSize,
+		TotalSize:       availableSize,
+		UsedSize:        0,
+		ExtentSize:      extentSize,
+		PeerID:          peerID,
+		ProvisionerType: api.ProvisionerTypeLvm,
+	}
+
+	err = deviceutils.AddOrUpdateDevice(deviceInfo)
+	if err != nil {
+		c.Logger().WithError(err).WithField("peerid", peerID).Error("Couldn't add deviceinfo to store")
+		return err
+	}
+	return nil
+}
+
+func txnPrepareDeviceLoop(req deviceapi.AddDeviceReq, c transaction.TxnCtx) error {
+	var peerID uuid.UUID
+	if err := c.Get("peerid", &peerID); err != nil {
+		c.Logger().WithError(err).WithField("key", "peerid").Error("Failed to get key from transaction context")
+		return err
+	}
+
+	deviceInfo := deviceapi.Info{Device: req.Device}
+
+	// TODO: Validate Path contains file system and empty
+
+	stat, err := fsutils.StatFs(req.Device)
+	if os.IsNotExist(err) {
+		c.Logger().WithError(err).WithField("device", req.Device).Error("Failed to prepare device, device not found")
+		return err
+	}
+
+	deviceInfo = deviceapi.Info{
+		Device:          req.Device,
+		State:           deviceapi.DeviceEnabled,
+		AvailableSize:   stat.Total,
+		TotalSize:       stat.Free,
+		UsedSize:        stat.Total - stat.Free,
+		PeerID:          peerID,
+		ProvisionerType: api.ProvisionerTypeLoop,
 	}
 
 	err = deviceutils.AddOrUpdateDevice(deviceInfo)


### PR DESCRIPTION
Register the Bricks hosting directory using,

```
glustercli device add <peerid> <path> --provisioner loop
```

Example:

```
glustercli device add 70d79c3f-e7af-43f6-8b65-05dff2423da1 \
	   /exports --provisioner loop
```

Now create the volume using,

```
glustercli volume create gv1 --size 1G \
	   --provisioner loop \
	   --replica 3
```

Fixes: #1418
Signed-off-by: Aravinda VK <avishwan@redhat.com>