### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/glusterd2/pmap/registry.go
+++ b/glusterd2/pmap/registry.go
@@ -123,7 +123,7 @@ func (r *pmapRegistry) NumOfBricksOnPort(port int) (int, error) {
 	return -1, fmt.Errorf("NumOfBricksOnPort: port %d not found in registry", port)
 }
 
-// RemoveByConn deletes port map entry by brick process's TCP connection.
+// RemovePortByConn deletes port map entry by brick process's TCP connection.
 // There will be only one TCP connection per brick process, regardless of
 // number of bricks in the process.
 func (r *pmapRegistry) RemovePortByConn(conn net.Conn) error {

--- a/glusterd2/transactionv2/steprunner.go
+++ b/glusterd2/transactionv2/steprunner.go
@@ -105,7 +105,7 @@ func (sm *stepManager) RollBackStep(ctx context.Context, step *transaction.Step,
 	return nil
 }
 
-// RunStepRunStep will execute the step on local node
+// RunStep will execute the step on local node
 func (sm *stepManager) RunStep(ctx context.Context, step *transaction.Step, txnCtx transaction.TxnCtx) error {
 	if !sm.shouldRunStep(step) {
 		txnCtx.Logger().WithField("step", step.DoFunc).Debug("peer is excluded in running this step")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?