### PR TITLE
tracing: refactor tracing code in transaction

### DIFF
--- a/glusterd2/middleware/tracing.go
+++ b/glusterd2/middleware/tracing.go
@@ -1,0 +1,12 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.opencensus.io/plugin/ochttp"
+)
+
+// Tracing is a http middleware to be use for trace incoming http.Request
+func Tracing(next http.Handler) http.Handler {
+	return &ochttp.Handler{Handler: next}
+}

--- a/glusterd2/servers/rest/rest.go
+++ b/glusterd2/servers/rest/rest.go
@@ -20,7 +20,6 @@ import (
 	"github.com/justinas/alice"
 	log "github.com/sirupsen/logrus"
 	config "github.com/spf13/viper"
-	"go.opencensus.io/plugin/ochttp"
 )
 
 const (
@@ -92,17 +91,15 @@ func NewMuxed(m cmux.CMux) *GDRest {
 		gdutils.EnableProfiling(rest.Routes)
 	}
 
-	// Set Handler to opencensus HTTP handler to enable tracing
 	// Set chain of ordered middlewares
-	rest.server.Handler = &ochttp.Handler{
-		Handler: alice.New(
-			middleware.Recover,
-			middleware.Expvar,
-			middleware.ReqIDGenerator,
-			middleware.LogRequest,
-			middleware.Auth,
-		).Then(rest.Routes),
-	}
+	rest.server.Handler = alice.New(
+		middleware.Recover,
+		middleware.Tracing,
+		middleware.Expvar,
+		middleware.ReqIDGenerator,
+		middleware.LogRequest,
+		middleware.Auth,
+	).Then(rest.Routes)
 
 	return rest
 }

--- a/glusterd2/transactionv2/executor.go
+++ b/glusterd2/transactionv2/executor.go
@@ -20,11 +20,13 @@ type Executor interface {
 // NewExecutor returns an Executor instance
 func NewExecutor() Executor {
 	e := &executorImpl{
-		txnManager:  NewTxnManager(store.Store.Watcher),
-		stepManager: newStepManager(),
-		selfNodeID:  gdctx.MyUUID,
+		txnManager: NewTxnManager(store.Store.Watcher),
+		selfNodeID: gdctx.MyUUID,
 	}
 
+	stepManager := newStepManager()
+	stepManager = newTracingManager(stepManager)
+	e.stepManager = stepManager
 	return e
 }
 

--- a/glusterd2/transactionv2/steptracing.go
+++ b/glusterd2/transactionv2/steptracing.go
@@ -1,0 +1,75 @@
+package transaction
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gluster/glusterd2/glusterd2/transaction"
+
+	"go.opencensus.io/trace"
+)
+
+func newTracingManager(next StepManager) StepManager {
+	return &tracingManager{next}
+}
+
+type tracingManager struct {
+	next StepManager
+}
+
+// RunStep is a middleware which creates tracing span for step.DoFunc
+func (t *tracingManager) RunStep(ctx context.Context, step *transaction.Step, txnCtx transaction.TxnCtx) (err error) {
+	spanName := fmt.Sprintf("RunStep/%s", step.DoFunc)
+	ctx, span := trace.StartSpan(ctx, spanName)
+	defer span.End()
+
+	defer func() {
+		attrs := []trace.Attribute{
+			trace.StringAttribute("reqID", txnCtx.GetTxnReqID()),
+		}
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		}
+		span.AddAttributes(attrs...)
+	}()
+
+	return t.next.RunStep(ctx, step, txnCtx)
+}
+
+// RollBackStep is a middleware which creates tracing span for step.UndoFunc
+func (t *tracingManager) RollBackStep(ctx context.Context, step *transaction.Step, txnCtx transaction.TxnCtx) (err error) {
+	spanName := fmt.Sprintf("RollBackStep/%s", step.UndoFunc)
+	ctx, span := trace.StartSpan(ctx, spanName)
+	defer span.End()
+
+	defer func() {
+		attrs := []trace.Attribute{
+			trace.StringAttribute("reqID", txnCtx.GetTxnReqID()),
+		}
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		}
+		span.AddAttributes(attrs...)
+	}()
+
+	return t.next.RollBackStep(ctx, step, txnCtx)
+}
+
+// SyncStep is a middleware which creates tracing span for Sync steps
+func (t *tracingManager) SyncStep(ctx context.Context, stepIndex int, txn *Txn) (err error) {
+	spanName := fmt.Sprintf("SyncStep/%s", txn.Steps[stepIndex].DoFunc)
+	ctx, span := trace.StartSpan(ctx, spanName)
+	defer span.End()
+
+	defer func() {
+		attrs := []trace.Attribute{
+			trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),
+		}
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		}
+		span.AddAttributes(attrs...)
+	}()
+
+	return t.next.SyncStep(ctx, stepIndex, txn)
+}

--- a/glusterd2/transactionv2/tracingexecutor.go
+++ b/glusterd2/transactionv2/tracingexecutor.go
@@ -18,7 +18,7 @@ type tracingExecutor struct {
 
 // Execute will record trace info for Execute operation.
 func (t *tracingExecutor) Execute(ctx context.Context, txn *Txn) error {
-	ctx, span := trace.StartSpan(ctx, "txnEng.executor.Execute/")
+	ctx, span := trace.StartSpanWithRemoteParent(ctx, "txnEng.executor.Execute/", txn.TxnSpanCtx)
 	defer span.End()
 	span.AddAttributes(
 		trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),
@@ -28,7 +28,7 @@ func (t *tracingExecutor) Execute(ctx context.Context, txn *Txn) error {
 
 // Resume will record trace info for Resume operation.
 func (t *tracingExecutor) Resume(ctx context.Context, txn *Txn) error {
-	ctx, span := trace.StartSpan(ctx, "txnEng.executor.Resume/")
+	ctx, span := trace.StartSpanWithRemoteParent(ctx, "txnEng.executor.Resume/", txn.TxnSpanCtx)
 	defer span.End()
 	span.AddAttributes(
 		trace.StringAttribute("reqID", txn.Ctx.GetTxnReqID()),


### PR DESCRIPTION
Decouples tracing code from RunStepFuncLocally() func and
added a middleware which implements transaction.StepManager
to trace step funcs. This will provide a better trace
management and clean code.

Signed-off-by: Oshank Kumar <okumar@redhat.com>