### PR TITLE
BlockVolume add extra arguments to create and reduce number of cluster locks

### DIFF
--- a/glustercli/cmd/volume-create.go
+++ b/glustercli/cmd/volume-create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/api"
 
 	log "github.com/sirupsen/logrus"
@@ -315,7 +316,7 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 			fmt.Println("Thin arbiter can only be enabled for replica count 2")
 			return
 		}
-		if err := addThinArbiter(&req, cmd.Flag("thin-arbiter").Value.String()); err != nil {
+		if err := volume.AddThinArbiter(&req, cmd.Flag("thin-arbiter").Value.String()); err != nil {
 			fmt.Println(err)
 			return
 		}
@@ -330,21 +331,4 @@ func volumeCreateCmdRun(cmd *cobra.Command, args []string) {
 	}
 	fmt.Printf("%s Volume created successfully\n", vol.Name)
 	fmt.Println("Volume ID: ", vol.ID)
-}
-
-func addThinArbiter(req *api.VolCreateReq, thinArbiter string) error {
-
-	s := strings.Split(thinArbiter, ":")
-	if len(s) != 2 && len(s) != 3 {
-		return fmt.Errorf("thin arbiter brick must be of the form <host>:<brick> or <host>:<brick>:<port>")
-	}
-
-	// TODO: If required, handle this in a generic way, just like other
-	// volume set options that we're going to allow to be set during
-	// volume create.
-	req.Options = map[string]string{
-		"replicate.thin-arbiter": thinArbiter,
-	}
-	req.AllowAdvanced = true
-	return nil
 }

--- a/glusterd2/volume/filters.go
+++ b/glusterd2/volume/filters.go
@@ -34,6 +34,30 @@ func ApplyCustomFilters(volumes []*Volinfo, filters ...Filter) []*Volinfo {
 	return volumes
 }
 
+// FilterThinArbiterVolumes filters out volumes that are thin arbiter volumes
+func FilterThinArbiterVolumes(volumes []*Volinfo) []*Volinfo {
+	var volInfos []*Volinfo
+	for _, volume := range volumes {
+		_, exists := volume.Options["cluster/replicate.thin-arbiter"]
+		if exists {
+			volInfos = append(volInfos, volume)
+		}
+	}
+	return volInfos
+}
+
+//FilterShardVolumes filters out volumes that are shard enabled
+func FilterShardVolumes(volumes []*Volinfo) []*Volinfo {
+	var volInfos []*Volinfo
+	for _, volume := range volumes {
+		_, exists := volume.Options["features/shard"]
+		if exists {
+			volInfos = append(volInfos, volume)
+		}
+	}
+	return volInfos
+}
+
 // FilterBlockHostedVolumes filters out volume which are suitable for hosting block volume
 func FilterBlockHostedVolumes(volumes []*Volinfo) []*Volinfo {
 	var volInfos []*Volinfo

--- a/glusterd2/volume/volume-utils.go
+++ b/glusterd2/volume/volume-utils.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -398,4 +399,29 @@ func CleanBricksLoop(volinfo *Volinfo) error {
 		}
 	}
 	return nil
+}
+
+//AddThinArbiter adds thin arbiter option to the volume create request
+func AddThinArbiter(req *api.VolCreateReq, thinArbiter string) error {
+
+	s := strings.Split(thinArbiter, ":")
+	if len(s) != 2 && len(s) != 3 {
+		return errors.New("thin arbiter brick must be of the form <host>:<brick> or <host>:<brick>:<port>")
+	}
+
+	// TODO: If required, handle this in a generic way, just like other
+	// volume set options that we're going to allow to be set during
+	// volume create.
+	req.Options["replicate.thin-arbiter"] = thinArbiter
+	req.AllowAdvanced = true
+	return nil
+}
+
+//AddShard adds shard options to the volume create request
+func AddShard(req *api.VolCreateReq, shardSize uint64) {
+
+	req.Options["features/shard"] = "on"
+	req.Options["features/shard.shard-block-size"] = strconv.FormatUint(shardSize, 10)
+	req.AllowAdvanced = true
+	return
 }

