### PR TITLE
Skip local bricks path validation if auto provisioned volume

### DIFF
--- a/glusterd2/commands/volumes/brick-replace-txn.go
+++ b/glusterd2/commands/volumes/brick-replace-txn.go
@@ -67,9 +67,13 @@ func replaceVolinfo(c transaction.TxnCtx) error {
 		return err
 	}
 
-	allBricks, err := volume.GetAllBricksInCluster()
-	if err != nil {
-		return err
+	var allBricks []brick.Brickinfo
+	// Validate brick paths only if it is not a smart volume
+	if newBrick.Size == 0 {
+		allBricks, err = volume.GetAllBricksInCluster()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Used by other peers to check if proposed bricks are already in use.

--- a/glusterd2/commands/volumes/volume-create-txn.go
+++ b/glusterd2/commands/volumes/volume-create-txn.go
@@ -209,9 +209,13 @@ func createVolinfo(c transaction.TxnCtx) error {
 		return err
 	}
 
-	allBricks, err := volume.GetAllBricksInCluster()
-	if err != nil {
-		return err
+	var allBricks []brick.Brickinfo
+	// Validate brick paths only if it is not a smart volume
+	if req.Size == 0 {
+		allBricks, err = volume.GetAllBricksInCluster()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Used by other peers to check if proposed bricks are already in use.

--- a/glusterd2/commands/volumes/volume-expand-txn.go
+++ b/glusterd2/commands/volumes/volume-expand-txn.go
@@ -68,9 +68,13 @@ func expandValidatePrepare(c transaction.TxnCtx) error {
 		return err
 	}
 
-	allBricks, err := volume.GetAllBricksInCluster()
-	if err != nil {
-		return err
+	var allBricks []brick.Brickinfo
+	// Validate brick paths only if it is not a smart volume
+	if req.Size == 0 {
+		allBricks, err = volume.GetAllBricksInCluster()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Used by other peers to check if proposed bricks are already in use.


### PR DESCRIPTION
Brick paths are generated while creating smart volume using volume
name, subvol number and brick number. So collision will not happen
when multiple smart volumes are created.

Signed-off-by: Aravinda VK <avishwan@redhat.com>