### PR TITLE
Add gluster-rsyslog Alpine container

### DIFF
--- a/extras/rsyslog-container/Dockerfile
+++ b/extras/rsyslog-container/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:latest
+
+ENV NAME="gluster-rsyslog" \
+    DESC="Rsyslog for Gluster on Alpine" \
+    VERSION=0 \
+    RELEASE=1 \
+    ARCH=x86_64 \
+    container=docker
+
+LABEL name="$NAME" \
+      version="$VERSION" \
+      architecture="$ARCH" \
+      vendor="Red Hat, Inc" \
+      summary="$DESC" \
+      io.k8s.display-name="Gluster rsyslog service based on Alpine" \
+      io.k8s.description="Gluster rsyslog service based on Alpine which includes rsyslog packages, configuration and rulebase to parse and normalize gluster logs." \
+      description="Gluster rsyslog image is based on Alpine which includes rsyslog packages, configuration and rulebase to parse and normalize gluster logs." \
+      maintainer="Sidharth Anupkrishnan <sanupkri@redhat.com>, Sridhar Seshasayee <sseshasa@redhat.com>"
+
+RUN apk add --update rsyslog rsyslog-mmnormalize \
+    && rm -rf /var/cache/apk/*
+
+ADD rsyslog.conf /etc/rsyslog.conf
+ADD gd2.rulebase /etc/rsyslog.d/gd2.rulebase
+
+ENTRYPOINT ["rsyslogd", "-n"]

--- a/extras/rsyslog-container/README.md
+++ b/extras/rsyslog-container/README.md
@@ -1,0 +1,10 @@
+# Gluster Rsyslog Docker container:
+
+This dockerfile is used to run a rsyslog service with specific configuration
+and rulebase to parse gluster specific log files. The eventual objective is to
+normalize the gluster specific log files and feed it to and elastic search
+service to enable log search, analysis and visualization. This container is
+based on Alpine Linux and is therefore lightweight and run as a sidecar
+container in a [gcs](https://github.com/gluster/gcs) cluster along with
+containers running [GD2](https://github.com/gluster/glusterd2).As of now only
+GD2 log files are normalized to some extent.

--- a/extras/rsyslog-container/gd2.rulebase
+++ b/extras/rsyslog-container/gd2.rulebase
@@ -1,0 +1,19 @@
+version=2
+rule=:%{"name":"multilinegd2", "type":"repeat",
+    "parser":[
+               {"type":"char-sep", "name":"timekey", "extradata":"=\""},
+               {"type":"literal", "text":"=\""},
+               {"type":"char-sep", "name":"timevalue", "extradata":"\""},
+               {"type":"literal", "text":"\" "},
+               {"type":"char-sep", "name":"levelkey", "extradata":"="},
+               {"type":"literal", "text":"="},
+               {"type":"word", "name":"levelvalue"},
+               {"type":"literal", "text":" "},
+               {"type":"char-sep", "name":"msgkey", "extradata":"="},
+               {"type":"literal", "text":"="},
+               {"type":"char-sep", "name":"msgvalue", "extradata":"\n"},
+             ],
+    "while":[
+              {"type":"literal", "text":"\n"},
+            ]
+    }%

--- a/extras/rsyslog-container/rsyslog.conf
+++ b/extras/rsyslog-container/rsyslog.conf
@@ -1,0 +1,26 @@
+module(load="imfile" PollingInterval="10")
+module(load="mmnormalize")
+input(type="imfile"
+      file="/var/log/glusterd2/glusterd2.log"
+      tag="glusterd2"
+      addmetadata="on"
+      reopenOnTruncate="on"
+      discardTruncatedMsg="on"
+      msgDiscardingError="off")
+action(type="mmnormalize"
+       rulebase="/etc/rsyslog.d/gd2.rulebase")
+foreach ($.ii in $!multilinegd2) do {
+    if ($.ii!timekey == 'time') then {
+        set $!_time = $.ii!timevalue;
+    }
+    if ($.ii!levelkey == 'level') then {
+        set $!_level = $.ii!levelvalue;
+    }
+    if ($.ii!msgkey == 'msg') then {
+        set $!_msg = $.ii!msgvalue;
+    }
+}
+unset $!multilinegd2;
+module(load="omstdout")
+action(type="omstdout"
+       template="RSYSLOG_DebugFormat")


### PR DESCRIPTION
This is a lightweight container based on Alpine Linux and run as a
sidecar container in a gcs cluster along with containers running gd2.
This is mainly used to parse gluster specific logs and normalize it for
elastic search. Right now only gd2 logs are parsed to some extent. For
this, an rsyslog configuration along with a rulebase file are included.