--- a/plugins/blockvolume/api/types.go
+++ b/plugins/blockvolume/api/types.go
@@ -11,11 +11,25 @@ type BlockVolumeInfo struct {
 	HaCount int    `json:"hacount,omitempty"`
 }
 
+// HostVolumeInfo represents block volume info
+type HostVolumeInfo struct {
+	// HostVolReplicaCnt represents the replica count of the block hosting volume
+	HostVolReplicaCnt int `json:"hostvolreplicacnt,omitempty"`
+	// HostVolThinArbPath represents the thin arbiter path
+	HostVolThinArbPath string `json:"hostvolthinarbpath,omitempty"`
+	// HostVolShardSize represents the shard size of the block hosting volume
+	HostVolShardSize uint64 `json:"hostvolshardsize,omitempty"`
+	// Size represents Block Hosting Volume size in bytes
+	HostVolSize uint64 `json:"hostvolsize,omitempty"`
+}
+
 // BlockVolumeCreateRequest represents req Body for Block vol create req
 type BlockVolumeCreateRequest struct {
 	*BlockVolumeInfo
-	Clusters []string `json:"clusters,omitempty"`
-	Auth     bool     `json:"auth,omitempty"`
+	HostVolumeInfo
+	BlockType string   `json:"blocktype,omitempty"`
+	Clusters  []string `json:"clusters,omitempty"`
+	Auth      bool     `json:"auth,omitempty"`
 }
 
 // BlockVolumeCreateResp represents resp body for a Block Vol Create req

--- a/plugins/blockvolume/blockprovider/gluster-block/glusterblock.go
+++ b/plugins/blockvolume/blockprovider/gluster-block/glusterblock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/volume"
 	"github.com/gluster/glusterd2/pkg/size"
 	"github.com/gluster/glusterd2/plugins/blockvolume/blockprovider"
-	"github.com/gluster/glusterd2/plugins/blockvolume/utils"
+	"github.com/gluster/glusterd2/plugins/blockvolume/hostvol"
 	"time"
 
 	"github.com/gluster/gluster-block-restapi/client"
@@ -79,7 +79,7 @@ func (g *GlusterBlock) CreateBlockVolume(name string, size uint64, hostVolume st
 	}
 
 	resizeFunc := func(blockHostingAvailableSize, blockSize uint64) uint64 { return blockHostingAvailableSize - blockSize }
-	if err = utils.ResizeBlockHostingVolume(hostVolume, size, resizeFunc); err != nil {
+	if err = hostvol.ResizeBlockHostingVolume(hostVolume, size, resizeFunc); err != nil {
 		logger.WithError(err).Error("failed in updating hostvolume _block-hosting-available-size metadata")
 	}
 
@@ -133,7 +133,7 @@ func (g *GlusterBlock) DeleteBlockVolume(name string, options ...blockprovider.B
 
 	resizeFunc := func(blockHostingAvailableSize, blockSize uint64) uint64 { return blockHostingAvailableSize + blockSize }
 
-	if err = utils.ResizeBlockHostingVolume(hostVol, blockInfo.Size, resizeFunc); err != nil {
+	if err = hostvol.ResizeBlockHostingVolume(hostVol, blockInfo.Size, resizeFunc); err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
 			"size":  blockInfo.Size,

--- a/plugins/blockvolume/blockprovider/gluster-virtblock/gluster_virtblock.go
+++ b/plugins/blockvolume/blockprovider/gluster-virtblock/gluster_virtblock.go
@@ -108,12 +108,6 @@ func (g *GlusterVirtBlk) CreateBlockVolume(name string, size uint64, hostVolume 
 		}
 	}
 
-	resizeFunc := func(blockHostingAvailableSize, blockSize uint64) uint64 { return blockHostingAvailableSize - blockSize }
-	if err = hostvol.ResizeBlockHostingVolume(hostVolume, size, resizeFunc); err != nil {
-		logger.WithError(err).Error("failed in updating hostvolume _block-hosting-available-size metadata")
-		return nil, err
-	}
-
 	if err = clusterLocks.Lock(hostVolume); err != nil {
 		logger.WithError(err).Error("error in acquiring cluster lock")
 		return nil, err
@@ -125,6 +119,13 @@ func (g *GlusterVirtBlk) CreateBlockVolume(name string, size uint64, hostVolume 
 		logger.WithError(err).Errorf("failed to get host volume info %s", hostVolume)
 		return nil, err
 	}
+
+	resizeFunc := func(blockHostingAvailableSize, blockSize uint64) uint64 { return blockHostingAvailableSize - blockSize }
+	if err = hostvol.UpdateBlockHostingVolumeSize(volInfo, size, resizeFunc); err != nil {
+		logger.WithError(err).Error("failed in updating hostvolume _block-hosting-available-size metadata")
+		return nil, err
+	}
+
 	key := volume.BlockPrefix + name
 	val := strconv.FormatUint(size, 10)
 	volInfo.Metadata[key] = val
@@ -140,10 +141,33 @@ func (g *GlusterVirtBlk) CreateBlockVolume(name string, size uint64, hostVolume 
 	}, nil
 }
 
-func delBlockEntry(hostName string, name string) error {
+// DeleteBlockVolume deletes a gluster block volume of give name
+func (g *GlusterVirtBlk) DeleteBlockVolume(name string, options ...blockprovider.BlockVolOption) error {
 	var (
+		blockVolOpts = &blockprovider.BlockVolumeOptions{}
 		clusterLocks = transaction.Locks{}
 	)
+
+	blockVolOpts.ApplyOpts(options...)
+
+	blkVol, err := g.GetBlockVolume(name)
+	if err != nil || blkVol == nil {
+		return errors.ErrBlockVolNotFound
+	}
+
+	hostName := blkVol.HostVolume()
+	hostDir, err := mountHost(g, hostName)
+	if err != nil {
+		log.WithError(err).Errorf("error mounting block hosting volume :%s", hostName)
+		return err
+	}
+
+	blockFileName := hostDir + "/" + name
+	err = os.Remove(blockFileName)
+	if err != nil {
+		log.WithError(err).Errorf("error removing block :%s", blockFileName)
+		return err
+	}
 
 	if err := clusterLocks.Lock(hostName); err != nil {
 		log.WithError(err).Error("error in acquiring cluster lock")
@@ -160,53 +184,19 @@ func delBlockEntry(hostName string, name string) error {
 	for k := range hostVol.Metadata {
 		if k == (volume.BlockPrefix + name) {
 			delete(hostVol.Metadata, k)
-			if err := volume.AddOrUpdateVolume(hostVol); err != nil {
-				log.WithError(err).Error("failed in updating volume info to store")
-				return err
-			}
 		}
-	}
-	return nil
-}
-
-// DeleteBlockVolume deletes a gluster block volume of give name
-func (g *GlusterVirtBlk) DeleteBlockVolume(name string, options ...blockprovider.BlockVolOption) error {
-	var (
-		blockVolOpts = &blockprovider.BlockVolumeOptions{}
-	)
-
-	blockVolOpts.ApplyOpts(options...)
-
-	blkVol, err := g.GetBlockVolume(name)
-	if err != nil || blkVol == nil {
-		return errors.ErrBlockVolNotFound
-	}
-
-	hostDir, err := mountHost(g, blkVol.HostVolume())
-	if err != nil {
-		log.WithError(err).Errorf("error mounting block hosting volume :%s", blkVol.HostVolume())
-		return err
-	}
-
-	blockFileName := hostDir + "/" + name
-	err = os.Remove(blockFileName)
-	if err != nil {
-		log.WithError(err).Errorf("error removing block :%s", blockFileName)
-		return err
-	}
-
-	err = delBlockEntry(blkVol.HostVolume(), name)
-	if err != nil {
-		log.WithError(err).Error("error updating block host volume metadata")
-		return err
 	}
 
 	resizeFunc := func(blockHostingAvailableSize, blockSize uint64) uint64 { return blockHostingAvailableSize + blockSize }
-	if err = hostvol.ResizeBlockHostingVolume(blkVol.HostVolume(), blkVol.Size(), resizeFunc); err != nil {
+	if err = hostvol.UpdateBlockHostingVolumeSize(hostVol, blkVol.Size(), resizeFunc); err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
 			"size":  blkVol.Size(),
 		}).Error("error in resizing the block hosting volume")
+	}
+	if err := volume.AddOrUpdateVolume(hostVol); err != nil {
+		log.WithError(err).Error("failed in updating volume info to store")
+		return err
 	}
 
 	return err

--- a/plugins/blockvolume/blockprovider/options.go
+++ b/plugins/blockvolume/blockprovider/options.go
@@ -13,6 +13,7 @@ type BlockVolumeOptions struct {
 	ForceDelete        bool
 	UnlinkStorage      bool
 	Hosts              []string
+	BlockType          string
 }
 
 // ApplyOpts applies configured optional parameters on BlockVolumeOptions
@@ -67,5 +68,16 @@ func WithFullPrealloc(options *BlockVolumeOptions) {
 func WithHosts(hosts []string) BlockVolOption {
 	return func(options *BlockVolumeOptions) {
 		options.Hosts = hosts
+	}
+}
+
+// WithBlockType configures the block type
+func WithBlockType(blockType string) BlockVolOption {
+	return func(options *BlockVolumeOptions) {
+		if blockType == "" {
+			options.BlockType = "xfs"
+		} else {
+			options.BlockType = blockType
+		}
 	}
 }

--- a/plugins/blockvolume/handlers.go
+++ b/plugins/blockvolume/handlers.go
@@ -27,6 +27,7 @@ func (b *BlockVolume) CreateVolume(w http.ResponseWriter, r *http.Request) {
 	opts = append(opts,
 		blockprovider.WithHaCount(req.HaCount),
 		blockprovider.WithHosts(req.Clusters),
+		blockprovider.WithBlockType(req.BlockType),
 	)
 
 	if req.Auth {
@@ -39,7 +40,7 @@ func (b *BlockVolume) CreateVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hostVolInfo, err := b.hostVolManager.GetOrCreateHostingVolume(req.HostingVolume, req.Size)
+	hostVolInfo, err := b.hostVolManager.GetOrCreateHostingVolume(req.HostingVolume, req.Size, &req.HostVolumeInfo)
 	if err != nil {
 		utils.SendHTTPError(r.Context(), w, http.StatusInternalServerError, err)
 		return

--- a/plugins/blockvolume/routes.go
+++ b/plugins/blockvolume/routes.go
@@ -7,11 +7,12 @@ import (
 	"github.com/gluster/glusterd2/glusterd2/servers/rest/route"
 	"github.com/gluster/glusterd2/pkg/utils"
 	"github.com/gluster/glusterd2/plugins/blockvolume/api"
+	"github.com/gluster/glusterd2/plugins/blockvolume/hostvol"
 )
 
 // BlockVolume represents BlockVolume plugin
 type BlockVolume struct {
-	hostVolManager HostingVolumeManager
+	hostVolManager hostvol.HostingVolumeManager
 	initOnce       sync.Once
 }
 
@@ -68,6 +69,6 @@ func (*BlockVolume) RegisterStepFuncs() {
 // calling it multiple times will do nothing
 func (b *BlockVolume) Init() {
 	b.initOnce.Do(func() {
-		b.hostVolManager = newGlusterVolManager()
+		b.hostVolManager = hostvol.NewGlusterVolManager()
 	})
 }


### PR DESCRIPTION
With this the block volumes can be created on thin arbiter, shard volumes. 

Signed-off-by: Poornima G <pgurusid@redhat.com>